### PR TITLE
feat(mocha): revise current allure-mocha implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,13 @@
     "@types/node": "^13.7.7",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
-    "allure-commandline": "^2.9.0",
+    "allure-commandline": "^2.13.0",
     "eslint": "^6.5.1",
-    "lerna": "^3.13.3",
+    "lerna": "^3.20.2",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
     "rimraf": "^3.0.0",
     "ts-node": "^8.3.0",
-    "typescript": "^3.4.4"
+    "typescript": "^3.8.3"
   }
 }

--- a/packages/allure-js-commons/src/writers/InMemoryAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/InMemoryAllureWriter.ts
@@ -45,8 +45,18 @@ export class InMemoryAllureWriter implements IAllureWriter {
   }
 
   public getTestByName(name: string): TestResult {
-    const res = this.getMaybeTestByName(name);
-    if (res === undefined) throw new Error(`Test not found: ${name}`);
+    const res: TestResult | undefined = this.getMaybeTestByName(name);
+    if (!res) throw new Error(`Test not found: ${name}`);
+    return res;
+  }
+
+  public getMaybeGroupByName(name: string): TestResultContainer | undefined {
+    return this.groups.find(g => g.name === name);
+  }
+
+  public getGroupByName(name: string): TestResultContainer {
+    const res: TestResultContainer | undefined = this.getMaybeGroupByName(name);
+    if (!res) throw new Error(`Group not found: ${name}`);
     return res;
   }
 }

