### PR TITLE
Added support for scoped tags

### DIFF
--- a/packages/allure-js-commons/src/utils.ts
+++ b/packages/allure-js-commons/src/utils.ts
@@ -79,4 +79,4 @@ export const defaultReportFolder = (): string => {
 };
 
 export const allureIdRegexp = /^@?allure.id[:=](?<id>.+)$/;
-export const allureLabelRegexp = /@?allure.label.(?<name>.+)[:=](?<value>.+)/;
+export const allureLabelRegexp = /@?allure.label.(?<name>.+?)[:=](?<value>.+)/;

--- a/packages/allure-js-commons/test/specs/utils.spec.ts
+++ b/packages/allure-js-commons/test/specs/utils.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-import { ExecutableItem, Status } from "../../src/model";
-import { isAnyStepFailed } from "../../src/utils";
+import { ExecutableItem, LabelName, Status } from "../../src/model";
+import { isAnyStepFailed, allureLabelRegexp } from "../../src/utils";
 
 const fixtures = {
   withoutFailed: {
@@ -69,6 +69,37 @@ describe("utils > isAnyStepFailed", () => {
       // eslint-disable-next-line
       // @ts-ignore
       expect(isAnyStepFailed(fixtures.withFailedNested as ExecutableItem)).eq(true);
+    });
+  });
+});
+
+describe("utils > allureLabelRegexp", () => {
+  describe("with non scoped tag", () => {
+    it("return FOO", () => {
+      // eslint-disable-next-line
+      // @ts-ignore
+      const labelMatch = "@allure.label.tag=FOO".match(allureLabelRegexp);
+      const { name, value } = labelMatch?.groups || {};
+      expect(name).eq(LabelName.TAG);
+      expect(value).eq("FOO");
+    });
+  });
+  describe("with a scoped tag", () => {
+    it("return FOO:123", () => {
+      // eslint-disable-next-line
+      // @ts-ignore
+      const labelMatch = "@allure.label.tag=FOO:123".match(allureLabelRegexp);
+      const { name, value } = labelMatch?.groups || {};
+      expect(name).eq(LabelName.TAG);
+      expect(value).eq("FOO:123");
+    });
+    it("return FOO:123", () => {
+      // eslint-disable-next-line
+      // @ts-ignore
+      const labelMatch = "@allure.label.tag:FOO:123".match(allureLabelRegexp);
+      const { name, value } = labelMatch?.groups || {};
+      expect(name).eq(LabelName.TAG);
+      expect(value).eq("FOO:123");
     });
   });
 });


### PR DESCRIPTION
### Context

It is not possible to make scoped tags. comme `env:dev` or `env:prod`.
This PR corrects the regex to support scoped tags.

Before when I have `@allure.label.tag=env:prod`, that doesn't works, because the name of the label was `tag=env` and the value was `prod`.

With this PR, now, the label is `tag` and the value is `env:prod`

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
