### PR TITLE
fix(cucumberjs): grouping test retries and attach datatables for steps

### DIFF
--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -413,7 +413,7 @@ describe("CucumberJSAllureReporter", () => {
       expect(imageAttachment.type).eq("image/png");
     });
 
-    it("should process data table as csv attachment", async () => {
+    it("should process data table as csv step attachment", async () => {
       const results = await runFeatures(dataSet.dataTable);
       expect(results.tests).length(1);
 
@@ -421,7 +421,7 @@ describe("CucumberJSAllureReporter", () => {
       expect(attachmentsKeys).length(1);
       expect(results.attachments[attachmentsKeys[0]]).eq("a,b,result\n1,3,4\n2,4,6\n");
 
-      const [attachment] = results.tests[0].attachments;
+      const [attachment] = results.tests[0].steps[0].attachments;
       expect(attachment.type).eq("text/csv");
       expect(attachment.source).eq(attachmentsKeys[0]);
     });
@@ -432,14 +432,18 @@ describe("CucumberJSAllureReporter", () => {
 
       const attachmentsKeys = Object.keys(results.attachments);
       expect(attachmentsKeys).length(2);
-      expect(results.attachments[attachmentsKeys[0]]).eq("a\n1\n");
-      expect(results.attachments[attachmentsKeys[1]]).eq("b,result\n3,4\n");
+      const dataTableAttachment = results.tests[0].steps[0].attachments[0];
+      const exampleAttachment = results.tests[0].attachments[0];
 
-      const [firstAttachment, secondAttachment] = results.tests[0].attachments;
-      expect(firstAttachment.type).eq("text/csv");
-      expect(firstAttachment.source).eq(attachmentsKeys[0]);
-      expect(secondAttachment.type).eq("text/csv");
-      expect(secondAttachment.source).eq(attachmentsKeys[1]);
+      expect(exampleAttachment.type).eq("text/csv");
+      expect(exampleAttachment.source).eq(attachmentsKeys[0]);
+      expect(dataTableAttachment.type).eq("text/csv");
+      expect(dataTableAttachment.source).eq(attachmentsKeys[1]);
+
+      expect(results.attachments[attachmentsKeys[0]]).eq("b,result\n3,4\n");
+      expect(results.attachments[attachmentsKeys[1]]).eq("a\n1\n");
+
+
     });
 
     it("should create labels", async () => {
@@ -521,7 +525,7 @@ describe("CucumberJSAllureReporter", () => {
       expect(tags).length(1);
     });
 
-    it("should set fullName and testCaseId", async () => {
+    it("should set fullName and historyId", async () => {
       const results = await runFeatures(dataSet.simple);
 
       expect(results.tests).length(1);
@@ -531,7 +535,7 @@ describe("CucumberJSAllureReporter", () => {
       const name = source!.data.match(/\nScenario: (.+)\n/)?.[1];
       const fullName = `${source!.uri}#${name!}`;
       expect(testResult.fullName).eq(fullName);
-      expect(testResult.testCaseId).eq(md5(fullName));
+      expect(testResult.historyId).eq(md5(fullName));
     });
   });
 


### PR DESCRIPTION
### Context
When I switched to allure in cucumber v8, I encountered a number of problems that were not repeated in cucumber v6:
1) I can't install my CustomWorld, although the [documentation](https://github.com/allure-framework/allure-js/tree/master/packages/allure-cucumberjs#using-allure-api) has information about it. The reason is that the formatter explicitly sets CucumberAllureWorld after we specify our custom constructor
2) When using '--repeat', tests were duplicated instead of being placed in the history 
3) Attachments with the datatable are placed at the end of the test, not under the expected step. This is very unattractive if the test has several datatables. Previously, in Cucumber 6, they were placed under each step.

some pictures with changes:
**problem 2 before fix:**
<img width="410" alt="image" src="https://user-images.githubusercontent.com/18102654/207467516-43b5f288-78d6-4cde-b1a0-69a894c71ae2.png">

**problem 2 after:**
<img width="577" alt="image" src="https://user-images.githubusercontent.com/18102654/207467723-a358cab3-7adf-4498-a1b3-a35ccc4083ec.png">

**problem 3 before fix:**
<img width="340" alt="image" src="https://user-images.githubusercontent.com/18102654/207467620-feeaf7e5-db81-473c-8808-8318c1742d92.png">

**problem 3 after:**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/18102654/207467791-fd137ef9-3032-4aa8-9410-c3e653bdc755.png">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
