### PR TITLE
chore(commons): delete mkdirp package

### DIFF
--- a/packages/allure-js-commons/package.json
+++ b/packages/allure-js-commons/package.json
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@types/chai": "^4.2.21",
     "@types/glob": "^7.1.4",
-    "@types/mkdirp": "^1.0.0",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.7.10",
     "@types/uuid": "^8.3.0",
@@ -44,7 +43,6 @@
     "typescript": "^4.4.2"
   },
   "dependencies": {
-    "mkdirp": "^1.0.4",
     "properties": "^1.2.1",
     "uuid": "^8.3.0"
   },

--- a/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
@@ -1,6 +1,5 @@
-import { copyFileSync, existsSync, PathLike, writeFileSync } from "fs";
+import { copyFileSync, existsSync, PathLike, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
-import { sync as mkdirSync } from "mkdirp";
 import { stringify } from "properties";
 import { AllureConfig } from "../AllureConfig";
 import { Category, TestResult, TestResultContainer } from "../model";
@@ -13,7 +12,9 @@ const writeJson = (path: string, data: unknown): void => {
 export class FileSystemAllureWriter implements AllureWriter {
   constructor(private config: AllureConfig) {
     if (!existsSync(this.config.resultsDir)) {
-      mkdirSync(this.config.resultsDir);
+      mkdirSync(this.config.resultsDir, {
+        recursive: true,
+      });
     }
   }
 

--- a/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
+++ b/packages/allure-js-commons/src/writers/FileSystemAllureWriter.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, PathLike, writeFileSync, mkdirSync } from "fs";
+import { copyFileSync, existsSync, mkdirSync, PathLike, writeFileSync } from "fs";
 import { join } from "path";
 import { stringify } from "properties";
 import { AllureConfig } from "../AllureConfig";

--- a/packages/allure-js-commons/test/specs/FileSystemAllureWriter.spec.ts
+++ b/packages/allure-js-commons/test/specs/FileSystemAllureWriter.spec.ts
@@ -1,8 +1,10 @@
-import { AllureConfig, AllureRuntime, ContentType } from "../../dist";
-import path from "path";
+import { randomUUID } from "crypto";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "fs";
 import * as os from "os";
-import { readdirSync, writeFileSync, mkdtempSync, readFileSync } from "fs";
+import path from "path";
 import { expect } from "chai";
+
+import { AllureConfig, AllureRuntime, ContentType } from "../../dist";
 
 describe("FileSystemAllureWriter", () => {
   it("should save attachment from path", () => {
@@ -28,5 +30,14 @@ describe("FileSystemAllureWriter", () => {
 
     const actualContent = readFileSync(path.join(allureResults, actualAttachment));
     expect(actualContent.toString("utf-8")).to.be.eq(data, "data should match");
+  });
+
+  it("Should create allure-report nested path", () => {
+    const tmpReportPath = path.join(os.tmpdir(), `./allure-testing-dir/${randomUUID()}`);
+    const config: AllureConfig = {
+      resultsDir: tmpReportPath,
+    };
+    new AllureRuntime(config);
+    expect(existsSync(tmpReportPath)).to.be.eq(true);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,15 +1294,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mkdirp@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "@types/mkdirp@npm:1.0.2"
-  dependencies:
-    "@types/node": "*"
-  checksum: 72dedfb2d250f0e44ec964ac68ff6a4a03d7d9d6e83ae1d5ba6d212791af69cf051a5fac59846826242d099de56a18c8e0581861792fae8b845b3c9ad67ecdeb
-  languageName: node
-  linkType: hard
-
 "@types/mocha@npm:^9.0.0":
   version: 9.0.0
   resolution: "@types/mocha@npm:9.0.0"
@@ -1809,14 +1800,12 @@ __metadata:
   dependencies:
     "@types/chai": ^4.2.21
     "@types/glob": ^7.1.4
-    "@types/mkdirp": ^1.0.0
     "@types/mocha": ^9.0.0
     "@types/node": ^16.7.10
     "@types/uuid": ^8.3.0
     allure-mocha: "workspace:packages/allure-mocha"
     chai: ^4.3.4
     glob: ^7.1.7
-    mkdirp: ^1.0.4
     mocha: ^9.1.3
     mocha-multi-reporters: ^1.5.1
     nyc: ^15.1.0


### PR DESCRIPTION
`fs.mkdirSync(path, {recursive:true})` doing the same thing without any packages