### PR TITLE
Ignore `.nyc-output` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,4 +39,5 @@ dist-tests
 .gradle
 schema
 build
-/*/allure-results/
+**/allure-results
+**/.nyc_output


### PR DESCRIPTION
### Context
Updates `.gitignore` for `allure-results` and `.nyc-output` directories

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
