### PR TITLE
fix(cucumberjs): fix setup custom world

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -1,6 +1,6 @@
 import os from "os";
 import process from "process";
-import { Formatter } from "@cucumber/cucumber";
+import { Formatter, World } from "@cucumber/cucumber";
 import { IFormatterOptions } from "@cucumber/cucumber/lib/formatter";
 import TestCaseHookDefinition from "@cucumber/cucumber/lib/models/test_case_hook_definition";
 import * as messages from "@cucumber/messages";
@@ -146,9 +146,11 @@ export class CucumberJSAllureFormatter extends Formatter {
       }
       return message;
     };
-    // eslint-disable-next-line
-    // @ts-ignore
-    options.supportCodeLibrary.World = CucumberAllureWorld;
+    if (options.supportCodeLibrary.World === World) {
+      // eslint-disable-next-line
+      // @ts-ignore
+      options.supportCodeLibrary.World = CucumberAllureWorld;
+    }
     this.beforeHooks = options.supportCodeLibrary.beforeTestCaseHookDefinitions;
     this.afterHooks = options.supportCodeLibrary.afterTestCaseHookDefinitions;
   }

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -298,15 +298,15 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
   withCustomWorldConstructor: {
     supportCodeLibrary: buildSupportCodeLibrary(({ Given, When, Then, setWorldConstructor }) => {
       class CustomWorld extends CucumberAllureWorld {
-         customWorldMethod() {}
+        customWorldMethod() {}
       }
 
-      setWorldConstructor(CustomWorld)
+      setWorldConstructor(CustomWorld);
 
       Given("a step", function () {});
 
       When("world say hello", function (this: CustomWorld) {
-        this.customWorldMethod()
+        this.customWorldMethod();
       });
     }),
     sources: [

--- a/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
+++ b/packages/allure-cucumberjs/test/specs/allure_cucumberjs_test.ts
@@ -295,6 +295,32 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
       },
     ],
   },
+  withCustomWorldConstructor: {
+    supportCodeLibrary: buildSupportCodeLibrary(({ Given, When, Then, setWorldConstructor }) => {
+      class CustomWorld extends CucumberAllureWorld {
+         customWorldMethod() {}
+      }
+
+      setWorldConstructor(CustomWorld)
+
+      Given("a step", function () {});
+
+      When("world say hello", function (this: CustomWorld) {
+        this.customWorldMethod()
+      });
+    }),
+    sources: [
+      {
+        data:
+          "Feature: a\n" +
+          "\n" +
+          "  Scenario: b\n" +
+          "    Given a step\n" +
+          "    When world say hello\n",
+        uri: "withNestedAnonymous.feature",
+      },
+    ],
+  },
 };
 
 describe("CucumberJSAllureReporter", () => {
@@ -599,6 +625,13 @@ describe("CucumberJSAllureReporter", () => {
       expect(whenStep.steps[0].status).eq(Status.FAILED);
       expect(whenStep.steps[0].statusDetails.message).eq("an error message");
       expect(whenStep.steps[0].statusDetails.trace).not.eq("");
+    });
+
+    it("should applied custom world constructor", async () => {
+      const results = await runFeatures(dataSet.withCustomWorldConstructor);
+      expect(results.tests).length(1);
+      expect(results.tests[0].statusDetails.message).undefined;
+      expect(results.tests[0].status).eq(Status.PASSED);
     });
   });
 });


### PR DESCRIPTION
### Context
split pr #546

When I switched to allure in cucumber v8, I encountered a number of problems that were not repeated in cucumber v6:
1) I can't install my CustomWorld, although the [documentation](https://github.com/allure-framework/allure-js/tree/master/packages/allure-cucumberjs#using-allure-api) has information about it. The reason is that the formatter explicitly sets CucumberAllureWorld after we specify our custom constructor

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
