### PR TITLE
feat(codeceptjs): generate env and executor info

### DIFF
--- a/packages/allure-codeceptjs/package.json
+++ b/packages/allure-codeceptjs/package.json
@@ -25,7 +25,8 @@
     "codeceptjs": "^3.4.1",
     "jest": "^26.4.2",
     "ts-jest": "^26.4.2",
-    "typescript": "^4.4.2"
+    "typescript": "^4.4.2",
+    "ua-parser-js": "^1.0.34"
   },
   "dependencies": {
     "allure-js-commons": "workspace:*"

--- a/packages/allure-codeceptjs/tsconfig.json
+++ b/packages/allure-codeceptjs/tsconfig.json
@@ -11,6 +11,9 @@
     "types": ["jest", "codeceptjs"],
     "rootDir": "./src",
     "outDir": "./dist",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "lib": [
+      "dom"
+    ]
   }
 }


### PR DESCRIPTION
### Context
Generate environment.properties and executors info
<img width="1597" alt="Screen Shot 2023-03-18 at 12 34 15 PM" src="https://user-images.githubusercontent.com/7845001/226103104-031f6e46-64c3-4930-9a0d-ab9a052905cf.png">


#### Checklist
- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
