### PR TITLE
fix(cucumberjs): support steps' attachments 

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -385,7 +385,7 @@ export class CucumberJSAllureFormatter extends Formatter {
     const encoding = Buffer.isEncoding(contentEncoding) ? contentEncoding : undefined; // only pass through valid encodings
     const attachmentFilename = this.allureRuntime.writeAttachment(body, mediaType, encoding);
 
-    currentTest.addAttachment(
+    (currentStep ?? currentTest).addAttachment(
       fileName,
       {
         contentType: mediaType,

--- a/packages/allure-cucumberjs/test/specs/attachments_test.ts
+++ b/packages/allure-cucumberjs/test/specs/attachments_test.ts
@@ -46,7 +46,7 @@ describe("CucumberJSAllureReporter > examples", () => {
     expect(attachmentsKeys).length(2);
     expect(results.attachments[attachmentsKeys[0]]).eq("some text");
 
-    const [attachment] = results.tests[0].attachments;
+    const [attachment] = results.tests[0].steps[0].attachments;
     expect(attachment.type).eq("text/plain");
     expect(attachment.source).eq(attachmentsKeys[0]);
   });
@@ -58,7 +58,7 @@ describe("CucumberJSAllureReporter > examples", () => {
     const attachmentsKeys = Object.keys(results.attachments);
     expect(attachmentsKeys).length(2);
 
-    const [imageAttachment] = results.tests[1].attachments;
+    const [imageAttachment] = results.tests[1].steps[0].attachments;
     expect(imageAttachment.type).eq("image/png");
   });
 });


### PR DESCRIPTION
Closes #688

Please check linked issue to get more information about the problem


### Context
Allure attachments are place outside the cucumber steps

#### Checklist
- [X] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
