### PR TITLE
fix(playwright): do not throw if cannot copy attachment from given path

### DIFF
--- a/packages/allure-playwright/package.json
+++ b/packages/allure-playwright/package.json
@@ -6,7 +6,7 @@
   "author": {
     "name": "Microsoft Corporation"
   },
-  "repository": "https://github.com/allure-framework/allure-playwright",
+  "repository": "https://github.com/allure-framework/allure-js",
   "keywords": [
     "playwright",
     "allure"

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -92,9 +92,14 @@ class AllureReporter implements Reporter {
               continue;
             }
 
-            const fileName = attachment.body
-              ? runtime.writeAttachment(attachment.body, attachment.contentType)
-              : runtime.writeAttachmentFromPath(attachment.path!, attachment.contentType);
+            let fileName;
+            try {
+              fileName = attachment.body
+                ? runtime.writeAttachment(attachment.body, attachment.contentType)
+                : runtime.writeAttachmentFromPath(attachment.path!, attachment.contentType);
+            } catch(e) {
+              continue;
+            }
             allureTest.addAttachment(attachment.name, attachment.contentType, fileName);
             if (attachment.name === "diff") {
               allureTest.addLabel("testType", "screenshotDiff");

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import fs from "fs";
 import path from "path";
 import { FullConfig, TestStatus } from "@playwright/test";
 import { Reporter, Suite, TestStep } from "@playwright/test/reporter";
@@ -93,12 +94,13 @@ class AllureReporter implements Reporter {
             }
 
             let fileName;
-            try {
-              fileName = attachment.body
-                ? runtime.writeAttachment(attachment.body, attachment.contentType)
-                : runtime.writeAttachmentFromPath(attachment.path!, attachment.contentType);
-            } catch(e) {
-              continue;
+            if (attachment.body) {
+              fileName = runtime.writeAttachment(attachment.body, attachment.contentType);
+            } else {
+              if (!fs.existsSync(attachment.path!)) {
+                continue;
+              }
+              fileName = runtime.writeAttachmentFromPath(attachment.path!, attachment.contentType);
             }
             allureTest.addAttachment(attachment.name, attachment.contentType, fileName);
             if (attachment.name === "diff") {

--- a/packages/allure-playwright/test/attachment.spec.ts
+++ b/packages/allure-playwright/test/attachment.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test } from "./fixtures";
+
+test("should not throw on missing attachment", async ({ runInlineTest }) => {
+  const result = await runInlineTest(
+    {
+      "a.test.ts": `
+      import test from '@playwright/test';
+      test('should add attachment', async ({}, testInfo) => {
+        testInfo.attachments.push({
+          name: 'file-attachment',
+          path: 'does-not-exist.txt',
+          contentType: 'text/plain'
+        });
+        testInfo.attachments.push({
+          name: 'buffer-attachment',
+          body: Buffer.from('foo'),
+          contentType: 'text/plain'
+        });
+      });
+    `,
+    },
+    (writer) => {
+      return writer.tests[0].attachments.map((a) => {
+        const buffer = writer.attachments[a.source];
+        return { name: a.name, type: a.type, buffer };
+      });
+    },
+  );
+  expect(result).toEqual([
+    { name: "buffer-attachment", type: "text/plain", buffer: Buffer.from("foo").toJSON() },
+  ]);
+});


### PR DESCRIPTION
### Context
Some of the attachments may be deleted bu the runner (e.g. `video: on, preserveOutput: 'failures-only'` test config) or clients could add non-existing path as attachment.

Fixes https://github.com/microsoft/playwright/issues/8611

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
