### PR TITLE
Fix playwright path attachments

### DIFF
--- a/packages/allure-js-commons/src/AllureRuntime.ts
+++ b/packages/allure-js-commons/src/AllureRuntime.ts
@@ -47,12 +47,12 @@ export class AllureRuntime {
     return fileName;
   }
 
-  writeAttachmentPath(
+  writeAttachmentFromPath(
     filePath: PathLike,
     options: ContentType | string | AttachmentOptions,
   ): string {
     const fileName = buildAttachmentFileName(options);
-    this.writer.writeAttachmentPath(fileName, filePath);
+    this.writer.writeAttachmentFromPath(fileName, filePath);
     return fileName;
   }
 

--- a/packages/allure-js-commons/src/AllureRuntime.ts
+++ b/packages/allure-js-commons/src/AllureRuntime.ts
@@ -1,8 +1,17 @@
+import { PathLike } from "fs";
 import { v4 as randomUUID } from "uuid";
 import { AllureConfig } from "./AllureConfig";
 import { AllureGroup } from "./AllureGroup";
 import { AttachmentOptions, Category, ContentType, TestResult, TestResultContainer } from "./model";
 import { AllureWriter, FileSystemAllureWriter, typeToExtension } from "./writers";
+
+const buildAttachmentFileName = (options: ContentType | string | AttachmentOptions): string => {
+  if (typeof options === "string") {
+    options = { contentType: options };
+  }
+  const extension = typeToExtension(options);
+  return `${randomUUID()}-attachment.${extension}`;
+};
 
 export class AllureRuntime {
   private writer: AllureWriter;
@@ -33,12 +42,17 @@ export class AllureRuntime {
     content: Buffer | string,
     options: ContentType | string | AttachmentOptions,
   ): string {
-    if (typeof options === "string") {
-      options = { contentType: options };
-    }
-    const extension = typeToExtension(options);
-    const fileName = `${randomUUID()}-attachment.${extension}`;
+    const fileName = buildAttachmentFileName(options);
     this.writer.writeAttachment(fileName, content);
+    return fileName;
+  }
+
+  writeAttachmentPath(
+    filePath: PathLike,
+    options: ContentType | string | AttachmentOptions,
+  ): string {
+    const fileName = buildAttachmentFileName(options);
+    this.writer.writeAttachmentPath(fileName, filePath);
     return fileName;
   }
 

--- a/packages/allure-js-commons/src/writers/AllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/AllureWriter.ts
@@ -1,3 +1,4 @@
+import { PathLike } from "fs";
 import { Category, TestResult, TestResultContainer } from "../model";
 
 export interface AllureWriter {
@@ -6,6 +7,8 @@ export interface AllureWriter {
   writeGroup(result: TestResultContainer): void;
 
   writeAttachment(name: string, content: Buffer | string): void;
+
+  writeAttachmentPath(targetFileName: string, sourceFilePath: PathLike): void;
 
   writeEnvironmentInfo(info: Record<string, string | undefined>): void;
 

--- a/packages/allure-js-commons/src/writers/AllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/AllureWriter.ts
@@ -8,7 +8,7 @@ export interface AllureWriter {
 
   writeAttachment(name: string, content: Buffer | string): void;
 
-  writeAttachmentPath(targetFileName: string, sourceFilePath: PathLike): void;
+  writeAttachmentFromPath(targetFileName: string, sourceFilePath: PathLike): void;
 
   writeEnvironmentInfo(info: Record<string, string | undefined>): void;
 

--- a/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
@@ -22,7 +22,7 @@ export class FileSystemAllureWriter implements AllureWriter {
     writeFileSync(path, content);
   }
 
-  writeAttachmentPath(targetFileName: string, sourceFilePath: PathLike): void {
+  writeAttachmentFromPath(targetFileName: string, sourceFilePath: PathLike): void {
     const path = this.buildPath(targetFileName);
     copyFileSync(path, sourceFilePath);
   }

--- a/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
@@ -1,4 +1,4 @@
-import { existsSync, writeFileSync } from "fs";
+import { copyFileSync, existsSync, PathLike, writeFileSync } from "fs";
 import { join } from "path";
 import { sync as mkdirSync } from "mkdirp";
 import { stringify } from "properties";
@@ -20,6 +20,11 @@ export class FileSystemAllureWriter implements AllureWriter {
   writeAttachment(name: string, content: Buffer | string): void {
     const path = this.buildPath(name);
     writeFileSync(path, content);
+  }
+
+  writeAttachmentPath(targetFileName: string, sourceFilePath: PathLike): void {
+    const path = this.buildPath(targetFileName);
+    copyFileSync(path, sourceFilePath);
   }
 
   writeEnvironmentInfo(info?: Record<string, string | undefined>): void {

--- a/packages/allure-js-commons/src/writers/InMemoryAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/InMemoryAllureWriter.ts
@@ -1,3 +1,4 @@
+import { PathLike, readFileSync } from "fs";
 import { Category, TestResult, TestResultContainer } from "../model";
 import { AllureWriter } from "./AllureWriter";
 
@@ -18,6 +19,10 @@ export class InMemoryAllureWriter implements AllureWriter {
 
   public writeAttachment(name: string, content: Buffer | string): void {
     this.attachments[name] = content;
+  }
+
+  public writeAttachmentPath(targetFileName: string, sourceFilePath: PathLike): void {
+    this.attachments[targetFileName] = readFileSync(sourceFilePath);
   }
 
   public writeCategoriesDefinitions(categories: Category[]): void {

--- a/packages/allure-js-commons/src/writers/InMemoryAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/InMemoryAllureWriter.ts
@@ -21,7 +21,7 @@ export class InMemoryAllureWriter implements AllureWriter {
     this.attachments[name] = content;
   }
 
-  public writeAttachmentPath(targetFileName: string, sourceFilePath: PathLike): void {
+  public writeAttachmentFromPath(targetFileName: string, sourceFilePath: PathLike): void {
     this.attachments[targetFileName] = readFileSync(sourceFilePath);
   }
 

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -82,11 +82,14 @@ class AllureReporter implements Reporter {
           }
 
           for (const attachment of result.attachments) {
-            let fileName = attachment.path;
-            if (attachment.body) {
-              fileName = runtime.writeAttachment(attachment.body, attachment.contentType);
+            if (!attachment.body && !attachment.path) {
+              continue;
             }
-            allureTest.addAttachment(attachment.name, attachment.contentType, fileName!);
+
+            const fileName = attachment.body
+              ? runtime.writeAttachment(attachment.body, attachment.contentType)
+              : runtime.writeAttachmentPath(attachment.path!, attachment.contentType);
+            allureTest.addAttachment(attachment.name, attachment.contentType, fileName);
             if (attachment.name === "diff") {
               allureTest.addLabel("testType", "screenshotDiff");
             }

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -88,7 +88,7 @@ class AllureReporter implements Reporter {
 
             const fileName = attachment.body
               ? runtime.writeAttachment(attachment.body, attachment.contentType)
-              : runtime.writeAttachmentPath(attachment.path!, attachment.contentType);
+              : runtime.writeAttachmentFromPath(attachment.path!, attachment.contentType);
             allureTest.addAttachment(attachment.name, attachment.contentType, fileName);
             if (attachment.name === "diff") {
               allureTest.addLabel("testType", "screenshotDiff");


### PR DESCRIPTION
#### Context

fixes #326

the change also intruduces new API methods:

```js
AllureRuntime#writeAttachmentFromPath(string, PathLike);
AllureWriter#writeAttachmentFromPath(string, PathLike);
```


#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2