### PR TITLE
Fix breaking change introduced in 2.2.0

### DIFF
--- a/packages/allure-js-commons/src/AllureCommandStep.ts
+++ b/packages/allure-js-commons/src/AllureCommandStep.ts
@@ -213,6 +213,13 @@ export class AllureCommandStepExecutable implements AllureCommandStep {
     });
   }
 
+  async start(body: StepBodyFunction): Promise<MetadataMessage> {
+    return await new Promise<MetadataMessage>((resolve) =>
+      // eslint-disable-next-line @typescript-eslint/require-await
+      this.run(body, async (result) => resolve(result)),
+    );
+  }
+
   async run(
     body: StepBodyFunction,
     messageEmitter: (message: MetadataMessage) => Promise<void>,

--- a/packages/allure-js-commons/test/specs/AllureCommandStep.spec.ts
+++ b/packages/allure-js-commons/test/specs/AllureCommandStep.spec.ts
@@ -25,7 +25,7 @@ const fixtures = {
   binaryAttachment: Buffer.from([0]),
 };
 
-describe("AllureCommandStep", () => {
+describe("AllureCommandStep.run()", () => {
   let currentStep: AllureCommandStepExecutable;
 
   beforeEach(() => {
@@ -319,6 +319,242 @@ describe("AllureCommandStep", () => {
           expect(steps![0].steps[0].steps[0].attachments[0].content).eq(fixtures.attachment);
         },
       );
+    });
+  });
+});
+
+describe("AllureCommandStep.start()", () => {
+  let currentStep: AllureCommandStepExecutable;
+
+  beforeEach(() => {
+    currentStep = new AllureCommandStepExecutable(fixtures.name);
+  });
+
+  describe("labels", () => {
+    it("adds custom label", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.label(fixtures.label.name, fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql(fixtures.label);
+    });
+
+    it("adds epic", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.epic(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.EPIC, value: fixtures.label.value });
+    });
+
+    it("adds feature", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.feature(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.FEATURE, value: fixtures.label.value });
+    });
+
+    it("adds story", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.story(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.STORY, value: fixtures.label.value });
+    });
+
+    it("adds suite", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.suite(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.SUITE, value: fixtures.label.value });
+    });
+
+    it("adds parent suite", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.parentSuite(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.PARENT_SUITE, value: fixtures.label.value });
+    });
+
+    it("adds sub suite", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.subSuite(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.SUB_SUITE, value: fixtures.label.value });
+    });
+
+    it("adds owner", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.owner(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.OWNER, value: fixtures.label.value });
+    });
+
+    it("adds severity", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.severity(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.SEVERITY, value: fixtures.label.value });
+    });
+
+    it("adds tag", async () => {
+      const { labels } = await currentStep.start((step) => {
+        step.tag(fixtures.label.value);
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql({ name: LabelName.TAG, value: fixtures.label.value });
+    });
+  });
+
+  describe("links", () => {
+    it("adds custom link", async () => {
+      const { links } = await currentStep.start((step) => {
+        step.link(fixtures.link.url, fixtures.link.name, fixtures.link.type);
+      });
+
+      expect(links!.length).eq(1);
+      expect(links![0]).eql(fixtures.link);
+    });
+
+    it("adds issue link", async () => {
+      const { links } = await currentStep.start((step) => {
+        step.issue(fixtures.link.name, fixtures.link.url);
+      });
+
+      expect(links!.length).eq(1);
+      expect(links![0]).eql({
+        url: fixtures.link.url,
+        name: fixtures.link.name,
+        type: LinkType.ISSUE,
+      });
+    });
+
+    it("adds tms link", async () => {
+      const { links } = await currentStep.start((step) => {
+        step.tms(fixtures.link.name, fixtures.link.url);
+      });
+
+      expect(links!.length).eq(1);
+      expect(links![0]).eql({
+        url: fixtures.link.url,
+        name: fixtures.link.name,
+        type: LinkType.TMS,
+      });
+    });
+  });
+
+  describe("parameters", () => {
+    it("adds custom parameter", async () => {
+      const { parameter } = await currentStep.start((step) => {
+        step.parameter(
+          fixtures.parameter.name,
+          fixtures.parameter.value,
+          fixtures.parameter.options,
+        );
+      });
+
+      expect(parameter!.length).eq(1);
+      expect(parameter![0]).eql({
+        name: fixtures.parameter.name,
+        value: fixtures.parameter.value,
+        excluded: fixtures.parameter.options.excluded,
+        mode: fixtures.parameter.options.mode,
+      });
+    });
+  });
+
+  describe("attachments", () => {
+    describe("text attachment", () => {
+      it("adds attachment as is", async () => {
+        const { steps } = await currentStep.start((step) => {
+          step.attach(fixtures.attachment, ContentType.JSON);
+        });
+
+        expect(steps![0].attachments.length).eq(1);
+        expect(steps![0].attachments[0].content).eq(fixtures.attachment);
+        expect(steps![0].attachments[0].encoding).eq("utf8");
+      });
+    });
+
+    describe("binary attachment", () => {
+      it("adds attachment as base64 string", async () => {
+        const { steps } = await currentStep.start((step) => {
+          step.attach(fixtures.binaryAttachment, ContentType.PNG);
+        });
+
+        expect(steps![0].attachments.length).eq(1);
+        expect(steps![0].attachments[0].content).eq(fixtures.binaryAttachment.toString("base64"));
+        expect(steps![0].attachments[0].encoding).eq("base64");
+      });
+    });
+  });
+
+  describe("steps", () => {
+    it("adds nested steps", async () => {
+      const { steps } = await currentStep.start(async (s1) => {
+        await s1.step("my nested step name", async (s2) => {
+          await s2.step("my nested nested step name", () => {});
+        });
+      });
+
+      expect(steps!.length).eq(1);
+      expect(steps![0].steps.length).eq(1);
+      expect(steps![0].steps[0].steps.length).eq(1);
+    });
+
+    it("adds labels from nested steps to the metadata object", async () => {
+      const { labels } = await currentStep.start(async (s1) => {
+        await s1.step("my nested step name", async (s2) => {
+          await s2.step("my nested nested step name", (s3) => {
+            s3.label(fixtures.label.name, fixtures.label.value);
+          });
+        });
+      });
+
+      expect(labels!.length).eq(1);
+      expect(labels![0]).eql(fixtures.label);
+    });
+
+    it("adds links from nested steps to the metadata object", async () => {
+      const { links } = await currentStep.start(async (s1) => {
+        await s1.step("my nested step name", async (s2) => {
+          await s2.step("my nested nested step name", (s3) => {
+            s3.link(fixtures.link.url, fixtures.link.name, fixtures.link.type);
+          });
+        });
+      });
+
+      expect(links!.length).eq(1);
+      expect(links![0]).eql(fixtures.link);
+    });
+
+    it("adds attachment only for related step", async () => {
+      const { steps } = await currentStep.start(async (s1) => {
+        await s1.step("my nested step name", async (s2) => {
+          await s2.step("my nested nested step name", (s3) => {
+            s3.attach(fixtures.attachment, ContentType.JSON);
+          });
+        });
+      });
+
+      expect(steps![0].steps[0].steps[0].attachments.length).eq(1);
+      expect(steps![0].steps[0].steps[0].attachments[0].content).eq(fixtures.attachment);
     });
   });
 });


### PR DESCRIPTION
in 2.2.0 release `AllureStepCommand.start()` method was deleted. This
change adds the method back

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2