### PR TITLE
Add initial decorators support (fixes #7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1880,16 +1880,10 @@
 			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
 			"dev": true
 		},
-		"@types/eslint-visitor-keys": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-			"integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-			"dev": true
-		},
 		"@types/json-schema": {
-			"version": "7.0.8",
-			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.8.tgz",
-			"integrity": "sha512-YSBPTLTVm2e2OoQIDYx8HaeWJ5tTToLH67kXR7zYNGupXMEHa2++G8k+DczX2cFVgalypqtyZIcU19AFcmOpmg==",
+			"version": "7.0.9",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+			"integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
 			"dev": true
 		},
 		"@types/minimatch": {
@@ -1923,54 +1917,110 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
-			"integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.29.0.tgz",
+			"integrity": "sha512-eiREtqWRZ8aVJcNru7cT/AMVnYd9a2UHsfZT8MR1dW3UUEg6jDv9EQ9Cq4CUPZesyQ58YUpoAADGv71jY8RwgA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/experimental-utils": "2.34.0",
+				"@typescript-eslint/experimental-utils": "4.29.0",
+				"@typescript-eslint/scope-manager": "4.29.0",
+				"debug": "^4.3.1",
 				"functional-red-black-tree": "^1.0.1",
-				"regexpp": "^3.0.0",
-				"tsutils": "^3.17.1"
+				"regexpp": "^3.1.0",
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
 			}
 		},
 		"@typescript-eslint/experimental-utils": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-			"integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.29.0.tgz",
+			"integrity": "sha512-FpNVKykfeaIxlArLUP/yQfv/5/3rhl1ov6RWgud4OgbqWLkEq7lqgQU9iiavZRzpzCRQV4XddyFz3wFXdkiX9w==",
 			"dev": true,
 			"requires": {
-				"@types/json-schema": "^7.0.3",
-				"@typescript-eslint/typescript-estree": "2.34.0",
-				"eslint-scope": "^5.0.0",
-				"eslint-utils": "^2.0.0"
+				"@types/json-schema": "^7.0.7",
+				"@typescript-eslint/scope-manager": "4.29.0",
+				"@typescript-eslint/types": "4.29.0",
+				"@typescript-eslint/typescript-estree": "4.29.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^3.0.0"
+			},
+			"dependencies": {
+				"eslint-utils": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
+					"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^2.0.0"
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.34.0.tgz",
-			"integrity": "sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==",
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.29.0.tgz",
+			"integrity": "sha512-+92YRNHFdXgq+GhWQPT2bmjX09X7EH36JfgN2/4wmhtwV/HPxozpCNst8jrWcngLtEVd/4zAwA6BKojAlf+YqA==",
 			"dev": true,
 			"requires": {
-				"@types/eslint-visitor-keys": "^1.0.0",
-				"@typescript-eslint/experimental-utils": "2.34.0",
-				"@typescript-eslint/typescript-estree": "2.34.0",
-				"eslint-visitor-keys": "^1.1.0"
+				"@typescript-eslint/scope-manager": "4.29.0",
+				"@typescript-eslint/types": "4.29.0",
+				"@typescript-eslint/typescript-estree": "4.29.0",
+				"debug": "^4.3.1"
 			}
 		},
-		"@typescript-eslint/typescript-estree": {
-			"version": "2.34.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-			"integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+		"@typescript-eslint/scope-manager": {
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.29.0.tgz",
+			"integrity": "sha512-HPq7XAaDMM3DpmuijxLV9Io8/6pQnliiXMQUcAdjpJJSR+fdmbD/zHCd7hMkjJn04UQtCQBtshgxClzg6NIS2w==",
 			"dev": true,
 			"requires": {
-				"debug": "^4.1.1",
-				"eslint-visitor-keys": "^1.1.0",
-				"glob": "^7.1.6",
+				"@typescript-eslint/types": "4.29.0",
+				"@typescript-eslint/visitor-keys": "4.29.0"
+			}
+		},
+		"@typescript-eslint/types": {
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.29.0.tgz",
+			"integrity": "sha512-2YJM6XfWfi8pgU2HRhTp7WgRw78TCRO3dOmSpAvIQ8MOv4B46JD2chnhpNT7Jq8j0APlIbzO1Bach734xxUl4A==",
+			"dev": true
+		},
+		"@typescript-eslint/typescript-estree": {
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.0.tgz",
+			"integrity": "sha512-8ZpNHDIOyqzzgZrQW9+xQ4k5hM62Xy2R4RPO3DQxMc5Rq5QkCdSpk/drka+DL9w6sXNzV5nrdlBmf8+x495QXQ==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.29.0",
+				"@typescript-eslint/visitor-keys": "4.29.0",
+				"debug": "^4.3.1",
+				"globby": "^11.0.3",
 				"is-glob": "^4.0.1",
-				"lodash": "^4.17.15",
-				"semver": "^7.3.2",
-				"tsutils": "^3.17.1"
+				"semver": "^7.3.5",
+				"tsutils": "^3.21.0"
+			}
+		},
+		"@typescript-eslint/visitor-keys": {
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.0.tgz",
+			"integrity": "sha512-LoaofO1C/jAJYs0uEpYMXfHboGXzOJeV118X4OsZu9f7rG7Pr9B3+4HTU8+err81rADa4xfQmAxnRnPAI2jp+Q==",
+			"dev": true,
+			"requires": {
+				"@typescript-eslint/types": "4.29.0",
+				"eslint-visitor-keys": "^2.0.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				}
 			}
 		},
 		"JSONStream": {
@@ -5606,15 +5656,6 @@
 				"minipass": "^2.9.0"
 			}
 		},
-		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"mkdirp-infer-owner": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/mkdirp-infer-owner/-/mkdirp-infer-owner-2.0.0.tgz",
@@ -5720,6 +5761,15 @@
 				"which": "^1.3.1"
 			},
 			"dependencies": {
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"rimraf": {
 					"version": "2.7.1",
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -7022,6 +7072,14 @@
 				"tough-cookie": "~2.5.0",
 				"tunnel-agent": "^0.6.0",
 				"uuid": "^3.3.2"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				}
 			}
 		},
 		"require-directory": {
@@ -7610,6 +7668,15 @@
 				"yallist": "^3.0.3"
 			},
 			"dependencies": {
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
 				"yallist": {
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -7650,6 +7717,12 @@
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
 					"dev": true
 				}
 			}
@@ -7953,12 +8026,6 @@
 			"requires": {
 				"object.getownpropertydescriptors": "^2.0.3"
 			}
-		},
-		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"dev": true
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
   },
   "devDependencies": {
     "@types/node": "^14.6.0",
-    "@typescript-eslint/eslint-plugin": "^2.34.0",
-    "@typescript-eslint/parser": "^2.34.0",
+    "@typescript-eslint/eslint-plugin": "^4.1.1",
+    "@typescript-eslint/parser": "^4.1.1",
     "allure-commandline": "^2.13.0",
     "eslint": "^7.21.0",
     "eslint-config-prettier": "^8.3.0",

--- a/packages/allure-cucumberjs/package-lock.json
+++ b/packages/allure-cucumberjs/package-lock.json
@@ -9,6 +9,96 @@
 			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.21.tgz",
 			"integrity": "sha512-yd+9qKmJxm496BOV9CMNaey8TWsikaZOwMRwPHQIjcOJM9oV+fi9ZMNw3JsVnbEEbo2gRTDnGEBv8pjyn67hNg==",
 			"dev": true
+		},
+		"glob": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+			"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+			"dev": true,
+			"requires": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.4",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				}
+			}
 		}
 	}
 }

--- a/packages/allure-decorators/.eslintrc.js
+++ b/packages/allure-decorators/.eslintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  globals: {
+    __PATH_PREFIX__: true,
+  },
+  env: {
+    browser: true,
+    node: true,
+    es6: true,
+  },
+  extends: [
+    "../../.eslintrc.js",
+  ],
+};

