### PR TITLE
feature(playwright): Add `categories` and `environmentInfo` support to playwright

### DIFF
--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -27,6 +27,7 @@ import {
   AllureStep,
   AllureTest,
   AttachmentMetadata,
+  Category,
   ExecutableItemWrapper,
   InMemoryAllureWriter,
   LabelName,
@@ -39,6 +40,8 @@ type AllureReporterOptions = {
   detail?: boolean;
   outputFolder?: string;
   suiteTitle?: boolean;
+  categories?: Category[];
+  environmentInfo?: Record<string, string>;
 };
 
 class AllureReporter implements Reporter {
@@ -68,6 +71,9 @@ class AllureReporter implements Reporter {
       resultsDir: this.resultsDir,
       writer: this.allureWriter,
     });
+
+    this.allureRuntime.writeEnvironmentInfo(this.options?.environmentInfo || {});
+    this.allureRuntime.writeCategoriesDefinitions(this.options?.categories || []);
   }
 
   onTestBegin(test: TestCase): void {

--- a/packages/allure-playwright/test/categories.spec.ts
+++ b/packages/allure-playwright/test/categories.spec.ts
@@ -1,0 +1,66 @@
+/* eslint-disable quote-props */
+import { Status } from "allure-js-commons";
+import { expect, test } from "./fixtures";
+
+test("should have categories", async ({ runInlineTest }) => {
+  const categories: Record<string, string | undefined> | undefined = await runInlineTest(
+    {
+      "a.test.ts": `
+       import { test, expect } from '@playwright/test';
+       import { allure, LabelName,Status } from '../../dist/index'
+       test('should add epic label', async ({}, testInfo) => {
+       });
+     `,
+      reporterOptions: JSON.stringify({
+        categories: [
+          {
+            name: "Sad tests",
+            messageRegex: ".*Sad.*",
+            matchedStatuses: [Status.FAILED],
+          },
+          {
+            name: "Infrastructure problems",
+            messageRegex: ".*RuntimeException.*",
+            matchedStatuses: [Status.BROKEN],
+          },
+          {
+            name: "Outdated tests",
+            messageRegex: ".*FileNotFound.*",
+            matchedStatuses: [Status.BROKEN],
+          },
+          {
+            name: "Regression",
+            messageRegex: ".*\\sException:.*",
+            matchedStatuses: [Status.BROKEN],
+          },
+        ],
+      }),
+    },
+    (writer) => {
+      return writer.categories;
+    },
+  );
+
+  expect(categories).toEqual([
+    {
+      name: "Sad tests",
+      messageRegex: ".*Sad.*",
+      matchedStatuses: [Status.FAILED],
+    },
+    {
+      name: "Infrastructure problems",
+      messageRegex: ".*RuntimeException.*",
+      matchedStatuses: [Status.BROKEN],
+    },
+    {
+      name: "Outdated tests",
+      messageRegex: ".*FileNotFound.*",
+      matchedStatuses: [Status.BROKEN],
+    },
+    {
+      name: "Regression",
+      messageRegex: ".*\\sException:.*",
+      matchedStatuses: [Status.BROKEN],
+    },
+  ]);
+});

--- a/packages/allure-playwright/test/environmentInfo.spec.ts
+++ b/packages/allure-playwright/test/environmentInfo.spec.ts
@@ -1,0 +1,30 @@
+/* eslint-disable quote-props */
+import { Status } from "allure-js-commons";
+import { expect, test } from "./fixtures";
+
+test("should have envInfo", async ({ runInlineTest }) => {
+  const envInfo: Record<string, string | undefined> | undefined = await runInlineTest(
+    {
+      "a.test.ts": `
+       import { test, expect } from '@playwright/test';
+       import { allure, LabelName,Status } from '../../dist/index'
+       test('should add epic label', async ({}, testInfo) => {
+       });
+     `,
+      reporterOptions: JSON.stringify({
+        environmentInfo: {
+          envVar1: "envVar1Value",
+          envVar2: "envVar2Value",
+        },
+      }),
+    },
+    (writer) => {
+      return writer.envInfo;
+    },
+  );
+
+  expect(envInfo).toEqual({
+    envVar1: "envVar1Value",
+    envVar2: "envVar2Value",
+  });
+});

--- a/packages/allure-playwright/test/fixtures.ts
+++ b/packages/allure-playwright/test/fixtures.ts
@@ -31,11 +31,16 @@ const writeFiles = async (testInfo: TestInfo, files: Files) => {
   const baseDir = testInfo.outputPath();
 
   const hasConfig = Object.keys(files).some((name) => name.includes(".config."));
+  const reporterOptions = files.reporterOptions && JSON.parse(files.reporterOptions.toString());
   if (!hasConfig) {
     files = {
       ...files,
       "playwright.config.ts": `
-        module.exports = { projects: [ { name: 'project' } ] };
+        module.exports = {
+          projects: [{ name: 'project' }],
+          reporter: [[require.resolve("../../dist/index.js"),
+          ${JSON.stringify(reporterOptions || false)} || undefined]],
+       };
       `,
     };
   }
@@ -71,12 +76,8 @@ const runPlaywrightTest = async (
   }
   const outputDir = path.join(baseDir, "test-results");
   const args = [require.resolve("@playwright/test/cli"), "test"];
-  args.push(
-    `--output=${outputDir}`,
-    `--reporter=${require.resolve("../dist/index.js")}`,
-    "--workers=2",
-    ...paramList,
-  );
+  args.push(`--output=${outputDir}`, "--workers=2", ...paramList);
+
   if (additionalArgs) {
     args.push(...additionalArgs);
   }


### PR DESCRIPTION
This PR add categories and enviormentInfo support.
This fields setted via `playwright.config.ts` file
```diff
export default {
  reporter: [
    [
      "allure-playwright",
      {
+        environmentInfo: {
+         envVar1: "envVar1Value",
+         envVar2: "envVar2Value",
+       },
+       categories: [
+          {
+           name: "Infrastructure problems",
+           messageRegex: ".*RuntimeException.*",
+           matchedStatuses: ["broken"],
+         },
+      ],
      },
    ],
  ],
  projects: [
    {
      name: "chromium",
    },
  ],
};
```