### PR TITLE
feature(codeceptjs): feature to pass allure metadata through сodeceptjs tags

### DIFF
--- a/packages/allure-codeceptjs/README.md
+++ b/packages/allure-codeceptjs/README.md
@@ -48,3 +48,66 @@ Scenario("login-scenario1", async () => {
   allure.addAttachment("data.txt", "some data", "text/plain");
 });
 ```
+
+You can also use tags to manage labels on scenarios.
+
+### Id
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.id:228");
+```
+
+### Label
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.label.{{labelName}}:{{labelValue}}");
+```
+
+### Story
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.label.story:storyName");
+```
+### Suite
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.label.suite:suiteName");
+```
+
+### Owner
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.label.owner:ownerName");
+```
+
+### Tag
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.label.tag:tagName");
+```
+or keep it simple:
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("tagName");
+```

--- a/packages/allure-codeceptjs/src/helpers.ts
+++ b/packages/allure-codeceptjs/src/helpers.ts
@@ -1,8 +1,5 @@
-import { Label, LabelName } from "allure-js-commons";
+import { allureIdRegexp, allureLabelRegexp, Label, LabelName } from "allure-js-commons";
 import { CodeceptTest } from "./codecept-types";
-
-const allureIdRegexp = /^@?allure.id[:=](?<id>.+)$/;
-const allureLabelRegexp = /@?allure.label.(?<name>.+)[:=](?<value>.+)/;
 
 export const extractMeta = (test: CodeceptTest & { tags: string[] }) => {
   const labels: Label[] = test.tags.map((tag) => {

--- a/packages/allure-codeceptjs/src/helpers.ts
+++ b/packages/allure-codeceptjs/src/helpers.ts
@@ -1,0 +1,25 @@
+import { Label, LabelName } from "allure-js-commons";
+import { CodeceptTest } from "./codecept-types";
+
+const allureIdRegexp = /^@?allure.id[:=](?<id>.+)$/;
+const allureLabelRegexp = /@?allure.label.(?<name>.+)[:=](?<value>.+)/;
+
+export const extractMeta = (test: CodeceptTest & { tags: string[] }) => {
+  const labels: Label[] = test.tags.map((tag) => {
+    const idMatch = tag.match(allureIdRegexp);
+    const idValue = idMatch?.groups?.id;
+    if (idValue) {
+      return { name: LabelName.ALLURE_ID, value: idValue };
+    }
+
+    const labelMatch = tag.match(allureLabelRegexp);
+    const { name, value } = labelMatch?.groups || {};
+    if (name && value) {
+      return { name, value };
+    }
+
+    return { name: LabelName.TAG, value: tag };
+  });
+
+  return { labels };
+};

--- a/packages/allure-codeceptjs/src/index.ts
+++ b/packages/allure-codeceptjs/src/index.ts
@@ -24,6 +24,8 @@ import {
   CodeceptTest,
 } from "./codecept-types";
 
+import { extractMeta } from "./helpers";
+
 const { event } = global.codeceptjs;
 
 interface ReporterOptions {
@@ -158,10 +160,11 @@ class AllureReporter {
     this.currentTest = test;
 
     const allureTest = this.allureTestByCodeceptTest(test);
+    const { labels } = extractMeta(test);
     if (allureTest) {
-      for (const tag of test.tags) {
-        allureTest.addLabel(LabelName.TAG, tag);
-      }
+      labels.forEach((label) => {
+        allureTest.addLabel(label.name, label.value);
+      });
     }
   }
 

--- a/packages/allure-codeceptjs/test/codecept-tags.test.ts
+++ b/packages/allure-codeceptjs/test/codecept-tags.test.ts
@@ -7,7 +7,14 @@ test("simple scenarios", async () => {
       "login.test.js": /* js */ `
       Feature("tags")
       Scenario('taggs', () => {
-      }).tag('@slow').tag('important');
+      }).tag('@slow')
+        .tag('important')
+        .tag('@allure.label.owner:eroshenkoam')
+        .tag('@allure.label.layer:UI')
+        .tag('@allure.id:228')
+        .tag('@allure.label.story:aga')
+        .tag('@allure.label.epic:aga')
+        .tag('@allure.label.severity:critical');
       `,
     },
   });
@@ -33,6 +40,30 @@ test("simple scenarios", async () => {
       Object {
         "name": "tag",
         "value": "@important",
+      },
+      Object {
+        "name": "owner",
+        "value": "eroshenkoam",
+      },
+      Object {
+        "name": "layer",
+        "value": "UI",
+      },
+      Object {
+        "name": "ALLURE_ID",
+        "value": "228",
+      },
+      Object {
+        "name": "story",
+        "value": "aga",
+      },
+      Object {
+        "name": "epic",
+        "value": "aga",
+      },
+      Object {
+        "name": "severity",
+        "value": "critical",
       },
     ]
   `);

--- a/packages/allure-js-commons/index.ts
+++ b/packages/allure-js-commons/index.ts
@@ -45,7 +45,9 @@ export {
   isAnyStepFailed,
   readImageAsBase64,
   allureReportFolder,
-  stripAscii
+  stripAscii,
+  allureIdRegexp,
+  allureLabelRegexp
 } from "./src/utils";
 
 export { parseTestPlan } from "./src/testplan";

--- a/packages/allure-js-commons/src/utils.ts
+++ b/packages/allure-js-commons/src/utils.ts
@@ -77,3 +77,6 @@ export const allureReportFolder = (outputFolder?: string): string => {
 export const defaultReportFolder = (): string => {
   return path.resolve(process.cwd(), "allure-results");
 };
+
+export const allureIdRegexp = /^@?allure.id[:=](?<id>.+)$/;
+export const allureLabelRegexp = /@?allure.label.(?<name>.+)[:=](?<value>.+)/;

--- a/packages/newman-reporter-allure/src/helpers.ts
+++ b/packages/newman-reporter-allure/src/helpers.ts
@@ -1,11 +1,8 @@
-import { Label, LabelName } from "allure-js-commons";
+import { allureIdRegexp, allureLabelRegexp, Label, LabelName } from "allure-js-commons";
 import { EventList } from "postman-collection";
 
 export const extractMeta = (eventList: EventList) => {
   const labels: Label[] = [];
-
-  const allureIdRegexp = /^@?allure.id[:=](?<id>.+)$/;
-  const allureLabelRegexp = /@?allure.label.(?<name>.+)[:=](?<value>.+)/;
 
   eventList.each((event) => {
     if (event.listen === "test" && event.script.exec) {


### PR DESCRIPTION
### Context

The objective of this PR is to be able to manage the labels of pace via tags on the codeceptjs scenario.
for example:
```js
      Scenario('taggs', () => { 
        // my test
     }).tag('@slow')
        .tag('important')
        .tag('@owner:eroshenkoam')
        .tag('@layer:UI')
        .tag('@id:228')
        .tag('@story:aga')
        .tag('@epic:aga')
        .tag('@severity:critical');
   ```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
