### PR TITLE
added support for links to issues and tms for codeceptjs

### DIFF
--- a/packages/allure-codeceptjs/README.md
+++ b/packages/allure-codeceptjs/README.md
@@ -111,3 +111,63 @@ Scenario("login-scenario1", async () => {
   // your test
 }).tag("tagName");
 ```
+
+### Issue Link
+
+Setup codeceptjs plugin with: 
+
+```diff
+const { setHeadlessWhen, setCommonPlugins } = require("@codeceptjs/configure");
+const path = require("path");
+
+setCommonPlugins();
+
+module.exports.config = {
+  tests: "./**/*.test.js",
+  output: path.resolve(__dirname, "./output"),
+  plugins: {
+    allure: {
+      enabled: true,
+      require: "allure-codeceptjs",
++      issueURlTemplate: "https://example.qameta.io/allure-framework/allure-js/issues/%s",
+    },
+  },
+};
+```
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.issue:MY-ISSUE-82");
+```
+
+### TMS Link
+
+Setup codeceptjs plugin with: 
+
+```diff
+const { setHeadlessWhen, setCommonPlugins } = require("@codeceptjs/configure");
+const path = require("path");
+
+setCommonPlugins();
+
+module.exports.config = {
+  tests: "./**/*.test.js",
+  output: path.resolve(__dirname, "./output"),
+  plugins: {
+    allure: {
+      enabled: true,
+      require: "allure-codeceptjs",
++      tmsURLTemplate: "https://example.qameta.io/allure-framework/allure-js/tests/%s",
+    },
+  },
+};
+```
+
+```javascript
+Feature("login-feature");
+Scenario("login-scenario1", async () => {
+  // your test
+}).tag("@allure.tms:MY-TEST-CASE-64");
+```

