### PR TITLE
allow to override test & step timestamp

### DIFF
--- a/packages/allure-js-commons/src/AllureGroup.ts
+++ b/packages/allure-js-commons/src/AllureGroup.ts
@@ -16,8 +16,8 @@ export class AllureGroup {
     return group;
   }
 
-  startTest(name?: string): AllureTest {
-    const test = new AllureTest(this.runtime);
+  startTest(name?: string, start?: number): AllureTest {
+    const test = new AllureTest(this.runtime, start);
     this.testResultContainer.children.push(test.uuid);
     test.name = name || "Unnamed";
     return test;

--- a/packages/allure-js-commons/src/AllureTest.ts
+++ b/packages/allure-js-commons/src/AllureTest.ts
@@ -6,14 +6,14 @@ import { AllureRuntime } from "./AllureRuntime";
 export class AllureTest extends ExecutableItemWrapper {
   private readonly testResult: TestResult;
 
-  constructor(private readonly runtime: AllureRuntime) {
+  constructor(private readonly runtime: AllureRuntime, start: number = Date.now()) {
     super(testResult());
     this.testResult = this.wrappedItem as TestResult;
-    this.testResult.start = Date.now();
+    this.testResult.start = start;
   }
 
-  endTest(): void {
-    this.testResult.stop = Date.now();
+  endTest(stop: number = Date.now()): void {
+    this.testResult.stop = stop;
     this.runtime.writeResult(this.testResult);
     // TODO: test that child steps ended
   }

--- a/packages/allure-js-commons/src/ExecutableItemWrapper.ts
+++ b/packages/allure-js-commons/src/ExecutableItemWrapper.ts
@@ -113,13 +113,13 @@ export class ExecutableItemWrapper {
 
 // This class is here because of circular dependency with ExecutableItemWrapper
 export class AllureStep extends ExecutableItemWrapper {
-  constructor(private readonly stepResult: StepResult) {
+  constructor(private readonly stepResult: StepResult, start: number = Date.now()) {
     super(stepResult);
-    this.stepResult.start = Date.now();
+    this.stepResult.start = start;
   }
 
-  endStep() {
-    this.stepResult.stop = Date.now();
+  endStep(stop: number = Date.now()) {
+    this.stepResult.stop = stop;
     // TODO: test that child steps ended
   }
 }

--- a/packages/allure-js-commons/src/ExecutableItemWrapper.ts
+++ b/packages/allure-js-commons/src/ExecutableItemWrapper.ts
@@ -63,11 +63,11 @@ export class ExecutableItemWrapper {
     this.info.attachments.push({ name, type, source: fileName });
   }
 
-  public startStep(name: string): AllureStep {
+  public startStep(name: string, start?: number): AllureStep {
     const result = stepResult();
     this.info.steps.push(result);
 
-    const allureStep = new AllureStep(result);
+    const allureStep = new AllureStep(result, start);
     allureStep.name = name;
     return allureStep;
   }


### PR DESCRIPTION
* Useful when converting other report formats to allure, in which case time should be read from files instead of `Date.now()`
* This patch is backward compatible