### PR TITLE
update npmignore to include new files into published artifact

### DIFF
--- a/packages/allure-mocha/.npmignore
+++ b/packages/allure-mocha/.npmignore
@@ -1,8 +1,7 @@
 *
-!dist/**/*
-dist/test
-dist/declarations/test
+!runtime.d.ts
+!runtime.js
+!dist/**
 !package.json
-!package-lock.json
 !*.md
 !*.txt


### PR DESCRIPTION
In the https://github.com/allure-framework/allure-js/pull/46 I added a new file to the module –`runtime.js`.

But I forgot to update npmignore to make it actually published.

How I tested this: 

1. ran `npm pack`, checked the output: 

```
npm notice
npm notice 📦  allure-mocha@2.0.0-beta.5
npm notice === Tarball Contents ===
npm notice 1.7kB  package.json
npm notice 11.3kB LICENSE.txt
npm notice 1.3kB  README.md
npm notice 53B    runtime.d.ts
npm notice 578B   runtime.js
npm notice 993B   dist/AllureReporter.d.ts
npm notice 4.1kB  dist/AllureReporter.js
npm notice 3.8kB  dist/AllureReporter.js.map
npm notice 91B    dist/index.d.ts
npm notice 171B   dist/index.js
npm notice 138B   dist/index.js.map
npm notice 791B   dist/MochaAllureInterface.d.ts
npm notice 2.2kB  dist/MochaAllureInterface.js
npm notice 2.0kB  dist/MochaAllureInterface.js.map
npm notice 515B   dist/MochaAllureReporter.d.ts
npm notice 1.9kB  dist/MochaAllureReporter.js
npm notice 1.5kB  dist/MochaAllureReporter.js.map
npm notice 382B   dist/StepWrapper.d.ts
npm notice 585B   dist/StepWrapper.js
npm notice 646B   dist/StepWrapper.js.map
npm notice === Tarball Details ===
npm notice name:          allure-mocha
npm notice version:       2.0.0-beta.5
npm notice filename:      allure-mocha-2.0.0-beta.5.tgz
npm notice package size:  10.6 kB
npm notice unpacked size: 34.8 kB
npm notice shasum:        dc3ad4322b24aa4cd3f490366b52937a2bce7029
npm notice integrity:     sha512-tnRYWsn1Y26Xn[...]0DsNYsoe0X1Zw==
npm notice total files:   20
npm notice
allure-mocha-2.0.0-beta.5.tgz
```

2. Published a new release into our private registry, tested the installation from there. Works.