### PR TITLE
Add labels and links to playwright via attachments #332  #352 #341

### DIFF
--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -7,7 +7,9 @@ This project implements Allure integration with [Playwright Test](https://playwr
 ```bash
 npm i -D @playwright/test allure-playwright
 ```
+
 or via yarn:
+
 ```bash
 yarn add @playwright/test allure-playwright --dev
 ```
@@ -18,7 +20,7 @@ Either add **allure-playwright** into **playwright.config.ts**:
 
 ```js
 {
-  reporter: 'allure-playwright'
+  reporter: "allure-playwright";
 }
 ```
 
@@ -31,12 +33,68 @@ npx playwright test --reporter=line,allure-playwright
 Specify location for allure results:
 
 Mac / Linux
+
 ```bash
 ALLURE_RESULTS_DIR=my-allure-results npx playwright test --reporter=line,allure-playwright
 ```
 
 Windows
+
 ```bash
 set ALLURE_RESULTS_DIR=my-allure-results
 npx playwright test --reporter=line,allure-playwright
+```
+
+## Proving extra information
+
+You can use allure labels to provide extra information about tests such via
+
+- label
+- epic
+- feature
+- story
+- suite
+- parentSuite
+- subSuite
+- owner
+- severity
+- tag
+
+### Labels Usage
+
+```js
+import { test, expect } from "@playwright/test";
+import { epic, label, link, story } from "allure-playwright";
+
+test("basic test", async ({ page }, testInfo) => {
+  epic(testInfo, "Some Epic");
+  story(testInfo, "Some Story");
+});
+
+```
+
+### Links Usage
+
+```js
+import { test, expect } from "@playwright/test";
+import { epic, issue, label, link, story } from "allure-playwright";
+
+test("basic test", async ({ page }, testInfo) => {
+  link(testInfo, "https://playwright.dev", "playwright-site");
+  issue(testInfo, "https://github.com/allure-framework/allure-js/issues/352", "Target issue");
+});
+
+```
+
+### Attachments Usage
+
+```js
+import { test, expect } from "@playwright/test";
+
+test("basic test", async ({ page }, testInfo) => {
+  const path = testInfo.outputPath("screenshot.png");
+  await page.screenshot({ path });
+  testInfo.attachments.push({ name: "screenshot", path, contentType: "image/png" });
+});
+
 ```

--- a/packages/allure-playwright/src/helpers.ts
+++ b/packages/allure-playwright/src/helpers.ts
@@ -1,0 +1,105 @@
+import { TestInfo } from "@playwright/test";
+import { Label, LabelName, LinkType } from "allure-js-commons";
+
+export const ContentTypes = {
+  label: "allure/label",
+  link: "allure/link",
+};
+
+export function label(testInfo: TestInfo, label: Label) {
+  testInfo.attachments.push({
+    name: label.name,
+    contentType: ContentTypes.label,
+    path: label.value,
+  });
+}
+
+export function epic(testInfo: TestInfo, epic: string) {
+  label(testInfo, {
+    name: LabelName.EPIC,
+    value: epic,
+  });
+}
+
+export function feature(testInfo: TestInfo, feature: string) {
+  label(testInfo, {
+    name: LabelName.FEATURE,
+    value: feature,
+  });
+}
+
+export function story(testInfo: TestInfo, story: string): void {
+  label(testInfo, {
+    name: LabelName.STORY,
+    value: story,
+  });
+}
+
+export function suite(testInfo: TestInfo, name: string): void {
+  label(testInfo, {
+    name: LabelName.SUITE,
+    value: name,
+  });
+}
+
+export function parentSuite(testInfo: TestInfo, name: string) {
+  label(testInfo, {
+    name: LabelName.PARENT_SUITE,
+    value: name,
+  });
+}
+
+export function subSuite(testInfo: TestInfo, name: string) {
+  label(testInfo, {
+    name: LabelName.SUB_SUITE,
+    value: name,
+  });
+}
+
+export function owner(testInfo: TestInfo, owner: string) {
+  label(testInfo, {
+    name: LabelName.OWNER,
+    value: owner,
+  });
+}
+
+export function severity(testInfo: TestInfo, severity: string) {
+  label(testInfo, {
+    name: LabelName.SEVERITY,
+    value: severity,
+  });
+}
+
+export function tag(testInfo: TestInfo, tag: string) {
+  label(testInfo, {
+    name: LabelName.SEVERITY,
+    value: tag,
+  });
+}
+
+
+interface LinkData {
+  url: string;
+  name?: string;
+}
+
+export function link(testInfo: TestInfo, url: string, name?: string, type?: LinkType) {
+  testInfo.attachments.push({
+    name: type || "link",
+    contentType: ContentTypes.link,
+    path: JSON.stringify({
+      url,
+      name: name || undefined,
+    } as LinkData),
+  });
+}
+
+export function issue(testInfo: TestInfo, url: string, name: string) {
+  link(testInfo, url, name, LinkType.ISSUE);
+}
+
+export function tms(testInfo: TestInfo, url: string, name: string) {
+  link(testInfo, url, name, LinkType.TMS);
+}
+
+export { LabelName, LinkType, LinkData };

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -25,8 +25,11 @@ import {
   ExecutableItemWrapper,
   InMemoryAllureWriter,
   LabelName,
+  LinkType,
   Status,
 } from "allure-js-commons";
+
+import { ContentTypes, LinkData } from "./helpers";
 
 class AllureReporter implements Reporter {
   config!: FullConfig;
@@ -91,6 +94,33 @@ class AllureReporter implements Reporter {
           for (const attachment of result.attachments) {
             if (!attachment.body && !attachment.path) {
               continue;
+            }
+
+            if (attachment.contentType.includes("allure")) {
+              if (!attachment.path) {
+                continue;
+              }
+
+              switch (attachment.contentType) {
+                case ContentTypes.label: {
+                  allureTest.addLabel(attachment.name, attachment.path);
+                  
+                  break;
+                }
+                case ContentTypes.link: {
+                  const link = JSON.parse(attachment.path) as LinkData;
+
+                  if (attachment.name === LinkType.ISSUE) {
+                    allureTest.addIssueLink(link.url, link.name!);
+                  } else if (attachment.name === LinkType.TMS) {
+                    allureTest.addTmsLink(link.url, link.name!);
+                  } else {
+                    allureTest.addLink(link.url, link.name!);
+                  }
+
+                  break;
+                }
+              }
             }
 
             let fileName;
@@ -175,3 +205,5 @@ const appendStep = (parent: ExecutableItemWrapper, step: TestStep) => {
     appendStep(allureStep, child);
   }
 };
+
+export * from "./helpers";

--- a/packages/allure-playwright/test/label.spec.ts
+++ b/packages/allure-playwright/test/label.spec.ts
@@ -1,0 +1,20 @@
+import { Label, LabelName } from "allure-js-commons";
+import { test, expect } from "./fixtures";
+
+test("should have label", async ({ runInlineTest }) => {
+  const result: Label[] = await runInlineTest(
+    {
+      "a.test.ts": `
+       import { test, expect } from '@playwright/test';
+       import { label, LabelName } from '../../dist/index'
+       test('should add epic label', async ({}, testInfo) => {
+           label(testInfo,{name:LabelName.EPIC,value:'Test epic label'});
+       });
+     `,
+    },
+    (writer) => {
+      return writer.tests.map((t) => t.labels);
+    },
+  );
+  expect(result[0]).toContainEqual({ name: LabelName.EPIC, value: "Test epic label" });
+});

--- a/packages/allure-playwright/test/link.spec.ts
+++ b/packages/allure-playwright/test/link.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Microsoft Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Label, LabelName } from "allure-js-commons";
+import { test, expect } from "./fixtures";
+test.only("should have link", async ({ runInlineTest }) => {
+  const result: Label[] = await runInlineTest(
+    {
+      "a.test.ts": `
+        import { test, expect } from '@playwright/test';
+        import { link } from '../../dist/index'
+        test('should add epic link', async ({}, testInfo) => {
+            link(testInfo, "https://playwright.dev/docs/api/class-page#page-workers");
+        });
+      `,
+    },
+    (writer) => {
+      return writer.tests.map((t) => t.links);
+    },
+  );
+
+  expect(result[0]).toContainEqual({
+    url: "https://playwright.dev/docs/api/class-page#page-workers",
+  });
+});


### PR DESCRIPTION
### Context
Added allure metainfo to playwright via attachments.
resolve #332 #352 #341

#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