--- a/packages/allure-codeceptjs/src/helpers.ts
+++ b/packages/allure-codeceptjs/src/helpers.ts
@@ -1,22 +1,49 @@
-import { allureIdRegexp, allureLabelRegexp, Label, LabelName } from "allure-js-commons";
+import {
+  allureIdRegexp,
+  allureIssueRegexp,
+  allureLabelRegexp,
+  allureTMSRegexp,
+  Label,
+  LabelName,
+  Link,
+  LinkType,
+} from "allure-js-commons";
 import { CodeceptTest } from "./codecept-types";
 
 export const extractMeta = (test: CodeceptTest & { tags: string[] }) => {
-  const labels: Label[] = test.tags.map((tag) => {
+  const labels: Label[] = [];
+  const links: Link[] = [];
+  test.tags.forEach((tag) => {
     const idMatch = tag.match(allureIdRegexp);
     const idValue = idMatch?.groups?.id;
     if (idValue) {
-      return { name: LabelName.ALLURE_ID, value: idValue };
+      labels.push({ name: LabelName.ALLURE_ID, value: idValue });
+      return;
+    }
+
+    const issueMatch = tag.match(allureIssueRegexp);
+    const issueName = issueMatch?.groups?.name;
+    if (issueName) {
+      links.push({ url: "", type: LinkType.ISSUE, name: issueName });
+      return;
+    }
+
+    const tmsMatch = tag.match(allureTMSRegexp);
+    const tmsName = tmsMatch?.groups?.name;
+    if (tmsName) {
+      links.push({ url: "", type: LinkType.TMS, name: tmsName });
+      return;
     }
 
     const labelMatch = tag.match(allureLabelRegexp);
-    const { name, value } = labelMatch?.groups || {};
-    if (name && value) {
-      return { name, value };
+    const { name: tagName, value: tagValue } = labelMatch?.groups || {};
+    if (tagName && tagValue) {
+      labels.push({ name: tagName, value: tagValue });
+      return;
     }
 
-    return { name: LabelName.TAG, value: tag };
+    labels.push({ name: LabelName.TAG, value: tag });
   });
 
-  return { labels };
+  return { labels, links };
 };

--- a/packages/allure-codeceptjs/src/index.ts
+++ b/packages/allure-codeceptjs/src/index.ts
@@ -31,6 +31,8 @@ const { event } = global.codeceptjs;
 interface ReporterOptions {
   outputDir: string;
   postProcessorForTest?: any;
+  issueURlTemplate?: string;
+  tmsURLTemplate?: string;
 }
 class AllureReporter {
   allureRuntime?: AllureRuntime;
@@ -160,10 +162,18 @@ class AllureReporter {
     this.currentTest = test;
 
     const allureTest = this.allureTestByCodeceptTest(test);
-    const { labels } = extractMeta(test);
+    const { labels, links } = extractMeta(test);
     if (allureTest) {
       labels.forEach((label) => {
         allureTest.addLabel(label.name, label.value);
+      });
+      links.forEach((link) => {
+        const template =
+          link.type === LinkType.TMS
+            ? this.reporterOptions.tmsURLTemplate
+            : this.reporterOptions.issueURlTemplate;
+        const url = template?.replace(/%s$/, link.name || "") || link.name || "";
+        allureTest.addLink(url, link.name, link.type);
       });
     }
   }

--- a/packages/allure-codeceptjs/test/codecept-tags.test.ts
+++ b/packages/allure-codeceptjs/test/codecept-tags.test.ts
@@ -14,7 +14,10 @@ test("simple scenarios", async () => {
         .tag('@allure.id:228')
         .tag('@allure.label.story:aga')
         .tag('@allure.label.epic:aga')
-        .tag('@allure.label.severity:critical');
+        .tag('@allure.label.severity:critical')
+        .tag('@allure.issue:FOO-123')
+        .tag('@allure.tms:TEST-123')
+        ;
       `,
     },
   });
@@ -66,5 +69,20 @@ test("simple scenarios", async () => {
         "value": "critical",
       },
     ]
+  `);
+
+  expect(res.tests[0]!.links).toMatchInlineSnapshot(`
+  Array [
+    Object {
+      "name": "FOO-123",
+      "type": "issue",
+      "url": "https://example.qameta.io/allure-framework/allure-js/issues/FOO-123",
+    },
+    Object {
+      "name": "TEST-123",
+      "type": "tms",
+      "url": "https://example.qameta.io/allure-framework/allure-js/tests/TEST-123",
+    },
+  ]
   `);
 });

--- a/packages/allure-codeceptjs/test/utils/default-codecept.config.js
+++ b/packages/allure-codeceptjs/test/utils/default-codecept.config.js
@@ -15,6 +15,8 @@ module.exports.config = {
       require: "allure-codeceptjs",
       enabled: true,
       postProcessorForTest: global.postProcessorForTest,
+      issueURlTemplate: "https://example.qameta.io/allure-framework/allure-js/issues/%s",
+      tmsURLTemplate: "https://example.qameta.io/allure-framework/allure-js/tests/%s",
     },
   },
 };

--- a/packages/allure-js-commons/index.ts
+++ b/packages/allure-js-commons/index.ts
@@ -47,7 +47,9 @@ export {
   allureReportFolder,
   stripAscii,
   allureIdRegexp,
-  allureLabelRegexp
+  allureLabelRegexp,
+  allureIssueRegexp,
+  allureTMSRegexp
 } from "./src/utils";
 
 export { parseTestPlan } from "./src/testplan";

--- a/packages/allure-js-commons/src/utils.ts
+++ b/packages/allure-js-commons/src/utils.ts
@@ -80,3 +80,5 @@ export const defaultReportFolder = (): string => {
 
 export const allureIdRegexp = /^@?allure.id[:=](?<id>.+)$/;
 export const allureLabelRegexp = /@?allure.label.(?<name>.+)[:=](?<value>.+)/;
+export const allureIssueRegexp = /@?allure.issue[:=](?<name>.+)/;
+export const allureTMSRegexp = /@?allure.tms[:=](?<name>.+)/;


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
 I want use allure xray plugin, but I must configure link on my test.
So, I propose this PR to set up the links to issue and tms.

#### Issue Link

Setup codeceptjs plugin with: 

```diff
const { setHeadlessWhen, setCommonPlugins } = require("@codeceptjs/configure");
const path = require("path");

setCommonPlugins();

module.exports.config = {
  tests: "./**/*.test.js",
  output: path.resolve(__dirname, "./output"),
  plugins: {
    allure: {
      enabled: true,
      require: "allure-codeceptjs",
+      issueURlTemplate: "https://example.qameta.io/allure-framework/allure-js/issues/%s",
    },
  },
};
```

```javascript
Feature("login-feature");
Scenario("login-scenario1", async () => {
  // your test
}).tag("@allure.issue:MY-ISSUE-82");
```

#### TMS Link

Setup codeceptjs plugin with: 

```diff
const { setHeadlessWhen, setCommonPlugins } = require("@codeceptjs/configure");
const path = require("path");

setCommonPlugins();

module.exports.config = {
  tests: "./**/*.test.js",
  output: path.resolve(__dirname, "./output"),
  plugins: {
    allure: {
      enabled: true,
      require: "allure-codeceptjs",
+      tmsURLTemplate: "https://example.qameta.io/allure-framework/allure-js/tests/%s",
    },
  },
};
```

```javascript
Feature("login-feature");
Scenario("login-scenario1", async () => {
  // your test
}).tag("@allure.tms:MY-TEST-CASE-64");
```


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
