### PR TITLE
Add package label for mocha specs

### DIFF
--- a/packages/allure-mocha/src/AllureReporter.ts
+++ b/packages/allure-mocha/src/AllureReporter.ts
@@ -104,7 +104,7 @@ export class AllureReporter {
       const normalizedTestPath = normalize(testPath || "")
         .replace(/^\//, "")
         .split("/")
-        .filter(item => item !== basename(testPath));
+        .filter((item) => item !== basename(testPath));
 
       this.currentTest.addLabel(LabelName.PACKAGE, normalizedTestPath.join("."));
     }

--- a/packages/allure-mocha/test/fixtures/specs/package.ts
+++ b/packages/allure-mocha/test/fixtures/specs/package.ts
@@ -5,6 +5,6 @@ import { expect } from "chai";
 class Package {
   @test
   shouldPass() {
-    expect(1).eq(1)
+    expect(1).eq(1);
   }
 }

--- a/packages/allure-mocha/test/fixtures/specs/package.ts
+++ b/packages/allure-mocha/test/fixtures/specs/package.ts
@@ -1,0 +1,10 @@
+import { suite, test } from "@testdeck/mocha";
+import { expect } from "chai";
+
+@suite
+class Package {
+  @test
+  shouldPass() {
+    expect(1).eq(1)
+  }
+}

--- a/packages/allure-mocha/test/specs/package.ts
+++ b/packages/allure-mocha/test/specs/package.ts
@@ -1,0 +1,16 @@
+import { suite, test } from "@testdeck/mocha";
+import { LabelName } from "allure-js-commons";
+import { expect } from "chai";
+import { runTests } from "../utils";
+
+@suite
+class PackageSuite {
+  @test
+  async shouldHaveDescription() {
+    const writerStub = await runTests("package");
+    const currentTest = writerStub.getTestByName("shouldPass");
+    const packageLabel = currentTest.labels.find(label => label.name === LabelName.PACKAGE);
+
+    expect(packageLabel?.value).eq("test.fixtures.specs")
+  }
+}

--- a/packages/allure-mocha/test/specs/package.ts
+++ b/packages/allure-mocha/test/specs/package.ts
@@ -9,8 +9,8 @@ class PackageSuite {
   async shouldHaveDescription() {
     const writerStub = await runTests("package");
     const currentTest = writerStub.getTestByName("shouldPass");
-    const packageLabel = currentTest.labels.find(label => label.name === LabelName.PACKAGE);
+    const packageLabel = currentTest.labels.find((label) => label.name === LabelName.PACKAGE);
 
-    expect(packageLabel?.value).eq("test.fixtures.specs")
+    expect(packageLabel?.value).eq("test.fixtures.specs");
   }
 }


### PR DESCRIPTION
fixes #460

### Context
Adds `package` label for mocha specs. According another allure implementations, package now is a path to spec file

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
