### PR TITLE
fix(commons): fix parameters modes

### DIFF
--- a/packages/allure-cucumberjs/README.md
+++ b/packages/allure-cucumberjs/README.md
@@ -194,7 +194,9 @@ Given(/my step/, async function () {
 ```
 
 Also addParameter takes an third optional parameter with the hidden and excluded options:
-`hidden: true` - hides parameter from the report
+
+`mode: "hidden" | "masked"` - `masked` hide parameter value to secure sensitive data, and `hidden` entirely hide parameter from report
+
 `excluded: true` - excludes parameter from the history
 
 ```ts
@@ -202,7 +204,7 @@ import { Given } from "@cucumber/cucumber";
 
 Given(/my step/, async function () {
   await this.step("step can have anonymous body function", async function () {
-    await this.parameter("parameterName", "parameterValue", { hidden: true, excluded: true });
+    await this.parameter("parameterName", "parameterValue", { mode: "hidden", excluded: true });
   });
 });
 ```

--- a/packages/allure-cucumberjs/src/CucumberAllureWorld.ts
+++ b/packages/allure-cucumberjs/src/CucumberAllureWorld.ts
@@ -46,8 +46,8 @@ export class CucumberAllureWorld extends World implements AllureWorld {
         {
           name,
           value,
-          hidden: options?.hidden || false,
           excluded: options?.excluded || false,
+          mode: options?.mode,
         },
       ],
     };

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -399,10 +399,10 @@ export class CucumberJSAllureFormatter extends Formatter {
 
     links.forEach((link) => payload.test.addLink(link.url, link.type, link.name));
     labels.forEach((label) => payload.test.addLabel(label.name, label.value));
-    parameter.forEach(({ name, value, hidden, excluded }) =>
+    parameter.forEach(({ name, value, excluded, mode }) =>
       payload.test.addParameter(name, value, {
         excluded,
-        hidden,
+        mode,
       }),
     );
     steps.forEach((step) => {

--- a/packages/allure-hermione/README.md
+++ b/packages/allure-hermione/README.md
@@ -7,7 +7,7 @@ Allure integration for `hermione@^5.x.x`.
 Use your favorite node package manager to install required packages:
 
 ```shell
-npm add -D allure-hermione allure-js-commons      
+npm add -D allure-hermione allure-js-commons
 ```
 
 ## Setup
@@ -30,22 +30,22 @@ The plugin provides custom browser commands which allow to add additional info
 inside your tests:
 
 ```javascript
-import { expect } from "chai"
+import { expect } from "chai";
 
 it("my test", async ({ browser, currentTest }) => {
   await browser.url("https://www.example.org/");
-  await browser.$("#btn").click()
-  
-  const screenshot = await browser.takeScreenshot()
-  
-  await browser.attach(currentTest.id(), screenshot, "image/png")
-  await browser.epic(currentTest.id(), "my_epic")
+  await browser.$("#btn").click();
+
+  const screenshot = await browser.takeScreenshot();
+
+  await browser.attach(currentTest.id(), screenshot, "image/png");
+  await browser.epic(currentTest.id(), "my_epic");
   await browser.parameter(currentTest.id(), "parameter_name", "parameter_value", {
-    hidden: false,
+    mode: "hidden",
     excluded: false,
-  })
-  
-  expect(browser.url).not.eq("https://www.startpage.com/")
+  });
+
+  expect(browser.url).not.eq("https://www.startpage.com/");
 });
 ```
 
@@ -60,7 +60,7 @@ Markup you tests with labels using low-level `label` method:
 ```js
 it("my test", async ({ browser, currentTest }) => {
   await browser.label(currentTest.id(), "label_name", "label_value");
-})
+});
 ```
 
 Or using aliases: `id`, `epic`, `feature`, `story`, `suite`, `parentSuite`, `subSuite`,
@@ -69,7 +69,7 @@ Or using aliases: `id`, `epic`, `feature`, `story`, `suite`, `parentSuite`, `sub
 ```js
 it("my test", async ({ browser, currentTest }) => {
   await browser.epic(currentTest.id(), "my_epic");
-})
+});
 ```
 
 ### Links
