### PR TITLE
Suites nesting

### DIFF
--- a/packages/allure-mocha/src/MochaAllureReporter.ts
+++ b/packages/allure-mocha/src/MochaAllureReporter.ts
@@ -32,8 +32,7 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
   }
 
   private onTest(test: Mocha.Test) {
-    const suite = test.parent;
-    this.allure.startCase((suite && suite.title) || "Unnamed", test.title);
+    this.allure.startCase(test);
   }
 
   private onPassed(test: Mocha.Test) {
@@ -41,7 +40,6 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
   }
 
   private onFailed(test: Mocha.Test, error: Error) {
-    console.error(error);
     this.allure.failTestCase(test, error);
   }
 

--- a/packages/allure-mocha/test/fixtures/specs/nested.ts
+++ b/packages/allure-mocha/test/fixtures/specs/nested.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+
+it("top-level test", () => {
+  expect(1).to.be.eq(1);
+});
+
+describe("Parent suite", () => {
+  it("shallow test", () => {
+    expect(1).to.be.eq(1);
+  });
+
+  describe("Nested suite", () => {
+    describe("Sub suite", () => {
+      it("child test", () => {
+        expect(1).to.be.eq(1);
+      });
+
+      describe("Incredibly nested suite", () => {
+        it("the deepest test", () => {
+          expect(1).to.be.eq(1);
+        });
+      });
+    });
+  });
+});

--- a/packages/allure-mocha/test/fixtures/specs/pending.ts
+++ b/packages/allure-mocha/test/fixtures/specs/pending.ts
@@ -1,0 +1,7 @@
+describe("Pending tests", () => {
+  xit("simple pending", () => {});
+
+  it("skipped in runtime", function() {
+    this.skip();
+  });
+});

--- a/packages/allure-mocha/test/specs/common.ts
+++ b/packages/allure-mocha/test/specs/common.ts
@@ -1,7 +1,7 @@
-import { Status } from "allure-js-commons";
+import { LabelName, Status } from "allure-js-commons";
 import { expect } from "chai";
 import { suite } from "mocha-typescript";
-import { runTests } from "../utils";
+import { findLabelValue, runTests } from "../utils";
 
 @suite
 class CommonSuite {
@@ -20,5 +20,20 @@ class CommonSuite {
     expect(skippedTest.status).eq(Status.SKIPPED);
     expect(skippedTest.statusDetails.message).eq("Test ignored");
     expect(skippedTest.statusDetails.trace).eq(undefined);
+  }
+
+  @test
+  async shouldHaveCorrectSuitesForPendingTests() {
+    const writerStub = await runTests("pending");
+
+    const simplePending = writerStub.getTestByName("simple pending");
+    expect(simplePending.status).eq(Status.SKIPPED);
+    expect(simplePending.historyId).eq("a50daf11cd50a0dcb2583dfaa90f796a");
+    expect(findLabelValue(simplePending, LabelName.PARENT_SUITE)).eq("Pending tests");
+
+    const skippedInRuntime = writerStub.getTestByName("skipped in runtime");
+    expect(skippedInRuntime.status).eq(Status.SKIPPED);
+    expect(skippedInRuntime.historyId).eq("e67a7b309c00b0cfa384a68790ef7f57");
+    expect(findLabelValue(skippedInRuntime, LabelName.PARENT_SUITE)).eq("Pending tests");
   }
 }

--- a/packages/allure-mocha/test/specs/feature.ts
+++ b/packages/allure-mocha/test/specs/feature.ts
@@ -1,7 +1,7 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
 import { suite } from "mocha-typescript";
-import { findLabel, runTests } from "../utils";
+import { findLabelValue, runTests } from "../utils";
 
 @suite
 class FeatureSuite {
@@ -11,6 +11,6 @@ class FeatureSuite {
     const test = writerStub.getTestByName("shouldAssignFeature");
 
     expect(test.status).eq(Status.PASSED);
-    expect(findLabel(test, "feature")!.value).eq("Login");
+    expect(findLabelValue(test, "feature")).eq("Login");
   }
 }

--- a/packages/allure-mocha/test/specs/nesting.ts
+++ b/packages/allure-mocha/test/specs/nesting.ts
@@ -1,0 +1,45 @@
+import { InMemoryAllureWriter, LabelName } from "allure-js-commons";
+import { expect } from "chai";
+import { suite } from "mocha-typescript";
+import { findLabelValue, runTests } from "../utils";
+
+@suite
+class NestingSupport {
+  private writerStub!: InMemoryAllureWriter;
+
+  async before() {
+    this.writerStub = await runTests("nested");
+  }
+
+  @test
+  shouldAssignAllSuites() {
+    const test = this.writerStub.getTestByName("child test");
+    expect(findLabelValue(test, LabelName.PARENT_SUITE)).eq("Parent suite");
+    expect(findLabelValue(test, LabelName.SUITE)).eq("Nested suite");
+    expect(findLabelValue(test, LabelName.SUB_SUITE)).eq("Sub suite");
+  }
+
+  @test
+  shouldSkipMissingLevels() {
+    const test = this.writerStub.getTestByName("shallow test");
+    expect(findLabelValue(test, LabelName.PARENT_SUITE)).eq("Parent suite");
+    expect(findLabelValue(test, LabelName.SUITE)).eq(undefined);
+    expect(findLabelValue(test, LabelName.SUB_SUITE)).eq(undefined);
+  }
+
+  @test
+  shouldHandleTopLevelTests() {
+    const test = this.writerStub.getTestByName("top-level test");
+    expect(findLabelValue(test, LabelName.PARENT_SUITE)).eq(undefined);
+    expect(findLabelValue(test, LabelName.SUITE)).eq(undefined);
+    expect(findLabelValue(test, LabelName.SUB_SUITE)).eq(undefined);
+  }
+
+  @test
+  shouldMergeSubSuiteNames() {
+    const test = this.writerStub.getTestByName("the deepest test");
+    expect(findLabelValue(test, LabelName.PARENT_SUITE)).eq("Parent suite");
+    expect(findLabelValue(test, LabelName.SUITE)).eq("Nested suite");
+    expect(findLabelValue(test, LabelName.SUB_SUITE)).eq("Sub suite > Incredibly nested suite");
+  }
+}