--- a/packages/allure-mocha/package.json
+++ b/packages/allure-mocha/package.json
@@ -25,24 +25,24 @@
     "lint-fix": "eslint ./src ./test ./index.ts --ext .ts --fix"
   },
   "devDependencies": {
-    "@types/chai": "^4.1.7",
+    "@testdeck/mocha": "0.0.10",
+    "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
     "chai": "^4.2.0",
-    "codecov": "^3.3.0",
-    "dotenv": "^8.0.0",
-    "fs-jetpack": "^2.2.2",
-    "mocha": "^6.2.0",
-    "mocha-multi": "^1.1.1",
-    "mocha-typescript": "^1.1.17",
-    "nyc": "^15.0.0",
-    "prettier": "^1.17.0",
-    "source-map-support": "^0.5.12"
+    "codecov": "^3.6.5",
+    "dotenv": "^8.2.0",
+    "fs-jetpack": "^2.2.3",
+    "mocha": "^7.1.2",
+    "mocha-multi": "^1.1.3",
+    "nyc": "^15.0.1",
+    "prettier": "^2.0.5",
+    "source-map-support": "^0.5.19"
   },
   "dependencies": {
     "allure-js-commons": "^2.0.0-beta.6"
   },
   "peerDependencies": {
-    "mocha": "^6.2.0"
+    "mocha": ">=6.2.x"
   },
   "nyc": {
     "check-coverage": true,
@@ -53,8 +53,10 @@
     "extension": [
       ".ts"
     ],
-    "include": [
-      "dist/src/**/*.js"
+    "exclude": [
+      "test/**/*.*",
+      "**/*.d.ts",
+      "runtime.js"
     ],
     "reporter": [
       "lcov",

--- a/packages/allure-mocha/runtime.d.ts
+++ b/packages/allure-mocha/runtime.d.ts
@@ -1,1 +1,3 @@
-export { allure } from "./dist/MochaAllureReporter";
+export { MochaAllure } from "./dist/MochaAllure";
+export { MochaAllureReporter } from "./dist/MochaAllureReporter";
+export { allure } from './dist/MochaAllureReporter';

--- a/packages/allure-mocha/runtime.js
+++ b/packages/allure-mocha/runtime.js
@@ -5,11 +5,27 @@
 // https://babeljs.io/repl#?code_lz=KYDwDg9gTgLgBAbwIYBsUFcrAL5wGZQQC2cA5AHQD0AJgJYDOMl9UAxpQLISsAWSAgmkzAASsEixgUUkA
 "use strict";
 
-const reporter = require("./dist/MochaAllureReporter");
+const _MochaAllure = require("./dist/MochaAllure");
+const _MochaAllureReporter = require("./dist/MochaAllureReporter");
 
-Object.defineProperty(exports, "__esModule", { value: true });
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+Object.defineProperty(module.exports, "MochaAllure", {
+  enumerable: true,
+  get: function () {
+    return _MochaAllure.MochaAllure;
+  }
+});
 Object.defineProperty(module.exports, "allure", {
-  get() {
-    return reporter.allure;
+  enumerable: true,
+  get: function () {
+    return _MochaAllureReporter.allure;
+  }
+});
+Object.defineProperty(module.exports, "MochaAllureReporter", {
+  enumerable: true,
+  get: function () {
+    return _MochaAllureReporter.MochaAllureReporter;
   }
 });

--- a/packages/allure-mocha/src/MochaAllureReporter.ts
+++ b/packages/allure-mocha/src/MochaAllureReporter.ts
@@ -1,9 +1,9 @@
 import * as Mocha from "mocha";
 import { AllureRuntime, IAllureConfig } from "allure-js-commons";
 import { AllureReporter } from "./AllureReporter";
-import { MochaAllureInterface } from "./MochaAllureInterface";
+import { MochaAllure } from "./MochaAllure";
 
-export let allure: MochaAllureInterface;
+export let allure: MochaAllure;
 
 export class MochaAllureReporter extends Mocha.reporters.Base {
   private coreReporter: AllureReporter;
@@ -14,8 +14,7 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
     const allureConfig: IAllureConfig = { resultsDir: "allure-results", ...opts.reporterOptions };
 
     this.coreReporter = new AllureReporter(new AllureRuntime(allureConfig));
-
-    allure = this.coreReporter.getInterface();
+    allure = this.coreReporter.getImplementation();
 
     this.runner
       .on("suite", this.onSuite.bind(this))
@@ -23,30 +22,40 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
       .on("test", this.onTest.bind(this))
       .on("pass", this.onPassed.bind(this))
       .on("fail", this.onFailed.bind(this))
-      .on("pending", this.onPending.bind(this));
+      .on("pending", this.onPending.bind(this))
+      .on("hook", this.onHookStart.bind(this))
+      .on("hook end", this.onHookEnd.bind(this));
   }
 
-  private onSuite(suite: Mocha.Suite) {
+  private onSuite(suite: Mocha.Suite): void {
     this.coreReporter.startSuite(suite.fullTitle());
   }
 
-  private onSuiteEnd() {
+  private onSuiteEnd(): void {
     this.coreReporter.endSuite();
   }
 
-  private onTest(test: Mocha.Test) {
+  private onTest(test: Mocha.Test): void {
     this.coreReporter.startCase(test);
   }
 
-  private onPassed(test: Mocha.Test) {
+  private onPassed(test: Mocha.Test): void {
     this.coreReporter.passTestCase(test);
   }
 
-  private onFailed(test: Mocha.Test, error: Error) {
+  private onFailed(test: Mocha.Test, error: Error): void {
     this.coreReporter.failTestCase(test, error);
   }
 
-  private onPending(test: Mocha.Test) {
+  private onPending(test: Mocha.Test): void {
     this.coreReporter.pendingTestCase(test);
+  }
+
+  private onHookStart(hook: Mocha.Hook): void {
+    this.coreReporter.startHook(hook.title);
+  }
+
+  private onHookEnd(hook: Mocha.Hook): void {
+    this.coreReporter.endHook(hook.error());
   }
 }

--- a/packages/allure-mocha/src/StepWrapper.ts
+++ b/packages/allure-mocha/src/StepWrapper.ts
@@ -5,7 +5,7 @@ export class StepWrapper {
   constructor(private readonly reporter: AllureReporter, private readonly step: AllureStep) {}
 
   public startStep(name: string): StepWrapper {
-    const step = this.step.startStep(name);
+    const step: AllureStep = this.step.startStep(name);
     this.reporter.pushStep(step);
     return new StepWrapper(this.reporter, step);
   }

--- a/packages/allure-mocha/test/fixtures/specs/attachment.ts
+++ b/packages/allure-mocha/test/fixtures/specs/attachment.ts
@@ -1,5 +1,5 @@
 import { ContentType } from "allure-js-commons";
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/common.ts
+++ b/packages/allure-mocha/test/fixtures/specs/common.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 
 @suite
 class Common {

--- a/packages/allure-mocha/test/fixtures/specs/decoratedHooks.ts
+++ b/packages/allure-mocha/test/fixtures/specs/decoratedHooks.ts
@@ -1,0 +1,14 @@
+import { test, suite } from "@testdeck/mocha";
+import { ContentType } from "allure-js-commons";
+import { allure } from "../../../runtime";
+
+@suite
+class DecoratedHooks {
+  @test
+  shouldAddAfterHookAttachment() {
+  }
+
+  public after() {
+    allure.attachment("test attachment 1", "test attachment 1 content", ContentType.TEXT);
+  }
+}

--- a/packages/allure-mocha/test/fixtures/specs/description.ts
+++ b/packages/allure-mocha/test/fixtures/specs/description.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/epic.ts
+++ b/packages/allure-mocha/test/fixtures/specs/epic.ts
@@ -2,9 +2,9 @@ import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite
-class Tag {
+class Epic {
   @test
-  shouldAssignTag() {
-    allure.tag("smoke");
+  shouldAssignEpic() {
+    allure.epic("epic name");
   }
 }

--- a/packages/allure-mocha/test/fixtures/specs/feature.ts
+++ b/packages/allure-mocha/test/fixtures/specs/feature.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/globalInfo.ts
+++ b/packages/allure-mocha/test/fixtures/specs/globalInfo.ts
@@ -1,5 +1,5 @@
-import { Status } from "allure-js-commons";
-import { suite, test } from "mocha-typescript";
+import { Allure, Status } from "allure-js-commons";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/issueAndTms.ts
+++ b/packages/allure-mocha/test/fixtures/specs/issueAndTms.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite
@@ -7,6 +7,6 @@ class IssueAndTms {
   shouldAssignIssueAndTms() {
     allure.issue("1", "http://localhost/issues/1");
     allure.tms("2", "http://localhost/issues/2");
-    //allure.addIssue("3"); // fixme
+    // allure.addIssue("3"); // fixme
   }
 }

--- a/packages/allure-mocha/test/fixtures/specs/owner.ts
+++ b/packages/allure-mocha/test/fixtures/specs/owner.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/parameter.ts
+++ b/packages/allure-mocha/test/fixtures/specs/parameter.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/severity.ts
+++ b/packages/allure-mocha/test/fixtures/specs/severity.ts
@@ -1,5 +1,5 @@
 import { Severity } from "allure-js-commons";
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/step.ts
+++ b/packages/allure-mocha/test/fixtures/specs/step.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/fixtures/specs/story.ts
+++ b/packages/allure-mocha/test/fixtures/specs/story.ts
@@ -1,4 +1,4 @@
-import { suite, test } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { allure } from "../../../runtime";
 
 @suite

--- a/packages/allure-mocha/test/runner.ts
+++ b/packages/allure-mocha/test/runner.ts
@@ -5,14 +5,7 @@ import path from "path";
 import glob from "glob";
 import "source-map-support/register";
 
-declare module "mocha" {
-  interface InterfaceContributions {
-    "mocha-typescript": never;
-  }
-}
-
 const mocha = new Mocha({
-  ui: "mocha-typescript",
   timeout: 16000,
   reporter: "mocha-multi",
   ignoreLeaks: false,

--- a/packages/allure-mocha/test/specs/attachments.ts
+++ b/packages/allure-mocha/test/specs/attachments.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/common.ts
+++ b/packages/allure-mocha/test/specs/common.ts
@@ -1,6 +1,6 @@
 import { LabelName, Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/decoratedHooks.ts
+++ b/packages/allure-mocha/test/specs/decoratedHooks.ts
@@ -1,0 +1,25 @@
+import { InMemoryAllureWriter, Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { runTests } from "../utils";
+
+@suite
+class DecoratedHooks {
+  private writerStub!: InMemoryAllureWriter;
+
+  async before() {
+    this.writerStub = await runTests("decoratedHooks");
+  }
+
+  @test
+  shouldHandleAfterEachDecoratedHook() {
+    const test = this.writerStub.getTestByName("shouldAddAfterHookAttachment");
+    const group = this.writerStub.getGroupByName("DecoratedHooks");
+    const [afterHook] = group.afters;
+
+    expect(test.status).eq(Status.PASSED);
+    expect(afterHook).is.not.undefined;
+    expect(afterHook.attachments).have.length(1);
+    expect(afterHook.attachments[0].name).eq("test attachment 1");
+  }
+}

--- a/packages/allure-mocha/test/specs/description.ts
+++ b/packages/allure-mocha/test/specs/description.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/epic.ts
+++ b/packages/allure-mocha/test/specs/epic.ts
@@ -4,13 +4,13 @@ import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite
-class OwnerSuite {
+class EpicSuite {
   @test
-  async shouldHaveOwner() {
-    const writerStub = await runTests("owner");
-    const test = writerStub.getTestByName("shouldAssignOwner");
+  async shouldHaveEpic() {
+    const writerStub = await runTests("epic");
+    const test = writerStub.getTestByName("shouldAssignEpic");
 
     expect(test.status).eq(Status.PASSED);
-    expect(findLabelValue(test, "owner")).eq("sskorol");
+    expect(findLabelValue(test, "epic")).eq("epic name");
   }
 }

--- a/packages/allure-mocha/test/specs/feature.ts
+++ b/packages/allure-mocha/test/specs/feature.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/globalInfo.ts
+++ b/packages/allure-mocha/test/specs/globalInfo.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/hooks.ts
+++ b/packages/allure-mocha/test/specs/hooks.ts
@@ -1,6 +1,6 @@
 import { InMemoryAllureWriter, Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { runTests } from "../utils";
 
 @suite
@@ -14,31 +14,40 @@ class HooksSuite {
   @test
   shouldHandleBeforeEach() {
     const test = this.writerStub.getTestByName("test with beforeEach");
+    const group = this.writerStub.getGroupByName("hooks test beforeEach fails");
+    const [beforeHook] = group.befores;
 
     expect(test.status).eq(Status.BROKEN);
     expect(test.statusDetails.message).eq("In before each");
+    expect(beforeHook).is.not.undefined;
+    expect(beforeHook.status).eq(Status.BROKEN);
     expect(test.attachments).have.length(1);
     expect(test.attachments[0].name).eq("saved in beforeEach");
   }
 
   @test
   shouldHandleAfterEach() {
-    const test = this.writerStub.getTestByName("passed test with afterEach");
+    const group = this.writerStub.getGroupByName("hooks test afterEach fails");
+    const [afterHook] = group.afters;
 
-    expect(test.status).eq(Status.BROKEN);
-    expect(test.statusDetails.message).eq("In after each");
-    expect(test.attachments).have.length(1);
-    expect(test.attachments[0].name).eq("saved in afterEach");
+    expect(afterHook).is.not.undefined;
+    expect(afterHook.status).eq(Status.BROKEN);
+    expect(afterHook.attachments).have.length(1);
+    expect(afterHook.attachments[0].name).eq("saved in afterEach");
   }
 
   @test
   shouldPreserveTestErrorIfAfterEachFails() {
     const test = this.writerStub.getTestByName("failed test with afterEach");
+    const group = this.writerStub.getGroupByName("hooks test both afterEach and test fail");
+    const [afterHook] = group.afters;
 
     expect(test.status).eq(Status.FAILED);
     expect(test.statusDetails.message).eq("expected 1 to equal 2");
-    expect(test.attachments).have.length(1);
-    expect(test.attachments[0].name).eq("saved in afterEach");
+    expect(afterHook).is.not.undefined;
+    expect(afterHook.status).eq(Status.BROKEN);
+    expect(afterHook.attachments).have.length(1);
+    expect(afterHook.attachments[0].name).eq("saved in afterEach");
   }
 
   @test
@@ -52,8 +61,11 @@ class HooksSuite {
   @test
   shouldHandleAfter() {
     const test = this.writerStub.getTestByName("fails in after");
+    const group = this.writerStub.getGroupByName("hooks test after fails");
+    const [afterHook] = group.afters;
 
-    expect(test.status).eq(Status.BROKEN);
-    expect(test.statusDetails.message).eq("In after");
+    expect(test.status).eq(Status.PASSED);
+    expect(afterHook).is.not.undefined;
+    expect(afterHook.status).eq(Status.BROKEN);
   }
 }

--- a/packages/allure-mocha/test/specs/issueAndTms.ts
+++ b/packages/allure-mocha/test/specs/issueAndTms.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/nesting.ts
+++ b/packages/allure-mocha/test/specs/nesting.ts
@@ -1,6 +1,6 @@
 import { InMemoryAllureWriter, LabelName } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/parameter.ts
+++ b/packages/allure-mocha/test/specs/parameter.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findParameter, runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/severity.ts
+++ b/packages/allure-mocha/test/specs/severity.ts
@@ -1,6 +1,6 @@
 import { Severity, Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/step.ts
+++ b/packages/allure-mocha/test/specs/step.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/story.ts
+++ b/packages/allure-mocha/test/specs/story.ts
@@ -1,6 +1,6 @@
-import { Severity, Status } from "allure-js-commons";
+import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite

--- a/packages/allure-mocha/test/specs/tag.ts
+++ b/packages/allure-mocha/test/specs/tag.ts
@@ -1,6 +1,6 @@
 import { Status } from "allure-js-commons";
 import { expect } from "chai";
-import { suite } from "mocha-typescript";
+import { suite, test } from "@testdeck/mocha";
 import { findLabelValue, runTests } from "../utils";
 
 @suite


### PR DESCRIPTION
As it's hard to reuse current allure-mocha implementation within other frameworks or libraries, there were made the following modifications:
- updated package dependencies to the latest versions;
- replaced deprecated `mocha-typescript` with `@testdeck/mocha`;
- added before/after hooks handlers (note that before hook won't work as expected until [mocha issue](https://github.com/mochajs/mocha/issues/4266) is fixed or we revise the current contexts' switching approach);
- covered `epic` feature;
- updated all the tests to support `@testdeck/mocha`.

Fixes #137, #50, #48 (partially), #7 (baseline).

Note that I've already tested it locally with decorators and standalone reporter examples. Current version is correctly injected as a default reporter into Mocha context. When we release a new decorators' module (will raise a separate PR), it'll be possible to wrap any reporter's instance for further decorators' usage.

Sample test with all the features:
```typescript
// ...
import { suite, test } from '@testdeck/mocha'
import { ContentType, Severity } from 'allure-js-commons'
import { allure, MochaAllure } from 'allure-mocha'
import { data, description, epic, feature, issue, owner, severity, story, tag, testCaseId, decorate } from 'allure-decorators'

@suite
class Authorization {
  public static testData = (): User => {
    return User.dummy()
  }

  @issue('1')
  @testCaseId('5')
  @severity(Severity.BLOCKER)
  @epic('User Authentication')
  @feature('Login')
  @story('Positive authorization')
  @owner('skorol')
  @tag('smoke')
  @description('Basic authorization test.')
  @data(Authorization.testData)
  @data.naming(user => `${user} should be able to sign`)
  @test
  public userShouldBeAbleToSignIn(user: User) {
    open(LoginPage)
      .loginWith(user)
      .select(ProfilePage)

    verifyThat(atProfilePage)
      .fullNameIs(user.fullName)
      .usernameIs(user.username)
  }

  public before() {
    decorate<MochaAllure>(allure)
    setUpCache()
  }

  public after() {
    this.allure.attachment('Test attachment', 'test attachment content', ContentType.TEXT)
    cleanUpCache()
  }
}

```

The result on the recent version looks like the following:
![image](https://user-images.githubusercontent.com/6638780/80914143-59b39f00-8d52-11ea-9d5b-df9d6dfb0126.png)


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
