### PR TITLE
fix(cucumberjs): attach a datable to the step

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -318,28 +318,6 @@ export class CucumberJSAllureFormatter extends Formatter {
       filteredTags.forEach((tag) => currentTest.addLabel(LabelName.TAG, tag.name));
     }
 
-    pickle.steps.forEach((ps) => {
-      const { argument } = ps;
-
-      if (!argument?.dataTable) {
-        return;
-      }
-
-      const csvDataTable = argument.dataTable.rows.reduce(
-        (acc, row) => `${acc + row.cells.map((cell) => cell.value).join(",")}\n`,
-        "",
-      );
-      const attachmentFilename = this.allureRuntime.writeAttachment(csvDataTable, "text/csv");
-
-      currentTest.addAttachment(
-        "Data table",
-        {
-          contentType: "text/csv",
-        },
-        attachmentFilename,
-      );
-    });
-
     if (!scenario?.examples?.length) {
       return;
     }
@@ -581,6 +559,26 @@ export class CucumberJSAllureFormatter extends Formatter {
           .find((kw) => kw !== undefined) || "";
       const allureStep = currentTest.startStep(keyword + ps.text, Date.now());
       this.allureSteps.set(data.testStepId, allureStep);
+
+      const {argument} = ps;
+
+      if (!argument?.dataTable) {
+        return;
+      }
+
+      const csvDataTable = argument.dataTable.rows.reduce(
+        (acc, row) => `${acc + row.cells.map((cell) => cell.value).join(",")}\n`,
+        "",
+      );
+      const attachmentFilename = this.allureRuntime.writeAttachment(csvDataTable, "text/csv");
+
+      allureStep.addAttachment(
+        "Data table",
+        {
+          contentType: "text/csv",
+        },
+        attachmentFilename,
+      );
     }
   }
 

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -12,6 +12,7 @@ import {
   AllureStep,
   AllureTest,
   Attachment,
+  ContentType,
   ExecutableItem,
   ExecutableItemWrapper,
   Label,
@@ -334,12 +335,12 @@ export class CucumberJSAllureFormatter extends Formatter {
       }
 
       const csvDataTable = `${csvDataTableHeader}\n${csvDataTableBody}\n`;
-      const attachmentFilename = this.allureRuntime.writeAttachment(csvDataTable, "text/csv");
+      const attachmentFilename = this.allureRuntime.writeAttachment(csvDataTable, ContentType.CSV);
 
       currentTest.addAttachment(
         "Examples",
         {
-          contentType: "text/csv",
+          contentType: ContentType.CSV,
         },
         attachmentFilename,
       );
@@ -560,7 +561,7 @@ export class CucumberJSAllureFormatter extends Formatter {
       const allureStep = currentTest.startStep(keyword + ps.text, Date.now());
       this.allureSteps.set(data.testStepId, allureStep);
 
-      const {argument} = ps;
+      const { argument } = ps;
 
       if (!argument?.dataTable) {
         return;
@@ -570,12 +571,12 @@ export class CucumberJSAllureFormatter extends Formatter {
         (acc, row) => `${acc + row.cells.map((cell) => cell.value).join(",")}\n`,
         "",
       );
-      const attachmentFilename = this.allureRuntime.writeAttachment(csvDataTable, "text/csv");
+      const attachmentFilename = this.allureRuntime.writeAttachment(csvDataTable, ContentType.CSV);
 
       allureStep.addAttachment(
         "Data table",
         {
-          contentType: "text/csv",
+          contentType: ContentType.CSV,
         },
         attachmentFilename,
       );

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -413,7 +413,7 @@ describe("CucumberJSAllureReporter", () => {
       expect(imageAttachment.type).eq("image/png");
     });
 
-    it("should process data table as csv attachment", async () => {
+    it("should process data table as csv step attachment", async () => {
       const results = await runFeatures(dataSet.dataTable);
       expect(results.tests).length(1);
 
@@ -421,7 +421,7 @@ describe("CucumberJSAllureReporter", () => {
       expect(attachmentsKeys).length(1);
       expect(results.attachments[attachmentsKeys[0]]).eq("a,b,result\n1,3,4\n2,4,6\n");
 
-      const [attachment] = results.tests[0].attachments;
+      const [attachment] = results.tests[0].steps[0].attachments;
       expect(attachment.type).eq("text/csv");
       expect(attachment.source).eq(attachmentsKeys[0]);
     });
@@ -432,14 +432,18 @@ describe("CucumberJSAllureReporter", () => {
 
       const attachmentsKeys = Object.keys(results.attachments);
       expect(attachmentsKeys).length(2);
-      expect(results.attachments[attachmentsKeys[0]]).eq("a\n1\n");
-      expect(results.attachments[attachmentsKeys[1]]).eq("b,result\n3,4\n");
+      const dataTableAttachment = results.tests[0].steps[0].attachments[0];
+      const exampleAttachment = results.tests[0].attachments[0];
 
-      const [firstAttachment, secondAttachment] = results.tests[0].attachments;
-      expect(firstAttachment.type).eq("text/csv");
-      expect(firstAttachment.source).eq(attachmentsKeys[0]);
-      expect(secondAttachment.type).eq("text/csv");
-      expect(secondAttachment.source).eq(attachmentsKeys[1]);
+      expect(exampleAttachment.type).eq("text/csv");
+      expect(exampleAttachment.source).eq(attachmentsKeys[0]);
+      expect(dataTableAttachment.type).eq("text/csv");
+      expect(dataTableAttachment.source).eq(attachmentsKeys[1]);
+
+      expect(results.attachments[attachmentsKeys[0]]).eq("b,result\n3,4\n");
+      expect(results.attachments[attachmentsKeys[1]]).eq("a\n1\n");
+
+
     });
 
     it("should create labels", async () => {

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -442,8 +442,6 @@ describe("CucumberJSAllureReporter", () => {
 
       expect(results.attachments[attachmentsKeys[0]]).eq("b,result\n3,4\n");
       expect(results.attachments[attachmentsKeys[1]]).eq("a\n1\n");
-
-
     });
 
     it("should create labels", async () => {


### PR DESCRIPTION
### Context
split pr https://github.com/allure-framework/allure-js/pull/546
When I switched to allure in cucumber v8, I encountered a number of problems that were not repeated in cucumber v6:
- Attachments with the datatable are placed at the end of the test, not under the expected step. This is very unattractive if the test has several datatables. Previously, in Cucumber 6, they were placed under each step.

some pictures with changes:
**problem before fix:**
<img width="340" alt="image" src="https://user-images.githubusercontent.com/18102654/207467620-feeaf7e5-db81-473c-8808-8318c1742d92.png">

**problem after fix:**
<img width="400" alt="image" src="https://user-images.githubusercontent.com/18102654/207467791-fd137ef9-3032-4aa8-9410-c3e653bdc755.png">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
