### PR TITLE
Implement importable runtime API

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
   },
   "devDependencies": {
     "@types/node": "^12.7.1",
-    "allure-commandline": "^2.9.0",
-    "lerna": "^3.13.3",
-    "npm-run-all": "^4.1.5",
-    "rimraf": "^3.0.0",
-    "typescript": "^3.4.4",
-    "eslint": "^5.16.0",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "nyc": "^14.0.0"
+    "allure-commandline": "^2.9.0",
+    "eslint": "^5.16.0",
+    "lerna": "^3.13.3",
+    "npm-run-all": "^4.1.5",
+    "nyc": "^14.0.0",
+    "rimraf": "^3.0.0",
+    "ts-node": "^8.3.0",
+    "typescript": "^3.4.4"
   }
 }

--- a/packages/allure-mocha/README.md
+++ b/packages/allure-mocha/README.md
@@ -23,8 +23,6 @@ Note that it's recommended to add the following dependencies as well for better 
 Either add **allure-mocha** into **mocha.opts**:
 
 ```text
---ui mocha-typescript
---require source-map-support/register
 --reporter allure-mocha
 ```
 
@@ -34,12 +32,18 @@ Or pass the same value via commandline / scripts:
 mocha -R allure-mocha
 ```
 
-Now you can access a global **allure** object from within your project:
+If you want to provide extra information, such as steps and attachments, import the `allure` object 
+into your code:
 
-```typescript
-import { MochaAllureInterface } from 'allure-mocha';
+```javascript
+// es-modules
+import { allure } from 'allure-mocha/runtime';
+// or commonjs
+const { allure } = require('allure-mocha/runtime');
 
-declare const allure: MochaAllureInterface;
+it('is a test', () => {
+  allure.epic('Some info');
+});
 ``` 
 
 ## Decorators Support

--- a/packages/allure-mocha/index.ts
+++ b/packages/allure-mocha/index.ts
@@ -1,5 +1,0 @@
-import { MochaAllureReporter } from "./src/MochaAllureReporter";
-
-export { MochaAllureInterface } from "./src/MochaAllureInterface";
-
-module.exports = MochaAllureReporter;

--- a/packages/allure-mocha/package.json
+++ b/packages/allure-mocha/package.json
@@ -18,9 +18,9 @@
     "build": "npm run lint && npm run compile",
     "generate-report": "allure generate ./out/allure-results -o ./out/allure-report --clean",
     "allure-report": "allure serve ./out/allure-results",
-    "test": "nyc node dist/test/runner",
+    "test": "nyc ts-node --project test/tsconfig.json test/runner.ts",
     "coverage": "codecov",
