### PR TITLE
chore(mocha): fix mocha tsconfig include

### DIFF
--- a/packages/allure-mocha/tsconfig.json
+++ b/packages/allure-mocha/tsconfig.json
@@ -5,5 +5,8 @@
     "types": [],
     "rootDir": "./src",
     "outDir": "./dist"
-  }
+  },
+  "include": [
+    "./src/**/*",
+  ],
 }


### PR DESCRIPTION
this PR fix the bug when mocha build fails when rebuild with the error
```
Cannot write file '/Users/vladimirsemenov/qameta/allure-js/packages/allure-mocha/dist/AllureReporter.d.ts' because it would overwrite input file.ts
Cannot write file '/Users/vladimirsemenov/qameta/allure-js/packages/allure-mocha/dist/AllureReporter.d.ts' because it would overwrite input file.ts
Cannot write file '/Users/vladimirsemenov/qameta/allure-js/packages/allure-mocha/dist/AllureReporter.d.ts' because it would overwrite input file.ts
```