@@ -79,7 +79,7 @@ Add any link by low-level `link` method:
 ```js
 it("my test", async ({ browser, currentTest }) => {
   await browser.link(currentTest.id(), "http://example.org", "my_link_name", "my_link_type");
-})
+});
 ```
 
 Or using aliases: `issue`, `tms`:
@@ -87,7 +87,7 @@ Or using aliases: `issue`, `tms`:
 ```js
 it("my test", async ({ browser, currentTest }) => {
   await browser.issue(currentTest.id(), "my_link_name", "http://example.org");
-})
+});
 ```
 
 ### Parameters
@@ -97,7 +97,6 @@ Test parameters can be added by `parameter` method:
 ```js
 it("my test", async ({ browser, currentTest }) => {
   await browser.parameter(currentTest.id(), "param_name", "param_value", {
-    hidden: true,
     excluded: false,
   });
 });
@@ -117,9 +116,9 @@ If you want to attach a screenshot generated in tests, you can use the same meth
 
 ```js
 it("adds screenshots", async ({ browser, currentTest }) => {
-  const screenshot = await browser.takeScreenshot()
+  const screenshot = await browser.takeScreenshot();
 
-  await browser.attach(currentTest.id(), screenshot, "image/png")
+  await browser.attach(currentTest.id(), screenshot, "image/png");
 });
 ```
 
@@ -139,4 +138,3 @@ it("my test", async ({ browser, currentTest }) => {
   });
 });
 ```
-

--- a/packages/allure-hermione/src/index.ts
+++ b/packages/allure-hermione/src/index.ts
@@ -103,7 +103,7 @@ const hermioneAllureReporter = (hermione: Hermione, opts: AllureReportOptions) =
     parameter.forEach((param) => {
       currentTest.addParameter(param.name, param.value, {
         excluded: param.excluded,
-        hidden: param.hidden,
+        mode: param.mode,
       });
     });
     attachments.forEach((attachment) => {

--- a/packages/allure-hermione/test/fixtures/parameter.js
+++ b/packages/allure-hermione/test/fixtures/parameter.js
@@ -1,6 +1,6 @@
 it("adds parameter", async ({ browser, currentTest }) => {
   await browser.parameter(currentTest.id(), "foo", "bar", {
-    hidden: true,
     excluded: false,
+    mode: "hidden",
   });
 });

--- a/packages/allure-hermione/test/spec/parameters.test.ts
+++ b/packages/allure-hermione/test/spec/parameters.test.ts
@@ -20,6 +20,6 @@ describe("parameters", () => {
     expect(parameter.name).eq("foo");
     expect(parameter.value).eq("bar");
     expect(parameter.excluded).eq(false);
-    expect(parameter.hidden).eq(true);
+    expect(parameter.mode).eq("hidden");
   });
 });

--- a/packages/allure-js-commons/src/AllureCommandStep.ts
+++ b/packages/allure-js-commons/src/AllureCommandStep.ts
@@ -138,8 +138,8 @@ export class AllureCommandStepExecutable implements AllureCommandStep {
     this.metadata.parameter.push({
       name,
       value,
-      hidden: options?.hidden || false,
       excluded: options?.excluded || false,
+      mode: options?.mode,
     });
   }
 

--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -48,11 +48,11 @@ export interface Link {
 export interface Parameter {
   name: string;
   value: string;
-  hidden?: boolean;
   excluded?: boolean;
+  mode?: "hidden" | "masked" | "default";
 }
 
-export type ParameterOptions = Pick<Parameter, "hidden" | "excluded">;
+export type ParameterOptions = Pick<Parameter, "mode" | "excluded">;
 
 export interface StatusDetails {
   message?: string;

--- a/packages/allure-js-commons/test/specs/AllureCommandStep.spec.ts
+++ b/packages/allure-js-commons/test/specs/AllureCommandStep.spec.ts
@@ -17,9 +17,9 @@ const fixtures = {
     name: "foo",
     value: "bar",
     options: {
-      hidden: true,
       excluded: true,
-    },
+      mode: "hidden",
+    } as const,
   },
   attachment: JSON.stringify({ foo: "bar" }),
   binaryAttachment: Buffer.from([0]),
@@ -175,8 +175,8 @@ describe("AllureCommandStep", () => {
       expect(parameter![0]).eql({
         name: fixtures.parameter.name,
         value: fixtures.parameter.value,
-        hidden: fixtures.parameter.options.hidden,
         excluded: fixtures.parameter.options.excluded,
+        mode: fixtures.parameter.options.mode,
       });
     });
   });