-    "lint": "eslint ./src ./test ./index.ts --ext .ts",
+    "lint": "eslint ./src ./test --ext .ts",
     "lint-fix": "eslint ./src ./test ./index.ts --ext .ts --fix"
   },
   "devDependencies": {

--- a/packages/allure-mocha/runtime.d.ts
+++ b/packages/allure-mocha/runtime.d.ts
@@ -1,0 +1,1 @@
+export { allure } from "./dist/MochaAllureReporter";

--- a/packages/allure-mocha/runtime.js
+++ b/packages/allure-mocha/runtime.js
@@ -1,0 +1,15 @@
+// Typescript does not handle re-exported values correctly
+// https://github.com/microsoft/TypeScript/issues/12522
+// We write a manual code here that represents the actual behavior of the standard.
+// Based on the Babel output:
+// https://babeljs.io/repl#?code_lz=KYDwDg9gTgLgBAbwIYBsUFcrAL5wGZQQC2cA5AHQD0AJgJYDOMl9UAxpQLISsAWSAgmkzAASsEixgUUkA
+"use strict";
+
+const reporter = require("./dist/MochaAllureReporter");
+
+Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(module.exports, "allure", {
+  get() {
+    return reporter.allure;
+  }
+});

--- a/packages/allure-mocha/src/AllureReporter.ts
+++ b/packages/allure-mocha/src/AllureReporter.ts
@@ -67,7 +67,7 @@ export class AllureReporter {
     }
 
     this.currentTest = this.currentSuite.startTest(test.title);
-    this.currentTest.fullName = test.name;
+    this.currentTest.fullName = test.title;
     this.currentTest.historyId = createHash("md5")
       .update(test.fullTitle())
       .digest("hex");

--- a/packages/allure-mocha/src/MochaAllureReporter.ts
+++ b/packages/allure-mocha/src/MochaAllureReporter.ts
@@ -1,18 +1,21 @@
 import * as Mocha from "mocha";
 import { AllureRuntime, IAllureConfig } from "allure-js-commons";
 import { AllureReporter } from "./AllureReporter";
+import { MochaAllureInterface } from "./MochaAllureInterface";
+
+export let allure: MochaAllureInterface;
 
 export class MochaAllureReporter extends Mocha.reporters.Base {
-  private allure: AllureReporter;
+  private coreReporter: AllureReporter;
 
   constructor(readonly runner: Mocha.Runner, readonly opts: Mocha.MochaOptions) {
     super(runner, opts);
 
     const allureConfig: IAllureConfig = { resultsDir: "allure-results", ...opts.reporterOptions };
 
-    this.allure = new AllureReporter(new AllureRuntime(allureConfig));
+    this.coreReporter = new AllureReporter(new AllureRuntime(allureConfig));
 
-    (global as any).allure = this.allure.getInterface();
+    allure = this.coreReporter.getInterface();
 
     this.runner
       .on("suite", this.onSuite.bind(this))
@@ -24,26 +27,26 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
   }
 
   private onSuite(suite: Mocha.Suite) {
-    this.allure.startSuite(suite.fullTitle());
+    this.coreReporter.startSuite(suite.fullTitle());
   }
 
   private onSuiteEnd() {
-    this.allure.endSuite();
+    this.coreReporter.endSuite();
   }
 
   private onTest(test: Mocha.Test) {
-    this.allure.startCase(test);
+    this.coreReporter.startCase(test);
   }
 
   private onPassed(test: Mocha.Test) {
-    this.allure.passTestCase(test);
+    this.coreReporter.passTestCase(test);
   }
 
   private onFailed(test: Mocha.Test, error: Error) {
-    this.allure.failTestCase(test, error);
+    this.coreReporter.failTestCase(test, error);
   }
 
   private onPending(test: Mocha.Test) {
-    this.allure.pendingTestCase(test);
+    this.coreReporter.pendingTestCase(test);
   }
 }

--- a/packages/allure-mocha/src/index.ts
+++ b/packages/allure-mocha/src/index.ts
@@ -1,0 +1,3 @@
+import { MochaAllureReporter } from "./MochaAllureReporter";
+
+export = MochaAllureReporter;

--- a/packages/allure-mocha/test/fixtures/specs/attachment.ts
+++ b/packages/allure-mocha/test/fixtures/specs/attachment.ts
@@ -1,8 +1,6 @@
 import { ContentType } from "allure-js-commons";
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class AttachmentSubSuite {

--- a/packages/allure-mocha/test/fixtures/specs/description.ts
+++ b/packages/allure-mocha/test/fixtures/specs/description.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Description {

--- a/packages/allure-mocha/test/fixtures/specs/feature.ts
+++ b/packages/allure-mocha/test/fixtures/specs/feature.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Feature {

--- a/packages/allure-mocha/test/fixtures/specs/globalInfo.ts
+++ b/packages/allure-mocha/test/fixtures/specs/globalInfo.ts
@@ -1,8 +1,6 @@
 import { Status } from "allure-js-commons";
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class GlobalInfo {

--- a/packages/allure-mocha/test/fixtures/specs/hooks.ts
+++ b/packages/allure-mocha/test/fixtures/specs/hooks.ts
@@ -1,8 +1,6 @@
-import { MochaAllureInterface } from "../../..";
 import { ContentType } from "allure-js-commons";
 import { expect } from "chai";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 describe("hooks test", () => {
   describe("before fails", () => {
@@ -50,5 +48,3 @@ describe("hooks test", () => {
     });
   });
 });
-
-

--- a/packages/allure-mocha/test/fixtures/specs/issueAndTms.ts
+++ b/packages/allure-mocha/test/fixtures/specs/issueAndTms.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class IssueAndTms {

--- a/packages/allure-mocha/test/fixtures/specs/owner.ts
+++ b/packages/allure-mocha/test/fixtures/specs/owner.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Owner {

--- a/packages/allure-mocha/test/fixtures/specs/parameter.ts
+++ b/packages/allure-mocha/test/fixtures/specs/parameter.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Parameter {

--- a/packages/allure-mocha/test/fixtures/specs/severity.ts
+++ b/packages/allure-mocha/test/fixtures/specs/severity.ts
@@ -1,8 +1,6 @@
 import { Severity } from "allure-js-commons";
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class SeveritySubSuite {

--- a/packages/allure-mocha/test/fixtures/specs/step.ts
+++ b/packages/allure-mocha/test/fixtures/specs/step.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Step {

--- a/packages/allure-mocha/test/fixtures/specs/story.ts
+++ b/packages/allure-mocha/test/fixtures/specs/story.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Story {

--- a/packages/allure-mocha/test/fixtures/specs/tag.ts
+++ b/packages/allure-mocha/test/fixtures/specs/tag.ts
@@ -1,7 +1,5 @@
 import { suite, test } from "mocha-typescript";
-import { MochaAllureInterface } from "../../../src/MochaAllureInterface";
-
-declare const allure: MochaAllureInterface;
+import { allure } from "../../../runtime";
 
 @suite
 class Tag {

--- a/packages/allure-mocha/test/runner.ts
+++ b/packages/allure-mocha/test/runner.ts
@@ -1,6 +1,7 @@
 // custom runner for mocha that allows to include a custom reporter
 // which is not packed into an npm module
 import Mocha from "mocha";
+import path from "path";
 import glob from "glob";
 import "source-map-support/register";
 
@@ -14,17 +15,18 @@ const mocha = new Mocha({
   ui: "mocha-typescript",
   timeout: 16000,
   reporter: "mocha-multi",
+  ignoreLeaks: false,
   reporterOptions: {
     list: "-",
     [require.resolve("../")]: {
       stdout: "-",
       options: {
-        resultsDir: "./out/allure-results"
+        resultsDir: path.resolve(__dirname, "../out/allure-results")
       }
     }
   }
 });
 
-glob.sync("dist/test/specs/**/*.js").forEach(file => mocha.addFile(file));
+glob.sync("test/specs/**/*.ts").forEach(file => mocha.addFile(file));
 
 mocha.run(failures => process.exit(failures === 0 ? 0 : 1));

--- a/packages/allure-mocha/test/tsconfig.json
+++ b/packages/allure-mocha/test/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "rootDir": "."
+  },
+  "exclude": [],
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/packages/allure-mocha/test/utils/index.ts
+++ b/packages/allure-mocha/test/utils/index.ts
@@ -1,10 +1,10 @@
 import jetpack = require("fs-jetpack");
 import * as path from "path";
 import Mocha from "mocha";
-import { MochaAllureReporter } from "../../src/MochaAllureReporter";
+import MochaAllureReporter from "../..";
 import { InMemoryAllureWriter, TestResult } from "allure-js-commons";
 
-const testDir = "./dist/test/fixtures/specs";
+const testDir = "./test/fixtures/specs";
 
 export function runTests(...specs: string[]): Promise<InMemoryAllureWriter> {
   const writer = new InMemoryAllureWriter();
@@ -28,7 +28,7 @@ export function findParameter(test: TestResult, parameterName: string): any {
 function assignSpecs(mocha: Mocha, specs: string[]) {
   jetpack
     .dir(testDir)
-    .find({ matching: specs.map(spec => `${spec}.js`) })
+    .find({ matching: specs.map(spec => `${spec}.ts`) })
     .forEach(file => {
       const testPath = path.resolve(testDir, file);
       // remove the test from node_modules cache, so it can be executed again

--- a/packages/allure-mocha/tsconfig.json
+++ b/packages/allure-mocha/tsconfig.json
@@ -1,18 +1,9 @@
 {
   "extends": "../../tsconfig.json",
-  "include": [
-    "./src/**/*",
-    "./test/**/*.ts",
-    "index.ts"
-  ],
+  "exclude": ["test/**", "runtime.d.ts"],
   "compilerOptions": {
-    "emitDecoratorMetadata": true,
-    "experimentalDecorators": true,
-    "types": [
-      "node",
-      "mocha",
-      "chai"
-    ],
+    "types": [],
+    "rootDir": "./src",
     "outDir": "./dist"
   }
 }


### PR DESCRIPTION
closes #37 

### Summary

1. Added a new top level file `allure-mocha/runtime` that customers should import to access `allure` object.
2. Created a separate typescript project for test files, this was needed to make local imports `import { allure } from "../../../runtime";` working correctly.
3. Disabled `ignoreLeaks` option in Mocha. This confirms that the fix is working