### PR TITLE
fix cucumberjs reporter on windows

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -232,6 +232,7 @@ export class CucumberJSAllureFormatter extends Formatter {
     const labels = this.parseTagsLabels(scenario?.tags || []);
     const links = this.parseTagsLinks(scenario?.tags || []);
     const currentTest = new AllureTest(this.allureRuntime, Date.now());
+    const thread = ALLURE_THREAD_NAME || process.pid.toString();
 
     this.runningTestsMap.set(data.id, currentTest);
     this.testCaseStartedMap.set(data.id, data);
@@ -239,9 +240,9 @@ export class CucumberJSAllureFormatter extends Formatter {
 
     currentTest.name = pickle.name;
     currentTest?.addLabel(LabelName.HOST, this.hostname);
-    currentTest?.addLabel(LabelName.THREAD, ALLURE_THREAD_NAME || process.getuid().toString());
     currentTest?.addLabel(LabelName.LANGUAGE, "javascript");
     currentTest?.addLabel(LabelName.FRAMEWORK, "cucumberjs");
+    currentTest?.addLabel(LabelName.THREAD, thread);
 
     if (doc?.feature) {
       currentTest.addLabel(LabelName.FEATURE, doc.feature.name);

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -358,7 +358,6 @@ describe("CucumberJSAllureReporter", () => {
 
   it("should create labels", async () => {
     sinon.stub(os, "hostname").returns("127.0.0.1");
-    sinon.stub(process, "getuid").returns(123);
 
     const results = await runFeatures(dataSet.withTags);
     expect(results.tests).length(1);
@@ -376,7 +375,7 @@ describe("CucumberJSAllureReporter", () => {
     expect(feature?.value).eq("a");
     expect(suite?.value).eq("b");
     expect(host?.value).eq("127.0.0.1");
-    expect(thread?.value).eq("123");
+    expect(thread?.value).eq(process.pid.toString());
     expect(tags).length(2);
     expect(tags[0].value).eq("@foo");
     expect(tags[1].value).eq("@bar");


### PR DESCRIPTION
### Context
fixes #492

Use `process.pid` as fallback value for `THREAD` label

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
