### PR TITLE
Correctly report information from before/after hooks

### DIFF
--- a/packages/allure-js-commons/src/ExecutableItemWrapper.ts
+++ b/packages/allure-js-commons/src/ExecutableItemWrapper.ts
@@ -30,8 +30,12 @@ export class ExecutableItemWrapper {
     this.info.descriptionHtml = descriptionHtml;
   }
 
-  public set status(status: Status) {
+  public set status(status: Status | undefined) {
     this.info.status = status;
+  }
+
+  public get status() {
+    return this.info.status;
   }
 
   public set statusDetails(details: StatusDetails) {

--- a/packages/allure-js-commons/src/constructors.ts
+++ b/packages/allure-js-commons/src/constructors.ts
@@ -1,7 +1,5 @@
-import { FixtureResult, StepResult, TestResult, TestResultContainer } from "./model";
+import { FixtureResult, Stage, Status, StepResult, TestResult, TestResultContainer } from "./model";
 import { v4 as randomUUID } from "uuid";
-import { Status } from "./model";
-import { Stage } from "./model";
 
 export function testResultContainer(): TestResultContainer {
   return {
@@ -25,7 +23,7 @@ export function fixtureResult(): FixtureResult {
 
 export function stepResult(): StepResult {
   return {
-    status: Status.BROKEN,
+    status: undefined,
     statusDetails: {},
     stage: Stage.PENDING,
     steps: [],
@@ -38,7 +36,7 @@ export function testResult(): TestResult {
   return {
     uuid: randomUUID(),
     historyId: randomUUID(),
-    status: Status.BROKEN,
+    status: undefined,
     statusDetails: {},
     stage: Stage.PENDING,
     steps: [],

--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -29,7 +29,7 @@ export interface StatusDetails {
 
 interface ExecutableItem {
   name?: string
-  status: Status
+  status?: Status
   statusDetails: StatusDetails
   stage: Stage
   description?: string

--- a/packages/allure-mocha/src/AllureReporter.ts
+++ b/packages/allure-mocha/src/AllureReporter.ts
@@ -87,20 +87,27 @@ export class AllureReporter {
     }
   }
 
-  public passTestCase() {
+  public passTestCase(test: Mocha.Test) {
+    if (this.currentTest === null) {
+      this.startCase(test);
+    }
     this.endTest(Status.PASSED);
   }
 
   public pendingTestCase(test: Mocha.Test) {
-    if (this.currentTest === null) {
-      this.startCase(test);
-    }
+    this.startCase(test);
     this.endTest(Status.SKIPPED, { message: "Test ignored" });
   }
 
   public failTestCase(test: Mocha.Test, error: Error) {
     if (this.currentTest === null) {
       this.startCase(test);
+    } else {
+      const latestStatus = this.currentTest.status;
+      // if test already has a failed state, we should not overwrite it
+      if (latestStatus === Status.FAILED || latestStatus === Status.BROKEN) {
+        return;
+      }
     }
     const status = error.name === "AssertionError" ? Status.FAILED : Status.BROKEN;
 
@@ -138,6 +145,5 @@ export class AllureReporter {
     this.currentTest.status = status;
     this.currentTest.stage = Stage.FINISHED;
     this.currentTest.endTest();
-    this.currentTest = null;
   }
 }

--- a/packages/allure-mocha/src/MochaAllureReporter.ts
+++ b/packages/allure-mocha/src/MochaAllureReporter.ts
@@ -36,7 +36,7 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
   }
 
   private onPassed(test: Mocha.Test) {
-    this.allure.passTestCase();
+    this.allure.passTestCase(test);
   }
 
   private onFailed(test: Mocha.Test, error: Error) {

--- a/packages/allure-mocha/test/fixtures/specs/hooks.ts
+++ b/packages/allure-mocha/test/fixtures/specs/hooks.ts
@@ -1,0 +1,54 @@
+import { MochaAllureInterface } from "../../..";
+import { ContentType } from "allure-js-commons";
+import { expect } from "chai";
+
+declare const allure: MochaAllureInterface;
+
+describe("hooks test", () => {
+  describe("before fails", () => {
+    before(function() {
+      throw new Error("In before");
+    });
+
+    it("never runs", () => {});
+  });
+
+  describe("after fails", () => {
+    it("fails in after", () => {});
+
+    after(function() {
+      throw new Error("In after");
+    });
+  });
+
+  describe("beforeEach fails", () => {
+    beforeEach(function() {
+      allure.attachment("saved in beforeEach", "should be saved", ContentType.TEXT);
+      throw new Error("In before each");
+    });
+
+    it("test with beforeEach", () => {});
+  });
+
+  describe("afterEach fails", () => {
+    afterEach(function() {
+      allure.attachment("saved in afterEach", "should be saved", ContentType.TEXT);
+      throw new Error("In after each");
+    });
+
+    it("passed test with afterEach", () => {});
+  });
+
+  describe("both afterEach and test fail", () => {
+    afterEach(function() {
+      allure.attachment("saved in afterEach", "should be saved", ContentType.TEXT);
+      throw new Error("In after each");
+    });
+
+    it("failed test with afterEach", () => {
+      expect(1).eq(2);
+    });
+  });
+});
+
+

--- a/packages/allure-mocha/test/specs/hooks.ts
+++ b/packages/allure-mocha/test/specs/hooks.ts
@@ -1,0 +1,59 @@
+import { InMemoryAllureWriter, Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite } from "mocha-typescript";
+import { runTests } from "../utils";
+
+@suite
+class HooksSuite {
+  private writerStub!: InMemoryAllureWriter;
+
+  async before() {
+    this.writerStub = await runTests("hooks");
+  }
+
+  @test
+  shouldHandleBeforeEach() {
+    const test = this.writerStub.getTestByName("test with beforeEach");
+
+    expect(test.status).eq(Status.BROKEN);
+    expect(test.statusDetails.message).eq("In before each");
+    expect(test.attachments).have.length(1);
+    expect(test.attachments[0].name).eq("saved in beforeEach");
+  }
+
+  @test
+  shouldHandleAfterEach() {
+    const test = this.writerStub.getTestByName("passed test with afterEach");
+
+    expect(test.status).eq(Status.BROKEN);
+    expect(test.statusDetails.message).eq("In after each");
+    expect(test.attachments).have.length(1);
+    expect(test.attachments[0].name).eq("saved in afterEach");
+  }
+
+  @test
+  shouldPreserveTestErrorIfAfterEachFails() {
+    const test = this.writerStub.getTestByName("failed test with afterEach");
+
+    expect(test.status).eq(Status.FAILED);
+    expect(test.statusDetails.message).eq("expected 1 to equal 2");
+    expect(test.attachments).have.length(1);
+    expect(test.attachments[0].name).eq("saved in afterEach");
+  }
+
+  @test
+  shouldHandleBefore() {
+    const test = this.writerStub.getTestByName("\"before all\" hook for \"never runs\"");
+
+    expect(test.status).eq(Status.BROKEN);
+    expect(test.statusDetails.message).eq("In before");
+  }
+
+  @test
+  shouldHandleAfter() {
+    const test = this.writerStub.getTestByName("fails in after");
+
+    expect(test.status).eq(Status.BROKEN);
+    expect(test.statusDetails.message).eq("In after");
+  }
+}


### PR DESCRIPTION
This is a port of changes from 1.x adapter:

* https://github.com/allure-framework/allure-mocha/commit/c26d04884540d2a7dd3288b7f7f3625d4430430b
* https://github.com/allure-framework/allure-js-commons/commit/f1548f66da469ced0e95f9b11ec2813972a94a47

Mocha emits `test end` event before afterEach hooks are being invoked. So, we should not remove the `currentTest` reference from the lifecycle to be able to store more attachments and steps.

Mocha can emit multiple `fail` events for a single test. First, when the test fail, second – from the `afterEach` hook if it fails too. We should report the test failure, because it is more important.

Added unit-tests check this behavior.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
