### PR TITLE
Provide `fullName` for test results

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -144,10 +144,6 @@ export class CucumberJSAllureFormatter extends Formatter {
   private onPickle(data: messages.Pickle): void {
     this.pickleMap.set(data.id, data);
     data.steps.forEach((ps) => this.pickleStepMap.set(ps.id, ps));
-
-    // if (data.tags?.length) {
-    //   this.currentTest.
-    // }
   }
 
   private onTestCase(data: messages.TestCase): void {
@@ -180,6 +176,10 @@ export class CucumberJSAllureFormatter extends Formatter {
 
     this.currentTest?.addLabel(LabelName.LANGUAGE, "javascript");
     this.currentTest?.addLabel(LabelName.FRAMEWORK, "cucumberjs");
+
+    if (doc?.uri) {
+      this.currentTest.fullName = doc?.uri;
+    }
 
     if (doc?.feature) {
       this.currentTest.addLabel(LabelName.FEATURE, doc.feature.name);

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -163,6 +163,7 @@ describe("CucumberJSAllureReporter", () => {
     expect(results.tests).length(1);
     const [testResult] = results.tests;
 
+    expect(testResult.fullName).eq("b");
     expect(testResult.name).eq("b");
   });
 


### PR DESCRIPTION
### Context
Adds feature `uri` (file path) as `fullName` parameter to be able to filter specs according [the documentation about filtering](https://github.com/cucumber/cucumber-js/blob/main/docs/filtering.md#names).

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
