### PR TITLE
feat(cucumberjs): extract links and labels from tags

### DIFF
--- a/packages/allure-cucumberjs/README.md
+++ b/packages/allure-cucumberjs/README.md
@@ -17,16 +17,18 @@ export default class Reporter extends CucumberJSAllureFormatter {
           epic: [/@feature:(.*)/],
           severity: [/@severity:(.*)/]
         },
-        links: {
-          issue: {
+        links: [
+          {
             pattern: [/@issue=(.*)/],
+            type: "issue",
             urlTemplate: "http://localhost:8080/issue/%s"
           },
-          tms: {
+          {
             pattern: [/@tms=(.*)/],
+            type: "tms",
             urlTemplate: "http://localhost:8080/tms/%s"
           }
-        }
+        ]
       }
     );
   }

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -90,6 +90,13 @@ export class CucumberJSAllureFormatter extends Formatter {
     this.afterHooks = options.supportCodeLibrary.afterTestCaseHookDefinitions;
   }
 
+  private get tagsIgnorePatterns(): RegExp[] {
+    // TODO: add labels to ignore too
+    const { links } = this;
+
+    return links.flatMap(({ pattern }) => pattern);
+  }
+
   private parseEnvelope(envelope: messages.Envelope): void {
     if (envelope.gherkinDocument) {
       this.onGherkinDocument(envelope.gherkinDocument);
@@ -202,7 +209,9 @@ export class CucumberJSAllureFormatter extends Formatter {
     }
 
     if (pickle.tags?.length) {
-      pickle.tags.forEach((tag) => {
+      const filteredTags = pickle.tags.filter((tag) => !this.tagsIgnorePatterns.some((pattern) => pattern.test(tag.name)));
+
+      filteredTags.forEach((tag) => {
         this.currentTest?.addLabel(LabelName.TAG, tag.name);
       });
     }

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -2,7 +2,7 @@ import { World as CucumberWorld, Formatter } from "@cucumber/cucumber";
 import { IFormatterOptions } from "@cucumber/cucumber/lib/formatter";
 import TestCaseHookDefinition from "@cucumber/cucumber/lib/models/test_case_hook_definition";
 import * as messages from "@cucumber/messages";
-import { TestStepResultStatus } from "@cucumber/messages";
+import { Tag, TestStepResultStatus } from "@cucumber/messages";
 import {
   Allure,
   AllureGroup,
@@ -12,6 +12,7 @@ import {
   ContentType,
   ExecutableItemWrapper,
   LabelName,
+  Link,
   Status,
 } from "allure-js-commons";
 import { CucumberAllureInterface } from "./CucumberAllureInterface";
@@ -22,19 +23,16 @@ export interface World extends CucumberWorld {
   allure: Allure;
 }
 
+export type LinkMatcher = {
+  pattern: RegExp[];
+  urlTemplate: string;
+  type?: "tms" | "issue" | string;
+};
+
 export class CucumberJSAllureFormatterConfig {
   exceptionFormatter?: (message: string) => string;
   labels?: { [key: string]: RegExp[] };
-  links?: {
-    issue?: {
-      pattern: RegExp[];
-      urlTemplate: string;
-    };
-    tms?: {
-      pattern: RegExp[];
-      urlTemplate: string;
-    };
-  };
+  links?: LinkMatcher[];
 }
 
 export class CucumberJSAllureFormatter extends Formatter {
@@ -47,16 +45,7 @@ export class CucumberJSAllureFormatter extends Formatter {
   private readonly beforeHooks: TestCaseHookDefinition[];
   private readonly exceptionFormatter: (message: string) => string;
   private readonly labels: { [key: string]: RegExp[] };
-  private readonly links: {
-    issue?: {
-      pattern: RegExp[];
-      urlTemplate: string;
-    };
-    tms?: {
-      pattern: RegExp[];
-      urlTemplate: string;
-    };
-  };
+  private readonly links: LinkMatcher[];
   private stepStack: AllureStep[] = [];
   private readonly documentMap: Map<string, messages.GherkinDocument> = new Map();
   private readonly featureMap: Map<string, messages.Feature> = new Map();
@@ -82,7 +71,7 @@ export class CucumberJSAllureFormatter extends Formatter {
     options.eventBroadcaster.on("envelope", this.parseEnvelope.bind(this));
 
     this.labels = config.labels || {};
-    this.links = config.links || {};
+    this.links = config.links || [];
     this.exceptionFormatter = (message): string => {
       if (config.exceptionFormatter !== undefined) {
         try {
@@ -125,6 +114,31 @@ export class CucumberJSAllureFormatter extends Formatter {
     }
   }
 
+  private parseTagsLinks(tags: readonly Tag[]): Link[] {
+    const tagKeyRe = /^@\S+=/;
+    const links: Link[] = [];
+
+    if (this.links.length === 0) {
+      return links;
+    }
+
+    this.links.forEach((matcher) => {
+      const matchedTags = tags.filter((tag) => matcher.pattern.some((pattern) => pattern.test(tag.name)));
+      const matchedLinks = matchedTags.map((tag) => {
+        const tagValue = tag.name.replace(tagKeyRe, "");
+
+        return {
+          url: matcher.urlTemplate.replace(/%s$/, tagValue) || tagValue,
+          type: matcher.type,
+        };
+      });
+
+      links.push(...matchedLinks);
+    });
+
+    return links;
+  }
+
   private onGherkinDocument(data: messages.GherkinDocument): void {
     if (data.uri) {
       this.documentMap.set(data.uri, data);
@@ -144,10 +158,6 @@ export class CucumberJSAllureFormatter extends Formatter {
   private onPickle(data: messages.Pickle): void {
     this.pickleMap.set(data.id, data);
     data.steps.forEach((ps) => this.pickleStepMap.set(ps.id, ps));
-
-    // if (data.tags?.length) {
-    //   this.currentTest.
-    // }
   }
 
   private onTestCase(data: messages.TestCase): void {
@@ -173,6 +183,8 @@ export class CucumberJSAllureFormatter extends Formatter {
     const doc = this.documentMap.get(pickle.uri);
     const scenarioId = pickle?.astNodeIds?.[0];
     const scenario = this.scenarioMap.get(scenarioId);
+    const links = this.parseTagsLinks(scenario?.tags || []);
+
     this.testCaseStartedMap.set(data.id, data);
     this.testCaseTestStepsResults.set(data.id, []);
     this.currentTest = new AllureTest(this.allureRuntime, Date.now());
@@ -194,6 +206,8 @@ export class CucumberJSAllureFormatter extends Formatter {
         this.currentTest?.addLabel(LabelName.TAG, tag.name);
       });
     }
+
+    links.forEach((link) => this.currentTest?.addLink(link.url, link.name, link.type));
 
     // writting data tables as csv attachments
     pickle.steps.forEach((ps) => {

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -130,7 +130,9 @@ export class CucumberJSAllureFormatter extends Formatter {
     }
 
     this.links.forEach((matcher) => {
-      const matchedTags = tags.filter((tag) => matcher.pattern.some((pattern) => pattern.test(tag.name)));
+      const matchedTags = tags.filter((tag) =>
+        matcher.pattern.some((pattern) => pattern.test(tag.name)),
+      );
       const matchedLinks = matchedTags.map((tag) => {
         const tagValue = tag.name.replace(tagKeyRe, "");
 
@@ -209,7 +211,9 @@ export class CucumberJSAllureFormatter extends Formatter {
     }
 
     if (pickle.tags?.length) {
-      const filteredTags = pickle.tags.filter((tag) => !this.tagsIgnorePatterns.some((pattern) => pattern.test(tag.name)));
+      const filteredTags = pickle.tags.filter(
+        (tag) => !this.tagsIgnorePatterns.some((pattern) => pattern.test(tag.name)),
+      );
 
       filteredTags.forEach((tag) => {
         this.currentTest?.addLabel(LabelName.TAG, tag.name);

--- a/packages/allure-cucumberjs/test/helpers/formatter_helpers.ts
+++ b/packages/allure-cucumberjs/test/helpers/formatter_helpers.ts
@@ -36,12 +36,15 @@ export interface ITestFormatterOptions extends ITestRunOptions {
   parsedArgvOptions?: FormatOptions;
 }
 
-export const runFeatures = async ({
-  parsedArgvOptions = {},
-  runtimeOptions = {},
-  supportCodeLibrary,
-  sources = [],
-}: ITestFormatterOptions, config?: CucumberJSAllureFormatterConfig): Promise<AllureResults> => {
+export const runFeatures = async (
+  {
+    parsedArgvOptions = {},
+    runtimeOptions = {},
+    supportCodeLibrary,
+    sources = [],
+  }: ITestFormatterOptions,
+  config?: CucumberJSAllureFormatterConfig,
+): Promise<AllureResults> => {
   const eventBroadcaster = new EventEmitter();
   const eventDataCollector = new EventDataCollector(eventBroadcaster);
   emitSupportCodeMessages({

--- a/packages/allure-cucumberjs/test/helpers/formatter_helpers.ts
+++ b/packages/allure-cucumberjs/test/helpers/formatter_helpers.ts
@@ -41,7 +41,7 @@ export const runFeatures = async ({
   runtimeOptions = {},
   supportCodeLibrary,
   sources = [],
-}: ITestFormatterOptions): Promise<AllureResults> => {
+}: ITestFormatterOptions, config?: CucumberJSAllureFormatterConfig): Promise<AllureResults> => {
   const eventBroadcaster = new EventEmitter();
   const eventDataCollector = new EventDataCollector(eventBroadcaster);
   emitSupportCodeMessages({
@@ -76,7 +76,7 @@ export const runFeatures = async ({
       snippetBuilder,
     },
     allureRuntime,
-    new CucumberJSAllureFormatterConfig(),
+    { ...config },
   );
 
   let pickleIds: string[] = [];

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -161,6 +161,7 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
     sources: [
       {
         data:
+          "@foo\n" +
           "Feature: a\n" +
           "\n" +
           "  @issue=1 @tms=2\n" +
@@ -343,11 +344,14 @@ describe("CucumberJSAllureReporter", () => {
     });
     expect(results.tests).length(1);
 
-    const { links } = results.tests[0];
+    const { links, labels } = results.tests[0];
     expect(links).length(2);
     expect(links[0].type).eq("issue");
     expect(links[0].url).eq("https://github.com/my_repo/issues/1");
     expect(links[1].type).eq("tms");
     expect(links[1].url).eq("https://jira_url/browse/2");
+
+    const tags = results.tests[0].labels.filter((label) => label.name === LabelName.TAG);
+    expect(tags).length(1);
   });
 });

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -154,6 +154,24 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
       },
     ],
   },
+  withLinks: {
+    supportCodeLibrary: buildSupportCodeLibrary(({ Given }) => {
+      Given("a step", () => {});
+    }),
+    sources: [
+      {
+        data:
+          "Feature: a\n" +
+          "\n" +
+          "  @issue=1 @tms=2\n" +
+          "  Scenario: b\n" +
+          "    Given a step\n" +
+          "    When do something\n" +
+          "    Then get something\n",
+        uri: "withIssueLink.feature",
+      },
+    ],
+  },
 };
 
 describe("CucumberJSAllureReporter", () => {
@@ -306,5 +324,30 @@ describe("CucumberJSAllureReporter", () => {
     expect(tags).length(2);
     expect(tags[0].value).eq("@foo");
     expect(tags[1].value).eq("@bar");
+  });
+
+  it("should add links", async () => {
+    const results = await runFeatures(dataSet.withLinks, {
+      links: [
+        {
+          pattern: [/@issue=(.*)/],
+          urlTemplate: "https://github.com/my_repo/issues/%s",
+          type: "issue",
+        },
+        {
+          pattern: [/@tms=(.*)/],
+          urlTemplate: "https://jira_url/browse/%s",
+          type: "tms",
+        },
+      ],
+    });
+    expect(results.tests).length(1);
+
+    const { links } = results.tests[0];
+    expect(links).length(2);
+    expect(links[0].type).eq("issue");
+    expect(links[0].url).eq("https://github.com/my_repo/issues/1");
+    expect(links[1].type).eq("tms");
+    expect(links[1].url).eq("https://jira_url/browse/2");
   });
 });

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -332,12 +332,12 @@ describe("CucumberJSAllureReporter", () => {
       links: [
         {
           pattern: [/@issue=(.*)/],
-          urlTemplate: "https://github.com/my_repo/issues/%s",
+          urlTemplate: "https://example.org/issues/%s",
           type: "issue",
         },
         {
           pattern: [/@tms=(.*)/],
-          urlTemplate: "https://jira_url/browse/%s",
+          urlTemplate: "https://example.org/tasks/%s",
           type: "tms",
         },
       ],
@@ -347,9 +347,9 @@ describe("CucumberJSAllureReporter", () => {
     const { links, labels } = results.tests[0];
     expect(links).length(2);
     expect(links[0].type).eq("issue");
-    expect(links[0].url).eq("https://github.com/my_repo/issues/1");
+    expect(links[0].url).eq("https://example.org/issues/1");
     expect(links[1].type).eq("tms");
-    expect(links[1].url).eq("https://jira_url/browse/2");
+    expect(links[1].url).eq("https://example.org/tasks/2");
 
     const tags = results.tests[0].labels.filter((label) => label.name === LabelName.TAG);
     expect(tags).length(1);


### PR DESCRIPTION
### Context
fixes #456

Provides a new API for `links` processing. Now, the related config part looks in this way:

```diff
export default class Reporter extends CucumberJSAllureFormatter {
  constructor(options) {
    super(
      options,
      new AllureRuntime({ resultsDir: "./allure-results" }),
      {
        labels: {
          epic: [/@feature:(.*)/],
          severity: [/@severity:(.*)/]
        },
-        links: {
-          issues: {
-            pattern: [/@issue=(.*)/],
-            urlTemplate: "http://localhost:8080/issue/%s"
-          },
-          tms: {
-            pattern: [/@tms=(.*)/],
-            urlTemplate: "http://localhost:8080/tms/%s"
-          }
-        }
+        links: [
+          {
+            pattern: [/@issue=(.*)/],
+            type: "issue",
+            urlTemplate: "http://localhost:8080/issue/%s"
+          },
+          {
+            pattern: [/@tms=(.*)/],
+            type: "tms",
+            urlTemplate: "http://localhost:8080/tms/%s"
+          }
+        ]
      }
    );
```

Now, you're able to define your own link types.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
