### PR TITLE
Added an option to display file suite title in report by environment variable 

### DIFF
--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -107,7 +107,7 @@ class AllureReporter implements Reporter {
     if (projectSuiteTitle) {
       allureTest.addLabel(LabelName.PARENT_SUITE, projectSuiteTitle);
     }
-    if (this.options.suiteTitle && fileSuiteTitle) {
+    if (process.env.DISPLAY_FILE_SUITES_TITLE || (this.options.suiteTitle && fileSuiteTitle)) {
       allureTest.addLabel(LabelName.SUITE, fileSuiteTitle);
     }
     if (suiteTitles.length > 0) {


### PR DESCRIPTION

### Context

In the newer versions (since version 2.0.0-beta.18) when generating the allure report, if we access the suites data in the generated folder (<generated_folder>/data/suites.json) the test suites titles are the defined title from the tests file instead of the file suite title. For example for the following file

```
# foo/foo.spec.ts

test.describe('foo example tests', () => {
...
```

The title will be 'foo example tests' instead of 'foo/foo.spec.ts'


This can be a problem if I want to map the test suites - since we can create two test files with the same title in the description, it can not be a unique id for the test suites. In the current version we can restore the file suite title usage by defining 'suiteTitle=true' in the reporter (allure-playwright) configuration.

The purpose of this pull request is to bypass the need to update the configuration and use the command line. For example, when running Playwright tests execution command, adding reporter flag with a list of that includes 'allure-playwright'

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