--- a/packages/allure-mocha/test/specs/owner.ts
+++ b/packages/allure-mocha/test/specs/owner.ts
@@ -1,7 +1,7 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
 import { suite } from "mocha-typescript";
-import { findLabel, runTests } from "../utils";
+import { findLabelValue, runTests } from "../utils";
 
 @suite
 class OwnerSuite {
@@ -11,6 +11,6 @@ class OwnerSuite {
     const test = writerStub.getTestByName("shouldAssignOwner");
 
     expect(test.status).eq(Status.PASSED);
-    expect(findLabel(test, "owner")!.value).eq("sskorol");
+    expect(findLabelValue(test, "owner")).eq("sskorol");
   }
 }

--- a/packages/allure-mocha/test/specs/severity.ts
+++ b/packages/allure-mocha/test/specs/severity.ts
@@ -1,7 +1,7 @@
 import { Severity, Status } from "allure-js-commons";
 import { expect } from "chai";
 import { suite } from "mocha-typescript";
-import { findLabel, runTests } from "../utils";
+import { findLabelValue, runTests } from "../utils";
 
 @suite
 class SeveritySuite {
@@ -10,6 +10,6 @@ class SeveritySuite {
     const writerStub = await runTests("severity");
     const test = writerStub.getTestByName("shouldAssignSeverity");
     expect(test.status).eq(Status.PASSED);
-    expect(findLabel(test, "severity")!.value).eq(Severity.BLOCKER);
+    expect(findLabelValue(test, "severity")).eq(Severity.BLOCKER);
   }
 }

--- a/packages/allure-mocha/test/specs/story.ts
+++ b/packages/allure-mocha/test/specs/story.ts
@@ -1,7 +1,7 @@
 import { Severity, Status } from "allure-js-commons";
 import { expect } from "chai";
 import { suite } from "mocha-typescript";
-import { findLabel, runTests } from "../utils";
+import { findLabelValue, runTests } from "../utils";
 
 @suite
 class StorySuite {
@@ -11,6 +11,6 @@ class StorySuite {
     const test = writerStub.getTestByName("shouldAssignStory");
 
     expect(test.status).eq(Status.PASSED);
-    expect(findLabel(test, "story")!.value).eq("Common story");
+    expect(findLabelValue(test, "story")).eq("Common story");
   }
 }

--- a/packages/allure-mocha/test/specs/tag.ts
+++ b/packages/allure-mocha/test/specs/tag.ts
@@ -1,7 +1,7 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
 import { suite } from "mocha-typescript";
-import { findLabel, runTests } from "../utils";
+import { findLabelValue, runTests } from "../utils";
 
 @suite
 class TagSuite {
@@ -11,6 +11,6 @@ class TagSuite {
     const test = writerStub.getTestByName("shouldAssignTag");
 
     expect(test.status).eq(Status.PASSED);
-    expect(findLabel(test, "tag")!.value).eq("smoke");
+    expect(findLabelValue(test, "tag")).eq("smoke");
   }
 }

--- a/packages/allure-mocha/test/utils/index.ts
+++ b/packages/allure-mocha/test/utils/index.ts
@@ -29,5 +29,10 @@ function assignSpecs(mocha: Mocha, specs: string[]) {
   jetpack
     .dir(testDir)
     .find({ matching: specs.map(spec => `${spec}.js`) })
-    .forEach(file => mocha.addFile(path.join(testDir, file)));
+    .forEach(file => {
+      const testPath = path.resolve(testDir, file);
+      // remove the test from node_modules cache, so it can be executed again
+      delete require.cache[testPath];
+      mocha.addFile(testPath);
+    });
 }

--- a/packages/allure-mocha/test/utils/index.ts
+++ b/packages/allure-mocha/test/utils/index.ts
@@ -16,8 +16,9 @@ export function runTests(...specs: string[]): Promise<InMemoryAllureWriter> {
   });
 }
 
-export function findLabel(test: TestResult, labelName: string) {
-  return test.labels.find(label => label.name === labelName);
+export function findLabelValue(test: TestResult, labelName: string) {
+  const label = test.labels.find(label => label.name === labelName);
+  return label && label.value;
 }
 
 export function findParameter(test: TestResult, parameterName: string): any {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "lib": ["es6"],
+    "target": "es2017",
+    "lib": ["es2017"],
     "module": "commonjs",
     "moduleResolution": "node",
     "declaration": true,


### PR DESCRIPTION
closes #38 

* [x] assigned correct labels for nested suites
* [x] fixed a reporter crash when it encounters a top-level test without any suite
* [x] fixed an issue where `historyId` was not recorded for failed and pending tests
* [x] fixed typescript config (previously it converted to a very old syntax, making it harder to debug issues)