### PR TITLE
fix(cucumberjs): grouping of retried tests

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -291,9 +291,11 @@ export class CucumberJSAllureFormatter extends Formatter {
     this.testCaseTestStepsResults.set(data.id, []);
     this.currentTestsMap.set(data.id, currentTest);
     const fullName = `${pickle.uri}#${pickle.name}`;
+    const testCaseId = md5(fullName);
     currentTest.name = pickle.name;
     currentTest.fullName = fullName;
-    currentTest.testCaseId = md5(fullName);
+    currentTest.testCaseId = testCaseId;
+    currentTest.historyId = testCaseId;
 
     currentTest.addLabel(LabelName.HOST, this.hostname);
     currentTest.addLabel(LabelName.LANGUAGE, "javascript");

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -1,4 +1,3 @@
-import { createHash } from "crypto";
 import os from "os";
 import process from "process";
 import { LabelName, md5, Status } from "allure-js-commons";
@@ -521,7 +520,7 @@ describe("CucumberJSAllureReporter", () => {
       expect(tags).length(1);
     });
 
-    it("should set fullName and testCaseId", async () => {
+    it("should set fullName, testCaseId and historyId", async () => {
       const results = await runFeatures(dataSet.simple);
 
       expect(results.tests).length(1);
@@ -532,6 +531,7 @@ describe("CucumberJSAllureReporter", () => {
       const fullName = `${source!.uri}#${name!}`;
       expect(testResult.fullName).eq(fullName);
       expect(testResult.testCaseId).eq(md5(fullName));
+      expect(testResult.historyId).eq(testResult.testCaseId);
     });
   });
 


### PR DESCRIPTION
### Context
split pr #546
When I switched to allure in cucumber v8, I encountered a number of problems that were not repeated in cucumber v6:
- When using '--repeat', tests were duplicated instead of being placed in the history 

some pictures with changes:
**problem before fix:**
<img width="410" alt="image" src="https://user-images.githubusercontent.com/18102654/207467516-43b5f288-78d6-4cde-b1a0-69a894c71ae2.png">

**problem after fix:**
<img width="577" alt="image" src="https://user-images.githubusercontent.com/18102654/207467723-a358cab3-7adf-4498-a1b3-a35ccc4083ec.png">

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