--- a/packages/allure-decorators/.npmignore
+++ b/packages/allure-decorators/.npmignore
@@ -1,0 +1,5 @@
+*
+!dist/**
+!package.json
+!*.md
+!*.txt

--- a/packages/allure-decorators/LICENSE.txt
+++ b/packages/allure-decorators/LICENSE.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Qameta Software
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/allure-decorators/README.md
+++ b/packages/allure-decorators/README.md
@@ -1,0 +1,132 @@
+# Allure Decorators
+
+This project introduces TS decorators integration for Allure framework.
+
+## Installation based on allure-mocha reporter
+
+```bash
+npm i allure-js-commons allure-decorators allure-mocha @testdeck/mocha mocha @types/mocha mocha-multi-reporters source-map-support --save-dev
+```
+or via yarn:
+```bash
+yarn add allure-js-commons allure-decorators allure-mocha @testdeck/mocha mocha @types/mocha mocha-multi-reporters source-map-support --dev
+```
+
+## Usage
+
+Create the following **.mocharc.json**:
+
+```json
+{
+  "require": "source-map-support/register",
+  "spec": "./src/tests/**/*.js",
+  "reporter": "mocha-multi-reporters",
+  "reporter-option": "configFile=reporterConfig.json"
+}
+```
+
+And the **reporterConfig.json**:
+
+```json
+{
+  "reporterEnabled": "allure-mocha, list",
+  "allureMochaReporterOptions": {
+    "resultsDir": "./allure-results"
+  }
+}
+```
+
+Note that there are known issues with Mocha 8+ parallel test execution. So try to avoid using this flag at the moment.
+
+Your **tsconfig.json** must include the following compiler options:
+
+```json
+{
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  }
+}
+```
+
+Now your test may look like the following:
+
+```typescript
+import { suite, test } from '@testdeck/mocha'
+import {
+  assignPmsUrl,
+  assignTmsUrl,
+  data,
+  decorate,
+  description,
+  epic,
+  feature,
+  issue,
+  owner,
+  severity,
+  story,
+  tag,
+  testCaseId
+} from 'allure-decorators'
+import { ContentType, Severity } from 'allure-js-commons'
+import { allure, MochaAllure } from 'allure-mocha/runtime'
+// the other imports
+
+@suite
+class AuthorizationTests {
+
+  public static testData = (): User[] => {
+    return [User.dummy(), User.dummy1()]
+  }
+
+  @issue('11')
+  @testCaseId('10')
+  @severity(Severity.BLOCKER)
+  @epic('User Authentication')
+  @feature('Login')
+  @story('Authorization')
+  @owner('skorol')
+  @tag('smoke')
+  @description('Basic authorization test.')
+  @data(AuthorizationTests.testData)
+  @data.naming(user => `${user} should be able to sign`)
+  @test
+  public userShouldBeAbleToSignIn(user: User) {
+    open(LoginPage)
+      .loginWith(user)
+      .select(ProfilePage)
+
+    verifyThat(atProfilePage)
+      .fullNameIs(user.fullName)
+      .usernameIs(user.username)
+  }
+
+  public before() {
+    decorate<MochaAllure>(allure)
+    assignTmsUrl(process.env.TMS_URL)
+    assignPmsUrl(process.env.PMS_URL)
+  }
+
+  public after() {
+    allure.attachment('Test attachment', 'test attachment content', ContentType.TEXT)
+  }
+}
+```
+
+You should pay attention to the following line:
+
+```typescript
+decorate<MochaAllure>(allure)
+```
+
+To be able to use decorators, you have to call `decorate` function explicitly and set your reporter's instance in `before` hook. This was done intentionally to allow clients decide which reporter they want to use with decorators module.  
+
+Note that `data` is a [testdeck](https://github.com/testdeck/testdeck) specific extension which allows injecting parameters into Allure scope.
+At the moment, **testdeck** supports only Mocha, Jest and Jasmine frameworks.
+If you want to add the other integration, feel free to contact Allure team to discuss the potential design options. 
+
+
+#### ToDo
+
+- [ ] Update [mocha-allure2-example](https://github.com/sskorol/mocha-allure2-example) with new `allure-decorators` dependency.   
+- [ ] Explore potential `data` decorator extension for the other frameworks.

--- a/packages/allure-decorators/index.ts
+++ b/packages/allure-decorators/index.ts
@@ -1,0 +1,17 @@
+export { data } from "./src/testdeck";
+export {
+  step,
+  attachment,
+  testCaseId,
+  issue,
+  feature,
+  story,
+  severity,
+  tag,
+  owner,
+  epic,
+  description,
+  decorate,
+  assignPmsUrl,
+  assignTmsUrl
+} from "./src/core";

--- a/packages/allure-decorators/package-lock.json
+++ b/packages/allure-decorators/package-lock.json
@@ -1,0 +1,3313 @@
+{
+	"name": "allure-decorators",
+	"version": "2.0.0-beta.10",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"eslint": {
+			"version": "7.32.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+			"integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.12.11",
+				"@eslint/eslintrc": "^0.4.3",
+				"@humanwhocodes/config-array": "^0.5.0",
+				"ajv": "^6.10.0",
+				"chalk": "^4.0.0",
+				"cross-spawn": "^7.0.2",
+				"debug": "^4.0.1",
+				"doctrine": "^3.0.0",
+				"enquirer": "^2.3.5",
+				"escape-string-regexp": "^4.0.0",
+				"eslint-scope": "^5.1.1",
+				"eslint-utils": "^2.1.0",
+				"eslint-visitor-keys": "^2.0.0",
+				"espree": "^7.3.1",
+				"esquery": "^1.4.0",
+				"esutils": "^2.0.2",
+				"fast-deep-equal": "^3.1.3",
+				"file-entry-cache": "^6.0.1",
+				"functional-red-black-tree": "^1.0.1",
+				"glob-parent": "^5.1.2",
+				"globals": "^13.6.0",
+				"ignore": "^4.0.6",
+				"import-fresh": "^3.0.0",
+				"imurmurhash": "^0.1.4",
+				"is-glob": "^4.0.0",
+				"js-yaml": "^3.13.1",
+				"json-stable-stringify-without-jsonify": "^1.0.1",
+				"levn": "^0.4.1",
+				"lodash.merge": "^4.6.2",
+				"minimatch": "^3.0.4",
+				"natural-compare": "^1.4.0",
+				"optionator": "^0.9.1",
+				"progress": "^2.0.0",
+				"regexpp": "^3.1.0",
+				"semver": "^7.2.1",
+				"strip-ansi": "^6.0.0",
+				"strip-json-comments": "^3.1.0",
+				"table": "^6.0.9",
+				"text-table": "^0.2.0",
+				"v8-compile-cache": "^2.0.3"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+							"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+							"dev": true
+						}
+					}
+				},
+				"@eslint/eslintrc": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+					"integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.12.4",
+						"debug": "^4.1.1",
+						"espree": "^7.3.0",
+						"globals": "^13.9.0",
+						"ignore": "^4.0.6",
+						"import-fresh": "^3.2.1",
+						"js-yaml": "^3.13.1",
+						"minimatch": "^3.0.4",
+						"strip-json-comments": "^3.1.1"
+					}
+				},
+				"@humanwhocodes/config-array": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+					"integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+					"dev": true,
+					"requires": {
+						"@humanwhocodes/object-schema": "^1.2.0",
+						"debug": "^4.1.1",
+						"minimatch": "^3.0.4"
+					}
+				},
+				"@humanwhocodes/object-schema": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+					"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+					"dev": true
+				},
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				},
+				"acorn-jsx": {
+					"version": "5.3.2",
+					"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+					"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+					"dev": true
+				},
+				"ajv": {
+					"version": "6.12.6",
+					"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+					"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+					"dev": true,
+					"requires": {
+						"fast-deep-equal": "^3.1.1",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.4.1",
+						"uri-js": "^4.2.2"
+					}
+				},
+				"ansi-colors": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"dev": true
+				},
+				"balanced-match": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"callsites": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+							"dev": true
+						},
+						"has-flag": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+							"dev": true
+						},
+						"supports-color": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^4.0.0"
+							}
+						}
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"deep-is": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+					"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+					"dev": true
+				},
+				"doctrine": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+					"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2"
+					}
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"enquirer": {
+					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+					"integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+					"dev": true,
+					"requires": {
+						"ansi-colors": "^4.1.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
+				"eslint-scope": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+					"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+					"dev": true,
+					"requires": {
+						"esrecurse": "^4.3.0",
+						"estraverse": "^4.1.1"
+					}
+				},
+				"eslint-utils": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+					"integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+					"dev": true,
+					"requires": {
+						"eslint-visitor-keys": "^1.1.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+							"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+							"dev": true
+						}
+					}
+				},
+				"eslint-visitor-keys": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+					"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+					"dev": true
+				},
+				"espree": {
+					"version": "7.3.1",
+					"resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+					"integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+					"dev": true,
+					"requires": {
+						"acorn": "^7.4.0",
+						"acorn-jsx": "^5.3.1",
+						"eslint-visitor-keys": "^1.3.0"
+					},
+					"dependencies": {
+						"eslint-visitor-keys": {
+							"version": "1.3.0",
+							"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+							"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+							"dev": true
+						}
+					}
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"esquery": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
+					"integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.1.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				},
+				"esrecurse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+					"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+					"dev": true,
+					"requires": {
+						"estraverse": "^5.2.0"
+					},
+					"dependencies": {
+						"estraverse": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+							"integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+							"dev": true
+						}
+					}
+				},
+				"estraverse": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+					"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+					"dev": true
+				},
+				"esutils": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+					"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+					"dev": true
+				},
+				"fast-deep-equal": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+					"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+					"dev": true
+				},
+				"fast-json-stable-stringify": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+					"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+					"dev": true
+				},
+				"fast-levenshtein": {
+					"version": "2.0.6",
+					"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+					"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+					"dev": true
+				},
+				"file-entry-cache": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+					"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+					"dev": true,
+					"requires": {
+						"flat-cache": "^3.0.4"
+					}
+				},
+				"flat-cache": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+					"integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+					"dev": true,
+					"requires": {
+						"flatted": "^3.1.0",
+						"rimraf": "^3.0.2"
+					}
+				},
+				"flatted": {
+					"version": "3.2.2",
+					"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+					"integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
+					"dev": true
+				},
+				"functional-red-black-tree": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+					"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+					"dev": true
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"globals": {
+					"version": "13.10.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-13.10.0.tgz",
+					"integrity": "sha512-piHC3blgLGFjvOuMmWZX60f+na1lXFDhQXBf1UYp2fXPXqvEUbOhNwi6BsQ0bQishwedgnjkwv1d9zKf+MWw3g==",
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.20.2"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"ignore": {
+					"version": "4.0.6",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+					"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+					"dev": true
+				},
+				"import-fresh": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+					"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+					"dev": true,
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					}
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+					"dev": true
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"dev": true
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"json-schema-traverse": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+					"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+					"dev": true
+				},
+				"json-stable-stringify-without-jsonify": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+					"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+					"dev": true
+				},
+				"levn": {
+					"version": "0.4.1",
+					"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+					"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "^1.2.1",
+						"type-check": "~0.4.0"
+					}
+				},
+				"lodash.clonedeep": {
+					"version": "4.5.0",
+					"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+					"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+					"dev": true
+				},
+				"lodash.merge": {
+					"version": "4.6.2",
+					"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+					"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+					"dev": true
+				},
+				"lodash.truncate": {
+					"version": "4.4.2",
+					"resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+					"integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+					"dev": true
+				},
+				"lru-cache": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+					"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+					"dev": true,
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"natural-compare": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+					"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+					"dev": true
+				},
+				"optionator": {
+					"version": "0.9.1",
+					"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+					"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+					"dev": true,
+					"requires": {
+						"deep-is": "^0.1.3",
+						"fast-levenshtein": "^2.0.6",
+						"levn": "^0.4.1",
+						"prelude-ls": "^1.2.1",
+						"type-check": "^0.4.0",
+						"word-wrap": "^1.2.3"
+					}
+				},
+				"parent-module": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+					"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+					"dev": true,
+					"requires": {
+						"callsites": "^3.0.0"
+					}
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"prelude-ls": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+					"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+					"dev": true
+				},
+				"progress": {
+					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+					"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+					"dev": true
+				},
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				},
+				"regexpp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+					"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+					"dev": true
+				},
+				"require-from-string": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+					"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+					"dev": true
+				},
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"dev": true,
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"slice-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+					"integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+							"dev": true
+						}
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"table": {
+					"version": "6.7.1",
+					"resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+					"integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
+					"dev": true,
+					"requires": {
+						"ajv": "^8.0.1",
+						"lodash.clonedeep": "^4.5.0",
+						"lodash.truncate": "^4.4.2",
+						"slice-ansi": "^4.0.0",
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ajv": {
+							"version": "8.6.2",
+							"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+							"integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
+							"dev": true,
+							"requires": {
+								"fast-deep-equal": "^3.1.1",
+								"json-schema-traverse": "^1.0.0",
+								"require-from-string": "^2.0.2",
+								"uri-js": "^4.2.2"
+							}
+						},
+						"json-schema-traverse": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+							"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+							"dev": true
+						}
+					}
+				},
+				"text-table": {
+					"version": "0.2.0",
+					"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+					"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+					"dev": true
+				},
+				"type-check": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+					"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+					"dev": true,
+					"requires": {
+						"prelude-ls": "^1.2.1"
+					}
+				},
+				"type-fest": {
+					"version": "0.20.2",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+					"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+					"dev": true
+				},
+				"uri-js": {
+					"version": "4.4.1",
+					"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+					"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"v8-compile-cache": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
+					"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"word-wrap": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+					"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+					"dev": true
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+					"dev": true
+				}
+			}
+		},
+		"mocha": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+			"integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+			"dev": true,
+			"requires": {
+				"ansi-colors": "3.2.3",
+				"browser-stdout": "1.3.1",
+				"chokidar": "3.3.0",
+				"debug": "3.2.6",
+				"diff": "3.5.0",
+				"escape-string-regexp": "1.0.5",
+				"find-up": "3.0.0",
+				"glob": "7.1.3",
+				"growl": "1.10.5",
+				"he": "1.2.0",
+				"js-yaml": "3.13.1",
+				"log-symbols": "3.0.0",
+				"minimatch": "3.0.4",
+				"mkdirp": "0.5.5",
+				"ms": "2.1.1",
+				"node-environment-flags": "1.0.6",
+				"object.assign": "4.1.0",
+				"strip-json-comments": "2.0.1",
+				"supports-color": "6.0.0",
+				"which": "1.3.1",
+				"wide-align": "1.1.3",
+				"yargs": "13.3.2",
+				"yargs-parser": "13.1.2",
+				"yargs-unparser": "1.6.0"
+			},
+			"dependencies": {
+				"ansi-colors": {
+					"version": "3.2.3",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+					"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"anymatch": {
+					"version": "3.1.2",
+					"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
+					"integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+					"dev": true,
+					"requires": {
+						"normalize-path": "^3.0.0",
+						"picomatch": "^2.0.4"
+					}
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+					"dev": true
+				},
+				"binary-extensions": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+					"integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"braces": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
+					"requires": {
+						"fill-range": "^7.0.1"
+					}
+				},
+				"browser-stdout": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
+					"integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+					"dev": true
+				},
+				"call-bind": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+					"integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.0.2"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					},
+					"dependencies": {
+						"supports-color": {
+							"version": "5.5.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"chokidar": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
+					"integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+					"dev": true,
+					"requires": {
+						"anymatch": "~3.1.1",
+						"braces": "~3.0.2",
+						"fsevents": "~2.1.1",
+						"glob-parent": "~5.1.0",
+						"is-binary-path": "~2.1.0",
+						"is-glob": "~4.0.1",
+						"normalize-path": "~3.0.0",
+						"readdirp": "~3.2.0"
+					}
+				},
+				"cliui": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+					"integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^3.1.0",
+						"strip-ansi": "^5.2.0",
+						"wrap-ansi": "^5.1.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"debug": {
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
+				},
+				"define-properties": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+					"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+					"dev": true,
+					"requires": {
+						"object-keys": "^1.0.12"
+					}
+				},
+				"diff": {
+					"version": "3.5.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+					"integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+					"dev": true
+				},
+				"es-abstract": {
+					"version": "1.18.5",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+					"integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"get-intrinsic": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.2",
+						"internal-slot": "^1.0.3",
+						"is-callable": "^1.2.3",
+						"is-negative-zero": "^2.0.1",
+						"is-regex": "^1.1.3",
+						"is-string": "^1.0.6",
+						"object-inspect": "^1.11.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.2",
+						"string.prototype.trimend": "^1.0.4",
+						"string.prototype.trimstart": "^1.0.4",
+						"unbox-primitive": "^1.0.1"
+					},
+					"dependencies": {
+						"object.assign": {
+							"version": "4.1.2",
+							"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+							"integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+							"dev": true,
+							"requires": {
+								"call-bind": "^1.0.0",
+								"define-properties": "^1.1.3",
+								"has-symbols": "^1.0.1",
+								"object-keys": "^1.1.1"
+							}
+						}
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"dev": true,
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"fill-range": {
+					"version": "7.0.1",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
+					"requires": {
+						"to-regex-range": "^5.0.1"
+					}
+				},
+				"find-up": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^3.0.0"
+					}
+				},
+				"flat": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+					"integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
+					"dev": true,
+					"requires": {
+						"is-buffer": "~2.0.3"
+					}
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"fsevents": {
+					"version": "2.1.3",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+					"integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+					"dev": true,
+					"optional": true
+				},
+				"function-bind": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+					"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"get-intrinsic": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+					"integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1"
+					}
+				},
+				"glob": {
+					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"glob-parent": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+					"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+					"dev": true,
+					"requires": {
+						"is-glob": "^4.0.1"
+					}
+				},
+				"growl": {
+					"version": "1.10.5",
+					"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+					"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+					"dev": true
+				},
+				"has": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+					"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1"
+					}
+				},
+				"has-bigints": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+					"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"has-symbols": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+					"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+					"dev": true
+				},
+				"he": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+					"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"internal-slot": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+					"integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+					"dev": true,
+					"requires": {
+						"get-intrinsic": "^1.1.0",
+						"has": "^1.0.3",
+						"side-channel": "^1.0.4"
+					}
+				},
+				"is-bigint": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+					"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+					"dev": true
+				},
+				"is-binary-path": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+					"integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+					"dev": true,
+					"requires": {
+						"binary-extensions": "^2.0.0"
+					}
+				},
+				"is-boolean-object": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+					"integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2"
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+					"dev": true
+				},
+				"is-callable": {
+					"version": "1.2.3",
+					"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+					"integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+					"dev": true
+				},
+				"is-date-object": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+					"integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+					"dev": true
+				},
+				"is-extglob": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+					"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"is-glob": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+					"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+					"dev": true,
+					"requires": {
+						"is-extglob": "^2.1.1"
+					}
+				},
+				"is-negative-zero": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+					"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+					"dev": true
+				},
+				"is-number": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-number-object": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+					"integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+					"dev": true
+				},
+				"is-regex": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+					"integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"has-symbols": "^1.0.2"
+					}
+				},
+				"is-string": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+					"integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+					"dev": true
+				},
+				"is-symbol": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+					"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+					"dev": true,
+					"requires": {
+						"has-symbols": "^1.0.2"
+					}
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.13.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+					"integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.21",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+					"dev": true
+				},
+				"log-symbols": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
+					"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.4.2"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"mkdirp": {
+					"version": "0.5.5",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"ms": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+					"dev": true
+				},
+				"node-environment-flags": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
+					"integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+					"dev": true,
+					"requires": {
+						"object.getownpropertydescriptors": "^2.0.3",
+						"semver": "^5.7.0"
+					}
+				},
+				"normalize-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+					"dev": true
+				},
+				"object-inspect": {
+					"version": "1.11.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+					"integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+					"dev": true
+				},
+				"object-keys": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+					"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+					"dev": true
+				},
+				"object.assign": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+					"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+					"dev": true,
+					"requires": {
+						"define-properties": "^1.1.2",
+						"function-bind": "^1.1.1",
+						"has-symbols": "^1.0.0",
+						"object-keys": "^1.0.11"
+					}
+				},
+				"object.getownpropertydescriptors": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+					"integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3",
+						"es-abstract": "^1.18.0-next.2"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+					"dev": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"picomatch": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+					"integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+					"dev": true
+				},
+				"readdirp": {
+					"version": "3.2.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
+					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+					"dev": true,
+					"requires": {
+						"picomatch": "^2.0.4"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"dev": true
+				},
+				"side-channel": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+					"integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.0",
+						"get-intrinsic": "^1.0.2",
+						"object-inspect": "^1.9.0"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+					"dev": true,
+					"requires": {
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"string.prototype.trimend": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+					"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"string.prototype.trimstart": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+					"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+					"dev": true,
+					"requires": {
+						"call-bind": "^1.0.2",
+						"define-properties": "^1.1.3"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
+					}
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+					"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"to-regex-range": {
+					"version": "5.0.1",
+					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
+					"requires": {
+						"is-number": "^7.0.0"
+					}
+				},
+				"unbox-primitive": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+					"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+					"dev": true,
+					"requires": {
+						"function-bind": "^1.1.1",
+						"has-bigints": "^1.0.1",
+						"has-symbols": "^1.0.2",
+						"which-boxed-primitive": "^1.0.2"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-boxed-primitive": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+					"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+					"dev": true,
+					"requires": {
+						"is-bigint": "^1.0.1",
+						"is-boolean-object": "^1.1.0",
+						"is-number-object": "^1.0.4",
+						"is-string": "^1.0.5",
+						"is-symbol": "^1.0.3"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
+				},
+				"wide-align": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+					"dev": true,
+					"requires": {
+						"string-width": "^1.0.2 || 2"
+					}
+				},
+				"wrap-ansi": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+					"integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.0",
+						"string-width": "^3.0.0",
+						"strip-ansi": "^5.0.0"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				},
+				"y18n": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "13.3.2",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^5.0.0",
+						"find-up": "^3.0.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^3.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^13.1.2"
+					},
+					"dependencies": {
+						"ansi-regex": {
+							"version": "4.1.0",
+							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+							"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+							"dev": true
+						},
+						"string-width": {
+							"version": "3.1.0",
+							"resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+							"integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+							"dev": true,
+							"requires": {
+								"emoji-regex": "^7.0.1",
+								"is-fullwidth-code-point": "^2.0.0",
+								"strip-ansi": "^5.1.0"
+							}
+						},
+						"strip-ansi": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+							"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+							"dev": true,
+							"requires": {
+								"ansi-regex": "^4.1.0"
+							}
+						}
+					}
+				},
+				"yargs-parser": {
+					"version": "13.1.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				},
+				"yargs-unparser": {
+					"version": "1.6.0",
+					"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+					"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+					"dev": true,
+					"requires": {
+						"flat": "^4.1.0",
+						"lodash": "^4.17.15",
+						"yargs": "^13.3.0"
+					}
+				}
+			}
+		},
+		"nyc": {
+			"version": "15.1.0",
+			"resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
+			"integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
+			"dev": true,
+			"requires": {
+				"@istanbuljs/load-nyc-config": "^1.0.0",
+				"@istanbuljs/schema": "^0.1.2",
+				"caching-transform": "^4.0.0",
+				"convert-source-map": "^1.7.0",
+				"decamelize": "^1.2.0",
+				"find-cache-dir": "^3.2.0",
+				"find-up": "^4.1.0",
+				"foreground-child": "^2.0.0",
+				"get-package-type": "^0.1.0",
+				"glob": "^7.1.6",
+				"istanbul-lib-coverage": "^3.0.0",
+				"istanbul-lib-hook": "^3.0.0",
+				"istanbul-lib-instrument": "^4.0.0",
+				"istanbul-lib-processinfo": "^2.0.2",
+				"istanbul-lib-report": "^3.0.0",
+				"istanbul-lib-source-maps": "^4.0.0",
+				"istanbul-reports": "^3.0.2",
+				"make-dir": "^3.0.0",
+				"node-preload": "^0.2.1",
+				"p-map": "^3.0.0",
+				"process-on-spawn": "^1.0.0",
+				"resolve-from": "^5.0.0",
+				"rimraf": "^3.0.0",
+				"signal-exit": "^3.0.2",
+				"spawn-wrap": "^2.0.0",
+				"test-exclude": "^6.0.0",
+				"yargs": "^15.0.2"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+					"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.14.5"
+					}
+				},
+				"@babel/compat-data": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+					"integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA==",
+					"dev": true
+				},
+				"@babel/core": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+					"integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-compilation-targets": "^7.15.0",
+						"@babel/helper-module-transforms": "^7.15.0",
+						"@babel/helpers": "^7.14.8",
+						"@babel/parser": "^7.15.0",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.2",
+						"json5": "^2.1.2",
+						"semver": "^6.3.0",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+					"integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-compilation-targets": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+					"integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+					"dev": true,
+					"requires": {
+						"@babel/compat-data": "^7.15.0",
+						"@babel/helper-validator-option": "^7.14.5",
+						"browserslist": "^4.16.6",
+						"semver": "^6.3.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+					"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.14.5",
+						"@babel/template": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+					"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-hoist-variables": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+					"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+					"integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.15.0"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+					"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+					"integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.14.5",
+						"@babel/helper-replace-supers": "^7.15.0",
+						"@babel/helper-simple-access": "^7.14.8",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.15.0",
+						"@babel/types": "^7.15.0"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+					"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+					"integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.15.0",
+						"@babel/helper-optimise-call-expression": "^7.14.5",
+						"@babel/traverse": "^7.15.0",
+						"@babel/types": "^7.15.0"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.14.8",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
+					"integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.8"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+					"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.14.9",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+					"dev": true
+				},
+				"@babel/helper-validator-option": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+					"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+					"dev": true
+				},
+				"@babel/helpers": {
+					"version": "7.14.8",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
+					"integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.14.5",
+						"@babel/traverse": "^7.14.8",
+						"@babel/types": "^7.14.8"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+					"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.5",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.0.tgz",
+					"integrity": "sha512-0v7oNOjr6YT9Z2RAOTv4T9aP+ubfx4Q/OhVtAet7PFDt0t9Oy6Jn+/rfC6b8HJ5zEqrQCiMxJfgtHpmIminmJQ==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.14.5",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+					"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/parser": "^7.14.5",
+						"@babel/types": "^7.14.5"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+					"integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.14.5",
+						"@babel/generator": "^7.15.0",
+						"@babel/helper-function-name": "^7.14.5",
+						"@babel/helper-hoist-variables": "^7.14.5",
+						"@babel/helper-split-export-declaration": "^7.14.5",
+						"@babel/parser": "^7.15.0",
+						"@babel/types": "^7.15.0",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0"
+					}
+				},
+				"@babel/types": {
+					"version": "7.15.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+					"integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.14.9",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@istanbuljs/load-nyc-config": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+					"integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.3.1",
+						"find-up": "^4.1.0",
+						"get-package-type": "^0.1.0",
+						"js-yaml": "^3.13.1",
+						"resolve-from": "^5.0.0"
+					}
+				},
+				"@istanbuljs/schema": {
+					"version": "0.1.3",
+					"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+					"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+					"dev": true
+				},
+				"aggregate-error": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+					"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+					"dev": true,
+					"requires": {
+						"clean-stack": "^2.0.0",
+						"indent-string": "^4.0.0"
+					}
+				},
+				"ansi-regex": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"append-transform": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
+					"integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "^3.0.0"
+					}
+				},
+				"archy": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+					"integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+					"dev": true
+				},
+				"argparse": {
+					"version": "1.0.10",
+					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+					"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+					"dev": true,
+					"requires": {
+						"sprintf-js": "~1.0.2"
+					}
+				},
+				"balanced-match": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"browserslist": {
+					"version": "4.16.7",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.7.tgz",
+					"integrity": "sha512-7I4qVwqZltJ7j37wObBe3SoTz+nS8APaNcrBOlgoirb6/HbEU2XxW/LpUDTCngM6iauwFqmRTuOMfyKnFGY5JA==",
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "^1.0.30001248",
+						"colorette": "^1.2.2",
+						"electron-to-chromium": "^1.3.793",
+						"escalade": "^3.1.1",
+						"node-releases": "^1.1.73"
+					}
+				},
+				"caching-transform": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
+					"integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+					"dev": true,
+					"requires": {
+						"hasha": "^5.0.0",
+						"make-dir": "^3.0.0",
+						"package-hash": "^4.0.0",
+						"write-file-atomic": "^3.0.0"
+					}
+				},
+				"camelcase": {
+					"version": "5.3.1",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+					"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+					"dev": true
+				},
+				"caniuse-lite": {
+					"version": "1.0.30001249",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz",
+					"integrity": "sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"clean-stack": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+					"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+					"dev": true
+				},
+				"cliui": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+					"integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+					"dev": true,
+					"requires": {
+						"string-width": "^4.2.0",
+						"strip-ansi": "^6.0.0",
+						"wrap-ansi": "^6.2.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"colorette": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+					"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
+					"dev": true
+				},
+				"commondir": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+					"integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+					"dev": true
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"convert-source-map": {
+					"version": "1.8.0",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+					"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.1.1"
+					}
+				},
+				"cross-spawn": {
+					"version": "7.0.3",
+					"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+					"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+					"dev": true,
+					"requires": {
+						"path-key": "^3.1.0",
+						"shebang-command": "^2.0.0",
+						"which": "^2.0.1"
+					}
+				},
+				"debug": {
+					"version": "4.3.2",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"dev": true,
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"decamelize": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+					"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+					"dev": true
+				},
+				"default-require-extensions": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
+					"integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+					"dev": true,
+					"requires": {
+						"strip-bom": "^4.0.0"
+					}
+				},
+				"electron-to-chromium": {
+					"version": "1.3.796",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz",
+					"integrity": "sha512-agwJFgM0FUC1UPPbQ4aII3HamaaJ09fqWGAWYHmzxDWqdmTleCHyyA0kt3fJlTd5M440IaeuBfzXzXzCotnZcQ==",
+					"dev": true
+				},
+				"emoji-regex": {
+					"version": "8.0.0",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+					"dev": true
+				},
+				"es6-error": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+					"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+					"dev": true
+				},
+				"escalade": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"esprima": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
+				},
+				"find-cache-dir": {
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+					"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
+					"dev": true,
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^3.0.2",
+						"pkg-dir": "^4.1.0"
+					}
+				},
+				"find-up": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"foreground-child": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
+					"integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
+					"dev": true,
+					"requires": {
+						"cross-spawn": "^7.0.0",
+						"signal-exit": "^3.0.2"
+					}
+				},
+				"fromentries": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+					"integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+					"dev": true
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"gensync": {
+					"version": "1.0.0-beta.2",
+					"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+					"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+					"dev": true
+				},
+				"get-caller-file": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+					"dev": true
+				},
+				"get-package-type": {
+					"version": "0.1.0",
+					"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+					"integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"globals": {
+					"version": "11.12.0",
+					"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+					"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+					"dev": true
+				},
+				"graceful-fs": {
+					"version": "4.2.6",
+					"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+					"integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"hasha": {
+					"version": "5.2.2",
+					"resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
+					"integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
+					"dev": true,
+					"requires": {
+						"is-stream": "^2.0.0",
+						"type-fest": "^0.8.0"
+					}
+				},
+				"html-escaper": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+					"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+					"dev": true
+				},
+				"imurmurhash": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+					"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+					"dev": true
+				},
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"is-fullwidth-code-point": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+					"dev": true
+				},
+				"is-stream": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+					"integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+					"dev": true
+				},
+				"is-typedarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+					"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+					"dev": true
+				},
+				"is-windows": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+					"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+					"dev": true
+				},
+				"isexe": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+					"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+					"integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
+					"integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
+					"dev": true,
+					"requires": {
+						"append-transform": "^2.0.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+					"integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+					"dev": true,
+					"requires": {
+						"@babel/core": "^7.7.5",
+						"@istanbuljs/schema": "^0.1.2",
+						"istanbul-lib-coverage": "^3.0.0",
+						"semver": "^6.3.0"
+					}
+				},
+				"istanbul-lib-processinfo": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
+					"integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+					"dev": true,
+					"requires": {
+						"archy": "^1.0.0",
+						"cross-spawn": "^7.0.0",
+						"istanbul-lib-coverage": "^3.0.0-alpha.1",
+						"make-dir": "^3.0.0",
+						"p-map": "^3.0.0",
+						"rimraf": "^3.0.0",
+						"uuid": "^3.3.3"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+					"integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^3.0.0",
+						"make-dir": "^3.0.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "4.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+							"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+							"dev": true
+						},
+						"supports-color": {
+							"version": "7.2.0",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+							"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+							"dev": true,
+							"requires": {
+								"has-flag": "^4.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+					"integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+					"dev": true,
+					"requires": {
+						"debug": "^4.1.1",
+						"istanbul-lib-coverage": "^3.0.0",
+						"source-map": "^0.6.1"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
+					}
+				},
+				"istanbul-reports": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+					"integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+					"dev": true,
+					"requires": {
+						"html-escaper": "^2.0.0",
+						"istanbul-lib-report": "^3.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+					"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+					"dev": true
+				},
+				"js-yaml": {
+					"version": "3.14.1",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+					"integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
+				"jsesc": {
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+					"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+					"dev": true
+				},
+				"json5": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+					"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.5"
+					}
+				},
+				"locate-path": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+					"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^4.1.0"
+					}
+				},
+				"lodash.flattendeep": {
+					"version": "4.4.0",
+					"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+					"integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+					"dev": true
+				},
+				"make-dir": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+					"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+					"dev": true,
+					"requires": {
+						"semver": "^6.0.0"
+					}
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+					"dev": true
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
+				},
+				"node-preload": {
+					"version": "0.2.1",
+					"resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
+					"integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
+					"dev": true,
+					"requires": {
+						"process-on-spawn": "^1.0.0"
+					}
+				},
+				"node-releases": {
+					"version": "1.1.73",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
+					"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==",
+					"dev": true
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+					"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.2.0"
+					}
+				},
+				"p-map": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
+					"integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+					"dev": true,
+					"requires": {
+						"aggregate-error": "^3.0.0"
+					}
+				},
+				"p-try": {
+					"version": "2.2.0",
+					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+					"dev": true
+				},
+				"package-hash": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
+					"integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.15",
+						"hasha": "^5.0.0",
+						"lodash.flattendeep": "^4.4.0",
+						"release-zalgo": "^1.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"path-key": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+					"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+					"dev": true
+				},
+				"pkg-dir": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+					"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+					"dev": true,
+					"requires": {
+						"find-up": "^4.0.0"
+					}
+				},
+				"process-on-spawn": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
+					"integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
+					"dev": true,
+					"requires": {
+						"fromentries": "^1.2.0"
+					}
+				},
+				"release-zalgo": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
+					"integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+					"dev": true,
+					"requires": {
+						"es6-error": "^4.0.1"
+					}
+				},
+				"require-directory": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+					"integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+					"dev": true
+				},
+				"require-main-filename": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+					"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+					"dev": true
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				},
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+					"dev": true
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				},
+				"set-blocking": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+					"dev": true
+				},
+				"shebang-command": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+					"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+					"dev": true,
+					"requires": {
+						"shebang-regex": "^3.0.0"
+					}
+				},
+				"shebang-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+					"dev": true
+				},
+				"signal-exit": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+					"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"spawn-wrap": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
+					"integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
+					"dev": true,
+					"requires": {
+						"foreground-child": "^2.0.0",
+						"is-windows": "^1.0.2",
+						"make-dir": "^3.0.0",
+						"rimraf": "^3.0.0",
+						"signal-exit": "^3.0.2",
+						"which": "^2.0.1"
+					}
+				},
+				"sprintf-js": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+					"integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+					"dev": true
+				},
+				"string-width": {
+					"version": "4.2.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+					"integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+					"dev": true,
+					"requires": {
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^5.0.0"
+					}
+				},
+				"strip-bom": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+					"integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				},
+				"test-exclude": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+					"integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+					"dev": true,
+					"requires": {
+						"@istanbuljs/schema": "^0.1.2",
+						"glob": "^7.1.4",
+						"minimatch": "^3.0.4"
+					}
+				},
+				"to-fast-properties": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+					"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+					"dev": true
+				},
+				"type-fest": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+					"dev": true
+				},
+				"typedarray-to-buffer": {
+					"version": "3.1.5",
+					"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+					"integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+					"dev": true,
+					"requires": {
+						"is-typedarray": "^1.0.0"
+					}
+				},
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+					"dev": true
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
+				"which-module": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+					"integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+					"dev": true
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.3.0",
+							"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+							"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+							"dev": true,
+							"requires": {
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+							"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+							"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+							"dev": true
+						}
+					}
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+					"integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"is-typedarray": "^1.0.0",
+						"signal-exit": "^3.0.2",
+						"typedarray-to-buffer": "^3.1.5"
+					}
+				},
+				"y18n": {
+					"version": "4.0.3",
+					"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+					"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+					"dev": true
+				},
+				"yargs": {
+					"version": "15.4.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+					"integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+					"dev": true,
+					"requires": {
+						"cliui": "^6.0.0",
+						"decamelize": "^1.2.0",
+						"find-up": "^4.1.0",
+						"get-caller-file": "^2.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^2.0.0",
+						"set-blocking": "^2.0.0",
+						"string-width": "^4.2.0",
+						"which-module": "^2.0.0",
+						"y18n": "^4.0.0",
+						"yargs-parser": "^18.1.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "18.1.3",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+					"integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+					"dev": true,
+					"requires": {
+						"camelcase": "^5.0.0",
+						"decamelize": "^1.2.0"
+					}
+				}
+			}
+		},
+		"prettier": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+			"integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+			"dev": true
+		},
+		"rimraf": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
+			"requires": {
+				"glob": "^7.1.3"
+			},
+			"dependencies": {
+				"balanced-match": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+					"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+					"dev": true
+				},
+				"brace-expansion": {
+					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+					"dev": true,
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
+				},
+				"concat-map": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+					"dev": true
+				},
+				"fs.realpath": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+					"dev": true
+				},
+				"glob": {
+					"version": "7.1.7",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
+					"integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+					"dev": true,
+					"requires": {
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
+					}
+				},
+				"inflight": {
+					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+					"dev": true,
+					"requires": {
+						"once": "^1.3.0",
+						"wrappy": "1"
+					}
+				},
+				"inherits": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+					"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+					"dev": true
+				},
+				"minimatch": {
+					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+					"dev": true,
+					"requires": {
+						"brace-expansion": "^1.1.7"
+					}
+				},
+				"once": {
+					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+					"dev": true,
+					"requires": {
+						"wrappy": "1"
+					}
+				},
+				"path-is-absolute": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+					"dev": true
+				},
+				"wrappy": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+					"dev": true
+				}
+			}
+		}
+	}
+}

--- a/packages/allure-decorators/package.json
+++ b/packages/allure-decorators/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "allure-decorators",
+  "version": "2.0.0-beta.10",
+  "description": "Write your tests in a Java-like annotation-driven manner via JS decorators.",
+  "license": "Apache-2.0",
+  "author": "Sergey Korol <serhii.s.korol@gmail.com>",
+  "repository": "https://github.com/allure-framework/allure-js",
+  "keywords": [
+    "typescript",
+    "allure",
+    "decorators"
+  ],
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "clean": "rimraf ./dist ./out",
+    "compile": "tsc",
+    "prepublishOnly": "npm run clean && npm run build",
+    "build": "npm run lint && npm run compile",
+    "generate-report": "allure generate ./out/allure-results -o ./out/allure-report --clean",
+    "allure-report": "allure serve ./out/allure-results",
+    "test": "nyc ts-node --project test/tsconfig.json test/runner.ts",
+    "coverage": "codecov",
+    "lint": "eslint ./src --ext .ts",
+    "lint-fix": "eslint ./src --ext .ts --fix"
+  },
+  "dependencies": {
+    "allure-js-commons": "^2.0.0-beta.10"
+  },
+  "devDependencies": {
+    "@testdeck/mocha": "0.1.2",
+    "@types/chai": "^4.2.11",
+    "@types/chai-arrays": "2.0.0",
+    "@types/mocha": "^7.0.2",
+    "allure-mocha": "^2.0.0-beta.10",
+    "chai": "^4.2.0",
+    "chai-arrays": "^2.2.0",
+    "codecov": "^3.6.5",
+    "dotenv": "^10.0.0",
+    "eslint": "^7.24.0",
+    "fs-jetpack": "^4.1.0",
+    "glob": "^7.1.6",
+    "mocha": "^8.1.1",
+    "mocha-multi-reporters": "^1.1.7",
+    "npm-run-all": "^4.1.5",
+    "nyc": "^15.0.1",
+    "prettier": "^2.0.5",
+    "rimraf": "^3.0.2",
+    "source-map-support": "^0.5.19"
+  },
+  "nyc": {
+    "check-coverage": true,
+    "lines": 80,
+    "statements": 80,
+    "functions": 75,
+    "branches": 70,
+    "extension": [
+      ".ts"
+    ],
+    "exclude": [
+      "test/**/*.*",
+      "**/*.d.ts",
+      "index.ts"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ],
+    "all": true,
+    "report-dir": "./out/coverage",
+    "temp-dir": "./out/.nyc"
+  }
+}

--- a/packages/allure-decorators/src/core/descriptor.ts
+++ b/packages/allure-decorators/src/core/descriptor.ts
@@ -1,0 +1,29 @@
+export const processDescriptor = <T>(
+  parameterFn: string | ((arg: T) => string),
+  reporterFn: (arg: string) => void,
+  descriptor: PropertyDescriptor,
+  propsFilter: (arg: string) => boolean = () => true,
+): PropertyDescriptor => {
+  const original: any = descriptor.value;
+  if (typeof original === "function") {
+    descriptor.value = function(...args: [T]) {
+      try {
+        const value: string =
+          typeof parameterFn === "function" ? parameterFn.apply(this, args) : parameterFn;
+        reporterFn(value);
+      } catch (e) {
+        /* eslint-disable no-console */
+        console.error(`[ERROR] Failed to apply decorator: ${e}`);
+      }
+      return original.apply(this, args);
+    };
+  }
+
+  for (const prop of Object.keys(original)) {
+    if (Object.prototype.hasOwnProperty.call(original, prop) && propsFilter(prop)) {
+      descriptor.value[prop] = original[prop];
+    }
+  }
+
+  return descriptor;
+};

--- a/packages/allure-decorators/src/core/index.ts
+++ b/packages/allure-decorators/src/core/index.ts
@@ -1,0 +1,136 @@
+import { Allure, ContentType, Severity } from "allure-js-commons";
+import { processDescriptor } from "./descriptor";
+
+type TestDecorator = (
+  target: unknown,
+  property: string,
+  descriptor: PropertyDescriptor,
+) => PropertyDescriptor;
+
+/* eslint-disable no-shadow */
+const enum LinkType {
+  ISSUE = "issue",
+  TMS = "tms",
+}
+
+const defaultTrackerAddress = "http://localhost";
+let allure: Allure;
+let pmsUrl: string;
+let tmsUrl: string;
+
+export const step = <T>(nameFn: string | ((arg: T) => string)) => {
+  return (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const original: unknown = descriptor.value;
+    let callable: (args: T) => void;
+
+    if (typeof original === "function") {
+      descriptor.value = function(...args: [T]) {
+        try {
+          const value: string = typeof nameFn === "function" ? nameFn.apply(this, args) : nameFn;
+          callable = () => getAllure().step(value, () => original.apply(this, args));
+        } catch (e) {
+          /* eslint-disable no-console */
+          console.error(`[ERROR] Failed to apply step decorator: ${e}`);
+        }
+        return callable ? callable.apply(this, args) : original.apply(this, args);
+      };
+    }
+    return descriptor;
+  };
+};
+
+export const attachment = <T>(name: string, type: ContentType) => {
+  return (target: unknown, propertyKey: string, descriptor: PropertyDescriptor) => {
+    const original: unknown = descriptor.value;
+    let callable: (args: T) => void;
+
+    if (typeof original === "function") {
+      descriptor.value = function(...args: [T]) {
+        try {
+          const content: Buffer | string = original.apply(this, args);
+          callable = () => getAllure().attachment(name, content, type);
+        } catch (e) {
+          /* eslint-disable no-console */
+          console.error(`[ERROR] Failed to apply attachment decorator: ${e}`);
+        }
+        return callable ? callable.apply(this, args) : {};
+      };
+    }
+    return descriptor;
+  };
+};
+
+export const testCaseId = <T>(idFn: string | ((arg: T) => string)): TestDecorator => {
+  return processDecorator(idFn, (id) => getAllure().link(`${getTmsUrl()}/${id}`, id, LinkType.TMS));
+};
+
+export const issue = <T>(idFn: string | ((arg: T) => string)): TestDecorator => {
+  return processDecorator(idFn, (id) =>
+    getAllure().link(`${getPmsUrl()}/${id}`, id, LinkType.ISSUE),
+  );
+};
+
+export const feature = <T>(featureFn: string | ((arg: T) => string)): TestDecorator => {
+  return processDecorator(featureFn, (name) => getAllure().feature(name));
+};
+
+export const story = <T>(storyFn: string | ((arg: T) => string)): TestDecorator => {
+  return processDecorator(storyFn, (name) => getAllure().story(name));
+};
+
+export const severity = <T>(
+  severityFn: Severity | string | ((arg: T) => string | Severity),
+): TestDecorator => {
+  return processDecorator(severityFn, (name) => getAllure().severity(name));
+};
+
+export const tag = <T>(tagFn: string | ((arg: T) => string)) => {
+  return processDecorator(tagFn, (name) => getAllure().tag(name));
+};
+
+export const owner = <T>(ownerFn: string | ((arg: T) => string)) => {
+  return processDecorator(ownerFn, (name) => getAllure().owner(name));
+};
+
+export const epic = <T>(epicFn: string | ((arg: T) => string)) => {
+  return processDecorator(epicFn, (name) => getAllure().epic(name));
+};
+
+export const description = <T>(descriptionFn: string | ((arg: T) => string)) => {
+  return processDecorator(descriptionFn, (text) => getAllure().description(text));
+};
+
+export const decorate = <T extends Allure>(allureInstance: T): void => {
+  allure = allureInstance;
+};
+
+export const getAllure = <T extends Allure>(): T => {
+  if (!allure) {
+    throw new Error("Unable to find Allure implementation");
+  }
+  return allure as T;
+};
+
+export const assignTmsUrl = (url: string): void => {
+  tmsUrl = url;
+};
+
+const getTmsUrl = (): string => {
+  return tmsUrl || defaultTrackerAddress;
+};
+
+export const assignPmsUrl = (url: string): void => {
+  pmsUrl = url;
+};
+
+const getPmsUrl = (): string => {
+  return pmsUrl || defaultTrackerAddress;
+};
+
+const processDecorator = <T>(
+  parameterFn: string | ((arg: T) => string),
+  reporterFn: (arg: string) => void,
+): TestDecorator => {
+  return (target: unknown, property: string, descriptor: PropertyDescriptor) =>
+    processDescriptor(parameterFn, reporterFn, descriptor);
+};

--- a/packages/allure-decorators/src/testdeck/index.ts
+++ b/packages/allure-decorators/src/testdeck/index.ts
@@ -1,0 +1,68 @@
+import { getAllure } from "../core";
+import { processDescriptor } from "../core/descriptor";
+
+/**
+ * This code was partially cloned from testdeck/core package and improved to support missing data tracking features.
+ */
+const nodeSymbol: (key: string) => string = (key): string => `__testdeck_${key}`;
+const testNameSymbol: string = nodeSymbol("name");
+const parametersSymbol: string = nodeSymbol("parametersSymbol");
+const nameForParametersSymbol: string = nodeSymbol("nameForParameters");
+
+type Params = any | ((arg?: any) => any);
+type Execution = undefined | "pending" | "only" | "skip" | "execution";
+type TestDecorator = (
+  target: unknown,
+  property: string,
+  descriptor: PropertyDescriptor,
+) => PropertyDescriptor;
+type ParamsDecorator = (params: Params, name?: string) => TestDecorator;
+
+interface ParameterizedPropertyDescriptor extends PropertyDescriptor {
+  (params: Params, name?: string): MethodDecorator;
+
+  skip(params: Params, name?: string): MethodDecorator;
+
+  only(params: Params, name?: string): MethodDecorator;
+
+  pending(params: Params, name?: string): MethodDecorator;
+
+  naming(nameForParameters: (params: Params) => string): MethodDecorator;
+}
+
+const makeParamsNameFunction = (): any => {
+  return (nameForParameters: (params: Params) => string) =>
+    (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+      target[propertyKey][nameForParametersSymbol] = nameForParameters;
+      return descriptor;
+    };
+};
+
+const makeParamsFunction = <T>(execution?: Execution): ParamsDecorator => {
+  return (params: Params, name?: string) =>
+    (target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+      const adjustedParams: any = typeof params === "function" ? params() : params;
+      target[propertyKey][testNameSymbol] = propertyKey.toString();
+      target[propertyKey][parametersSymbol] = target[propertyKey][parametersSymbol] || [];
+      [].concat(adjustedParams || []).forEach((param) => {
+        target[propertyKey][parametersSymbol].push({ execution, name, params: param });
+      });
+      return processDescriptor<T>(
+        (args) => JSON.stringify(args),
+        (arg) => getAllure().parameter("inputs", arg),
+        descriptor,
+        (prop) => prop.startsWith("__testdeck_"),
+      );
+    };
+};
+
+const makeParamsObject = (): any => {
+  return Object.assign(makeParamsFunction(), {
+    only: makeParamsFunction("only"),
+    pending: makeParamsFunction("pending"),
+    skip: makeParamsFunction("skip"),
+    naming: makeParamsNameFunction(),
+  });
+};
+
+export const data: ParameterizedPropertyDescriptor = makeParamsObject();

--- a/packages/allure-decorators/test/fixtures/model/User.ts
+++ b/packages/allure-decorators/test/fixtures/model/User.ts
@@ -1,0 +1,7 @@
+export class User {
+  constructor(readonly firstName: string, readonly lastName: string) {}
+
+  toString(): string {
+    return `${this.firstName}${this.lastName}`;
+  }
+}

--- a/packages/allure-decorators/test/fixtures/specs/attachment.ts
+++ b/packages/allure-decorators/test/fixtures/specs/attachment.ts
@@ -1,0 +1,38 @@
+import { suite, test } from "@testdeck/mocha";
+import { attachment, step } from "../../../";
+import { ContentType } from "allure-js-commons";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Attachment extends BaseTest {
+  @attachment("Test attachment", ContentType.TEXT)
+  public testAttachment() {
+    return "Attachment 1";
+  }
+
+  @attachment("Step attachment", ContentType.TEXT)
+  public stepAttachment() {
+    return "Attachment 2";
+  }
+
+  @attachment("Broken attachment", ContentType.TEXT)
+  public brokenAttachment() {
+    throw new Error("Broken attachment");
+  }
+
+  @step("Step with attachment")
+  public testStep() {
+    this.stepAttachment();
+  }
+
+  @test
+  shouldAssignDecoratedAttachment() {
+    this.testAttachment();
+    this.testStep();
+  }
+
+  @test
+  shouldNotProcessBrokenAttachment() {
+    this.brokenAttachment();
+  }
+}

--- a/packages/allure-decorators/test/fixtures/specs/baseTest.ts
+++ b/packages/allure-decorators/test/fixtures/specs/baseTest.ts
@@ -1,0 +1,10 @@
+import { decorate } from "../../../";
+import { allure, MochaAllure } from "allure-mocha/runtime";
+
+export class BaseTest {
+  public static readonly TEST_URL = "https://custom.domain.com";
+
+  public before() {
+    decorate<MochaAllure>(allure);
+  }
+}

--- a/packages/allure-decorators/test/fixtures/specs/description.ts
+++ b/packages/allure-decorators/test/fixtures/specs/description.ts
@@ -1,0 +1,14 @@
+import { suite, test } from "@testdeck/mocha";
+import { description } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Description extends BaseTest {
+  @description("Decorated description")
+  @test
+  shouldAssignDecoratedDescription() {}
+
+  @description(() => "Functional decorated description")
+  @test
+  shouldAssignFunctionalDecoratedDescription() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/epic.ts
+++ b/packages/allure-decorators/test/fixtures/specs/epic.ts
@@ -1,0 +1,10 @@
+import { suite, test } from "@testdeck/mocha";
+import { epic } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Epic extends BaseTest {
+  @epic("Epic Name")
+  @test
+  shouldAssignDecoratedEpic() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/feature.ts
+++ b/packages/allure-decorators/test/fixtures/specs/feature.ts
@@ -1,0 +1,10 @@
+import { suite, test } from "@testdeck/mocha";
+import { feature } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Feature extends BaseTest {
+  @feature("Decorated Feature")
+  @test
+  shouldAssignDecoratedFeature() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/issueAndTms.ts
+++ b/packages/allure-decorators/test/fixtures/specs/issueAndTms.ts
@@ -1,0 +1,11 @@
+import { suite, test } from "@testdeck/mocha";
+import { issue, testCaseId } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class IssueAndTms extends BaseTest {
+  @issue("4")
+  @testCaseId("5")
+  @test
+  shouldAssignDecoratedIssueAndTms() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/issueAndTmsWithUrl.ts
+++ b/packages/allure-decorators/test/fixtures/specs/issueAndTmsWithUrl.ts
@@ -1,0 +1,17 @@
+import { suite, test } from "@testdeck/mocha";
+import { assignPmsUrl, assignTmsUrl, issue, testCaseId } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class IssueAndTmsWithUrl extends BaseTest {
+  public before() {
+    super.before();
+    assignPmsUrl(BaseTest.TEST_URL);
+    assignTmsUrl(BaseTest.TEST_URL);
+  }
+
+  @issue("6")
+  @testCaseId("7")
+  @test
+  shouldAssignDecoratedIssueAndTmsWithUrl() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/missingAllure.ts
+++ b/packages/allure-decorators/test/fixtures/specs/missingAllure.ts
@@ -1,0 +1,9 @@
+import { suite, test } from "@testdeck/mocha";
+import { epic } from "../../../";
+
+@suite
+class MissingAllure {
+  @epic("Should not be handled")
+  @test
+  shouldNotHandleEpicWithoutAllure() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/owner.ts
+++ b/packages/allure-decorators/test/fixtures/specs/owner.ts
@@ -1,0 +1,10 @@
+import { suite, test } from "@testdeck/mocha";
+import { owner } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Owner extends BaseTest {
+  @owner("Sergey Korol")
+  @test
+  shouldAssignDecoratedOwner() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/severity.ts
+++ b/packages/allure-decorators/test/fixtures/specs/severity.ts
@@ -1,0 +1,11 @@
+import { Severity } from "allure-js-commons";
+import { suite, test } from "@testdeck/mocha";
+import { severity } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class SeveritySubSuite extends BaseTest {
+  @severity(Severity.CRITICAL)
+  @test
+  shouldAssignDecoratedSeverity() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/step.ts
+++ b/packages/allure-decorators/test/fixtures/specs/step.ts
@@ -1,0 +1,56 @@
+import { suite, test } from "@testdeck/mocha";
+import { step } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Step extends BaseTest {
+  @test
+  shouldAddDecoratedSteps() {
+    this.step1();
+    this.step2();
+    this.step3();
+    this.step5().step1();
+  }
+
+  @test
+  shouldIgnoreStepWithError() {
+    this.step7();
+  }
+
+  @step("Execute step 1")
+  step1() {}
+
+  @step(() => "Execute step 2")
+  step2() {
+    this.step3();
+  }
+
+  @step(Step.customTitle())
+  step3() {
+    this.step4();
+  }
+
+  @step("Execute step 4")
+  step4() {}
+
+  @step("Execute step 5")
+  step5() {
+    return this.step6();
+  }
+
+  @step("Execute step 6")
+  step6() {
+    return this;
+  }
+
+  @step(() => {
+    throw new Error("An intentional error in step");
+  })
+  step7() {
+    return this;
+  }
+
+  public static customTitle() {
+    return "Execute step 3";
+  }
+}

--- a/packages/allure-decorators/test/fixtures/specs/story.ts
+++ b/packages/allure-decorators/test/fixtures/specs/story.ts
@@ -1,0 +1,10 @@
+import { suite, test } from "@testdeck/mocha";
+import { story } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Story extends BaseTest {
+  @story("Common decorated story")
+  @test
+  shouldAssignDecoratedStory() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/tag.ts
+++ b/packages/allure-decorators/test/fixtures/specs/tag.ts
@@ -1,0 +1,10 @@
+import { suite, test } from "@testdeck/mocha";
+import { tag } from "../../../";
+import { BaseTest } from "./baseTest";
+
+@suite
+class Tag extends BaseTest {
+  @tag("regression")
+  @test
+  shouldAssignDecoratedTag() {}
+}

--- a/packages/allure-decorators/test/fixtures/specs/testData.ts
+++ b/packages/allure-decorators/test/fixtures/specs/testData.ts
@@ -1,0 +1,17 @@
+import { suite, test } from "@testdeck/mocha";
+import { data } from "../../../";
+import { User } from "../model/User";
+import { BaseTest } from "./baseTest";
+
+@suite
+class TestData extends BaseTest {
+  static testData = () => new User("Test", "User");
+
+  @data(TestData.testData)
+  @data.naming((value: User) => `shouldCall${value.toString()}DataOnTest`)
+  @test
+  shouldCallDataOnTest(value: User) {}
+
+  @data("")
+  shouldNotBeExecuted(value: string) {}
+}

--- a/packages/allure-decorators/test/runner.ts
+++ b/packages/allure-decorators/test/runner.ts
@@ -1,0 +1,22 @@
+// custom runner for mocha that allows to include a custom reporter
+// which is not packed into an npm module
+import Mocha from "mocha";
+import path from "path";
+import glob from "glob";
+import "source-map-support/register";
+
+const mocha = new Mocha({
+  timeout: 16000,
+  reporter: "mocha-multi-reporters",
+  ignoreLeaks: false,
+  reporterOptions: {
+    reporterEnabled: "list, ../allure-mocha",
+    allureMochaReporterOptions: {
+      resultsDir: path.resolve(__dirname, "../out/allure-results"),
+    },
+  },
+});
+
+glob.sync("test/specs/**/*.ts").forEach((file) => mocha.addFile(file));
+
+mocha.run((failures) => process.exit(failures === 0 ? 0 : 1));

--- a/packages/allure-decorators/test/specs/attachment.ts
+++ b/packages/allure-decorators/test/specs/attachment.ts
@@ -1,0 +1,28 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { runTests } from "../utils";
+
+@suite
+class AttachmentSuite {
+  @test
+  async shouldHaveAttachment() {
+    const writerStub = await runTests("attachment");
+    expect(writerStub.groups.find((suite) => suite.name === "Attachment")).not.eq(undefined);
+    let test = writerStub.getTestByName("shouldAssignDecoratedAttachment");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.attachments.length).eq(1);
+    expect(test.attachments[0].name).eq("Test attachment");
+    expect(test.attachments[0].type).eq("text/plain");
+    expect(test.steps.length).eq(1);
+    expect(test.steps[0].attachments.length).eq(1);
+    expect(test.steps[0].attachments[0].name).eq("Step attachment");
+    expect(test.steps[0].attachments[0].type).eq("text/plain");
+
+    test = writerStub.getTestByName("shouldNotProcessBrokenAttachment");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.attachments.length).eq(0);
+  }
+}

--- a/packages/allure-decorators/test/specs/description.ts
+++ b/packages/allure-decorators/test/specs/description.ts
@@ -1,0 +1,23 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { runTests } from "../utils";
+
+@suite
+class DescriptionSuite {
+  @test
+  async shouldHaveDescription() {
+    const writerStub = await runTests("description");
+    expect(writerStub.groups.find((suite) => suite.name === "Description")).not.eq(undefined);
+
+    let test = writerStub.getTestByName("shouldAssignDecoratedDescription");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.description).eq("Decorated description");
+
+    test = writerStub.getTestByName("shouldAssignFunctionalDecoratedDescription");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.description).eq("Functional decorated description");
+  }
+}

--- a/packages/allure-decorators/test/specs/epic.ts
+++ b/packages/allure-decorators/test/specs/epic.ts
@@ -1,0 +1,18 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class EpicSuite {
+  @test
+  async shouldHaveEpic() {
+    const writerStub = await runTests("epic");
+    expect(writerStub.groups.find((suite) => suite.name === "Epic")).not.eq(undefined);
+
+    const test = writerStub.getTestByName("shouldAssignDecoratedEpic");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "epic").value).eq("Epic Name");
+  }
+}

--- a/packages/allure-decorators/test/specs/feature.ts
+++ b/packages/allure-decorators/test/specs/feature.ts
@@ -1,0 +1,17 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class FeatureSuite {
+  @test
+  async shouldHaveFeature() {
+    const writerStub = await runTests("feature");
+    expect(writerStub.groups.find((suite) => suite.name === "Feature")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldAssignDecoratedFeature");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "feature").value).eq("Decorated Feature");
+  }
+}

--- a/packages/allure-decorators/test/specs/issueAndTms.ts
+++ b/packages/allure-decorators/test/specs/issueAndTms.ts
@@ -1,0 +1,46 @@
+import { Status } from "allure-js-commons";
+import * as chai from "chai";
+import assertArrays from "chai-arrays";
+import { suite, test } from "@testdeck/mocha";
+import { runTests } from "../utils";
+import { BaseTest } from "../fixtures/specs/baseTest";
+
+const expect = chai.expect;
+chai.use(assertArrays);
+
+@suite
+class IssueAndTmsSuite {
+  @test
+  async shouldHaveIssueAndTmsLinks() {
+    const writerStub = await runTests("issueAndTms");
+    expect(writerStub.groups.find((suite) => suite.name === "IssueAndTms")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldAssignDecoratedIssueAndTms");
+    expect(test).not.eq(undefined);
+    expect(test.links).length(2);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.links.map((link) => link.name)).to.be.equalTo(["4", "5"]);
+    expect(test.links.map((link) => link.url)).to.be.equalTo([
+      "http://localhost/4",
+      "http://localhost/5",
+    ]);
+    expect(test.links.map((link) => link.type)).to.be.equalTo(["issue", "tms"]);
+  }
+
+  @test
+  async shouldHaveCustomIssueAndTmsLinks() {
+    const writerStub = await runTests("issueAndTmsWithUrl");
+    expect(writerStub.groups.find((suite) => suite.name === "IssueAndTmsWithUrl")).not.eq(
+      undefined,
+    );
+    const test = writerStub.getTestByName("shouldAssignDecoratedIssueAndTmsWithUrl");
+    expect(test).not.eq(undefined);
+    expect(test.links).length(2);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.links.map((link) => link.name)).to.be.equalTo(["6", "7"]);
+    expect(test.links.map((link) => link.url)).to.be.equalTo([
+      `${BaseTest.TEST_URL}/6`,
+      `${BaseTest.TEST_URL}/7`,
+    ]);
+    expect(test.links.map((link) => link.type)).to.be.equalTo(["issue", "tms"]);
+  }
+}

--- a/packages/allure-decorators/test/specs/missingAllure.ts
+++ b/packages/allure-decorators/test/specs/missingAllure.ts
@@ -1,0 +1,18 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class MissingAllureSuite {
+  @test
+  async shouldNotHandleDecoratorsWithoutAllure() {
+    const writerStub = await runTests("missingAllure");
+    expect(writerStub.groups.find((suite) => suite.name === "MissingAllure")).not.eq(undefined);
+
+    const test = writerStub.getTestByName("shouldNotHandleEpicWithoutAllure");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "epic")).is.undefined;
+  }
+}

--- a/packages/allure-decorators/test/specs/owner.ts
+++ b/packages/allure-decorators/test/specs/owner.ts
@@ -1,0 +1,17 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class OwnerSuite {
+  @test
+  async shouldHaveOwner() {
+    const writerStub = await runTests("owner");
+    expect(writerStub.groups.find((suite) => suite.name === "Owner")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldAssignDecoratedOwner");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "owner").value).eq("Sergey Korol");
+  }
+}

--- a/packages/allure-decorators/test/specs/severity.ts
+++ b/packages/allure-decorators/test/specs/severity.ts
@@ -1,0 +1,17 @@
+import { Severity, Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class SeveritySuite {
+  @test
+  async shouldHaveSeverity() {
+    const writerStub = await runTests("severity");
+    expect(writerStub.groups.find((suite) => suite.name === "SeveritySubSuite")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldAssignDecoratedSeverity");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "severity").value).eq(Severity.CRITICAL);
+  }
+}

--- a/packages/allure-decorators/test/specs/step.ts
+++ b/packages/allure-decorators/test/specs/step.ts
@@ -1,0 +1,46 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findStep, runTests } from "../utils";
+
+@suite
+class StepSuite {
+  @test
+  async shouldHaveSteps() {
+    const writerStub = await runTests("step");
+    expect(writerStub.groups.find((suite) => suite.name === "Step")).not.eq(undefined);
+    let test = writerStub.getTestByName("shouldAddDecoratedSteps");
+
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.steps.map((step) => step.name)).deep.eq([
+      "Execute step 1",
+      "Execute step 2",
+      "Execute step 3",
+      "Execute step 5",
+      "Execute step 1",
+    ]);
+    expect(test.steps.map((step) => step.status)).contains(Status.PASSED);
+
+    let subStep = findStep(test, "Execute step 2").steps.pop();
+    expect(subStep.name).eq("Execute step 3");
+    expect(subStep.status).eq(Status.PASSED);
+
+    subStep = subStep.steps.pop();
+    expect(subStep.name).eq("Execute step 4");
+    expect(subStep.status).eq(Status.PASSED);
+
+    subStep = findStep(test, "Execute step 3").steps.pop();
+    expect(subStep.name).eq("Execute step 4");
+    expect(subStep.status).eq(Status.PASSED);
+
+    subStep = findStep(test, "Execute step 5").steps.pop();
+    expect(subStep.name).eq("Execute step 6");
+    expect(subStep.status).eq(Status.PASSED);
+
+    test = writerStub.getTestByName("shouldIgnoreStepWithError");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(test.steps).is.ofSize(0);
+  }
+}

--- a/packages/allure-decorators/test/specs/story.ts
+++ b/packages/allure-decorators/test/specs/story.ts
@@ -1,0 +1,17 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class StorySuite {
+  @test
+  async shouldHaveStories() {
+    const writerStub = await runTests("story");
+    expect(writerStub.groups.find((suite) => suite.name === "Story")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldAssignDecoratedStory");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "story").value).eq("Common decorated story");
+  }
+}

--- a/packages/allure-decorators/test/specs/tag.ts
+++ b/packages/allure-decorators/test/specs/tag.ts
@@ -1,0 +1,17 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findLabel, runTests } from "../utils";
+
+@suite
+class TagSuite {
+  @test
+  async shouldHaveTags() {
+    const writerStub = await runTests("tag");
+    expect(writerStub.groups.find((suite) => suite.name === "Tag")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldAssignDecoratedTag");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findLabel(test, "tag").value).eq("regression");
+  }
+}

--- a/packages/allure-decorators/test/specs/testData.ts
+++ b/packages/allure-decorators/test/specs/testData.ts
@@ -1,0 +1,22 @@
+import { Status } from "allure-js-commons";
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { findParameter, runTests } from "../utils";
+
+@suite
+class ParameterSuite {
+  @test
+  async shouldHaveParameter() {
+    const writerStub = await runTests("testData");
+    expect(writerStub.groups.find((suite) => suite.name === "TestData")).not.eq(undefined);
+    const test = writerStub.getTestByName("shouldCallTestUserDataOnTest");
+    expect(test).not.eq(undefined);
+    expect(test.status).eq(Status.PASSED);
+    expect(findParameter(test, "inputs").value).eq(
+      JSON.stringify({
+        firstName: "Test",
+        lastName: "User",
+      }),
+    );
+  }
+}

--- a/packages/allure-decorators/test/tsconfig.json
+++ b/packages/allure-decorators/test/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "rootDir": ".",
+    "paths": {"allure-mocha/*": ["../node_modules/allure-mocha/*"]},
+    "baseUrl": "."
+  },
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/packages/allure-decorators/test/utils/index.ts
+++ b/packages/allure-decorators/test/utils/index.ts
@@ -1,0 +1,41 @@
+import * as jetpack from "fs-jetpack";
+import Mocha from "mocha";
+import { MochaAllureReporter } from "allure-mocha/runtime";
+import * as path from "path";
+import { InMemoryAllureWriter, TestResult } from "allure-js-commons";
+
+const testDir = "./test/fixtures/specs";
+
+export function runTests(...specs: string[]): Promise<InMemoryAllureWriter> {
+  const writer = new InMemoryAllureWriter();
+  const mocha = new Mocha();
+  mocha.reporter(MochaAllureReporter, { writer });
+  assignSpecs(mocha, specs);
+  return new Promise((resolve) => {
+    mocha.run(() => resolve(writer));
+  });
+}
+
+export function findLabel(test: TestResult, labelName: string): any {
+  return test.labels.find((label) => label.name === labelName);
+}
+
+export function findParameter(test: TestResult, parameterName: string): any {
+  return test.parameters.find((parameter) => parameter.name === parameterName);
+}
+
+export function findStep(test: TestResult, stepName: string): any {
+  return test.steps.find((step) => step.name === stepName);
+}
+
+function assignSpecs(mocha: Mocha, specs: string[]) {
+  jetpack
+    .dir(testDir)
+    .find({ matching: specs.map((spec) => `${spec}.ts`) })
+    .forEach((file) => {
+      const testPath = path.resolve(testDir, file);
+      // remove the test from node_modules cache, so it can be executed again
+      delete require.cache[testPath];
+      mocha.addFile(testPath);
+    });
+}

--- a/packages/allure-decorators/tsconfig.json
+++ b/packages/allure-decorators/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "src/**/*",
+    "index.ts"
+  ],
+  "exclude": [
+    "test/**"
+  ],
+  "compilerOptions": {
+    "types": [
+      "node"
+    ],
+    "outDir": "./dist"
+  }
+}

--- a/packages/allure-jasmine/src/JasmineAllureReporter.ts
+++ b/packages/allure-jasmine/src/JasmineAllureReporter.ts
@@ -35,6 +35,7 @@ const findMessageAboutThrow = (expectations?: FailedExpectation[]): FailedExpect
   return null;
 };
 
+/* eslint-disable no-shadow */
 enum SpecStatus {
   PASSED = "passed",
   FAILED = "failed",

--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -87,7 +87,7 @@ export interface ExecutorInfo {
   reportName?: string;
 }
 
-/* eslint-disable no-undef */
+/* eslint-disable no-shadow */
 export enum Status {
   FAILED = "failed",
   BROKEN = "broken",
@@ -95,7 +95,7 @@ export enum Status {
   SKIPPED = "skipped",
 }
 
-/* eslint-disable no-undef */
+/* eslint-disable no-shadow */
 export enum Stage {
   SCHEDULED = "scheduled",
   RUNNING = "running",
@@ -104,7 +104,7 @@ export enum Stage {
   INTERRUPTED = "interrupted",
 }
 
-/* eslint-disable no-undef */
+/* eslint-disable no-shadow */
 export enum LabelName {
   AS_ID = "AS_ID",
   SUITE = "suite",
@@ -126,6 +126,7 @@ export enum LabelName {
   LANGUAGE = "language",
 }
 
+/* eslint-disable no-shadow */
 export enum Severity {
   BLOCKER = "blocker",
   CRITICAL = "critical",
@@ -134,6 +135,7 @@ export enum Severity {
   TRIVIAL = "trivial",
 }
 
+/* eslint-disable no-shadow */
 export enum ContentType {
   TEXT = "text/plain",
   XML = "application/xml",
@@ -148,6 +150,7 @@ export enum ContentType {
   JPEG = "image/jpeg",
 }
 
+/* eslint-disable no-shadow */
 export enum LinkType {
   ISSUE = "issue",
   TMS = "tms",

--- a/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
@@ -6,7 +6,7 @@ import { AllureConfig } from "../AllureConfig";
 import { Category, TestResult, TestResultContainer } from "../model";
 import { AllureWriter } from "./AllureWriter";
 
-const writeJson = (path: string, data: object): void => {
+const writeJson = (path: string, data: unknown): void => {
   writeFileSync(path, JSON.stringify(data), { encoding: "utf-8" });
 };
 

--- a/packages/allure-mocha/src/MochaAllure.ts
+++ b/packages/allure-mocha/src/MochaAllure.ts
@@ -18,7 +18,7 @@ export class MochaAllure extends Allure {
     super(runtime);
   }
 
-  public get currentExecutable(): ExecutableItemWrapper {
+  protected get currentExecutable(): ExecutableItemWrapper {
     const executable: AllureStep | AllureTest | ExecutableItemWrapper | null =
       this.reporter.currentStep || this.reporter.currentTest || this.reporter.currentExecutable;
     if (!executable) {
@@ -27,7 +27,7 @@ export class MochaAllure extends Allure {
     return executable;
   }
 
-  public set currentExecutable(executable: ExecutableItemWrapper) {
+  protected set currentExecutable(executable: ExecutableItemWrapper) {
     this.reporter.currentExecutable = executable;
   }
 
@@ -78,7 +78,7 @@ export class MochaAllure extends Allure {
     this.currentTest.addAttachment(name, options, file);
   }
 
-  public get currentTest(): AllureTest {
+  protected get currentTest(): AllureTest {
     if (this.reporter.currentTest === null) {
       throw new Error("No test running!");
     }

--- a/packages/allure-mocha/src/MochaAllureReporter.ts
+++ b/packages/allure-mocha/src/MochaAllureReporter.ts
@@ -11,7 +11,11 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
   constructor(readonly runner: Mocha.Runner, readonly opts: Mocha.MochaOptions) {
     super(runner, opts);
 
-    const allureConfig: AllureConfig = { resultsDir: "allure-results", ...opts.reporterOptions };
+    const { resultsDir } = opts.reporterOptions;
+    const allureConfig: AllureConfig = {
+      resultsDir: resultsDir || "allure-results",
+      ...opts.reporterOptions,
+    };
 
     this.coreReporter = new AllureReporter(new AllureRuntime(allureConfig));
     allure = this.coreReporter.getImplementation();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,9 @@
     "strict": true,
     "sourceMap": true,
     "esModuleInterop": true,
-    "removeComments": true
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with isses use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
- Added a separate `allure-decorators` module to allow setting framework-specific Allure implementation explicitly in a client code.
- Created core decorators for the main Allure functions like step, attachments, issue, etc.
- Added a testdeck extension for data-driven tests. Note that testdeck currently supports only Mocha, Jasmine and Jest. Any other integrations should be additionally discussed and designed.
- Updated outdated typescript linter dependencies that caused issues while creating a new module. Note that this update introduced some failures in the other modules (primarily related to shadow/unknown objects), that were fixed within this commit.

Fixes #7

Summon @just-boris @eroshenkoam @baev @korobochka for review.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