--- a/packages/allure-mocha/README.md
+++ b/packages/allure-mocha/README.md
@@ -59,14 +59,15 @@ it("is a test", () => {
 ```
 
 Also addParameter takes an third optional parameter with the hidden and excluded options:
-`hidden: true` - hides parameter from the report
+`mode: "hidden" | "masked"` - `masked` hide parameter value to secure sensitive data, and `hidden` entirely hide parameter from report
+
 `excluded: true` - excludes parameter from the history
 
 ```ts
 import { allure } from "allure-mocha/runtime";
 
 it("is a test", () => {
-  allure.parameter("parameterName", "parameterValue", { hidden: true, excluded: true });
+  allure.parameter("parameterName", "parameterValue", { mode: "hidden", excluded: true });
 });
 ```
 

--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -264,8 +264,8 @@ test("basic test", async ({ page }, testInfo) => {
 });
 ```
 
-Also addParameter takes an third optional parameter with the hidden and excluded options:
-`hidden: true` - hides parameter from the report
+Also addParameter takes an third optional parameter with the mode and excluded options:
+`mode: "hidden" | "masked"` - `masked` hide parameter value to secure sensitive data, and `hidden` entirely hide parameter from report
 `excluded: true` - excludes parameter from the history
 
 ```ts
@@ -273,7 +273,7 @@ import { test, expect } from "@playwright/test";
 import { allure } from "allure-playwright";
 
 test("basic test", async ({ page }, testInfo) => {
-  allure.addParameter("parameterName", "parameterValue", { hidden: true, excluded: true });
+  allure.addParameter("parameterName", "parameterValue", { mode: "masked", excluded: true });
 });
 ```
 

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -187,8 +187,8 @@ class AllureReporter implements Reporter {
         metadata.labels?.forEach((val) => allureTest.addLabel(val.name, val.value));
         metadata.parameter?.forEach((val) =>
           allureTest.addParameter(val.name, val.value, {
-            hidden: val.hidden,
             excluded: val.excluded,
+            mode: val.mode,
           }),
         );
 

--- a/packages/allure-playwright/test/parameters.spec.ts
+++ b/packages/allure-playwright/test/parameters.spec.ts
@@ -1,15 +1,17 @@
-import { Label } from "allure-js-commons";
+import { Label, Parameter } from "allure-js-commons";
 import { expect, test } from "./fixtures";
 
 test("should have parameter", async ({ runInlineTest }) => {
-  const param = { name: "parameterName", value: "parameterValue", hidden: true, excluded: false };
-  const result: Label[] = await runInlineTest(
+  const result: Parameter[][] = await runInlineTest(
     {
       "par.test.ts": `
        import { test, expect } from '@playwright/test';
        import { allure } from '../../dist/index'
        test('should add epic label', async ({}) => {
-           allure.addParameter("${param.name}", "${param.value}", { hidden:${param.hidden}, excluded: ${param.excluded}});
+        allure.parameter("param1", "paramValue1");
+        allure.parameter("param2", "paramValue2", {excluded:true});
+        allure.parameter("param3", "paramValue3", {mode:"masked", excluded:true});
+        allure.parameter("param4", "paramValue4", {mode:"hidden"});
        });
      `,
     },
@@ -18,10 +20,10 @@ test("should have parameter", async ({ runInlineTest }) => {
     },
   );
   expect(result[0]).toEqual([
-    {
-      name: "Project",
-      value: "project",
-    },
-    param,
+    { name: "Project", value: "project" },
+    { name: "param1", value: "paramValue1" },
+    { excluded: true, name: "param2", value: "paramValue2" },
+    { excluded: true, mode: "masked", name: "param3", value: "paramValue3" },
+    { mode: "hidden", name: "param4", value: "paramValue4" },
   ]);
 });


### PR DESCRIPTION
Previously format of parameters in `allure-js` was wrong and `hidden` option didn't work properly