### PR TITLE
Adding a check in onHookEnd to only call error function if it exists and is a function (fixes #482)

### DIFF
--- a/packages/allure-mocha/src/MochaAllureReporter.ts
+++ b/packages/allure-mocha/src/MochaAllureReporter.ts
@@ -81,6 +81,9 @@ export class MochaAllureReporter extends Mocha.reporters.Base {
   }
 
   private onHookEnd(hook: Mocha.Hook): void {
-    this.coreReporter.endHook(hook.error());
+    if(typeof(hook.error) === 'function')
+      this.coreReporter.endHook(hook.error());
+    else
+      this.coreReporter.endHook();
   }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests

Fixes #482 

The issue here is that, when running mocha in parallel mode with beforeEach or afterEach hooks, the onEndHook is called in MochaAllureReporter and the error() method is undefined.

Not sure about any unit tests for this.  The project unit tests weren't passing _before_ I made changes, so it's difficult to work with broken tests.  Instead, I have a reproduceable example here:   https://github.com/jamesmortensen/allure-js-reporter-issues#when-run-in-parallel-mode-with-hooks-hookerror-is-not-a-function

In the reproduceable example, run `npx mocha -p test-with-hooks.js` without the changes, to see the error occur, and run it with the changes to see the reporter function without errors and somewhat correctly.  (By somewhat correctly, there is this related issue https://github.com/allure-framework/allure-js/issues/485 where failed test cases in parallel mode are incorrectly reported as yellow/broken instead of red/failed.)

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
