### PR TITLE
Add ability to set display name and description for hermione tests

### DIFF
--- a/packages/allure-hermione/README.md
+++ b/packages/allure-hermione/README.md
@@ -53,6 +53,27 @@ Don't forget to pass current test id as first argument to command!
 
 ## Supported commands
 
+### Display name
+
+Change your test case name on custom value on the fly using `displayName` method:
+
+```js
+it("my test", async ({ browser, currentTest }) => {
+  await browser.displayName(currentTest.id(), "my test custom name");
+});
+```
+
+### Description
+
+Provide description in markdown or html syntax:
+
+```js
+it("my test", async ({ browser, currentTest }) => {
+  await browser.description(currentTest.id(), "my **markdown description**");
+  await browser.descriptionHtml(currentTest.id(), "<p>my <b>html description</b></p>");
+});
+```
+
 ### Labels
 
 Markup you tests with labels using low-level `label` method:

--- a/packages/allure-hermione/src/index.ts
+++ b/packages/allure-hermione/src/index.ts
@@ -27,6 +27,9 @@ import {
   addParameter,
   getSuitePath,
   sendMetadata,
+  setDescription,
+  setDescriptionHtml,
+  setDisplayName,
 } from "./utils";
 
 export type HermioneAttachmentMessage = {
@@ -144,6 +147,7 @@ const hermioneAllureReporter = (hermione: Hermione, opts: AllureReportOptions) =
       steps = [],
       description,
       descriptionHtml,
+      displayName,
     } = metadata;
 
     labels.forEach((label) => {
@@ -184,6 +188,10 @@ const hermioneAllureReporter = (hermione: Hermione, opts: AllureReportOptions) =
 
     if (descriptionHtml) {
       currentTest.descriptionHtml = descriptionHtml;
+    }
+
+    if (displayName) {
+      currentTest.name = displayName;
     }
   };
   const handleAllureStep = (testId: string, stepMetadata: StepMetadata) => {
@@ -262,6 +270,15 @@ const hermioneAllureReporter = (hermione: Hermione, opts: AllureReportOptions) =
         body,
         async (message: MetadataMessage) => await sendMetadata(testId(id), message),
       );
+    });
+    browser.addCommand("displayName", async (id: string, value: string) => {
+      await setDisplayName(testId(id), value);
+    });
+    browser.addCommand("description", async (id: string, value: string) => {
+      await setDescription(testId(id), value);
+    });
+    browser.addCommand("descriptionHtml", async (id: string, value: string) => {
+      await setDescriptionHtml(testId(id), value);
     });
   });
   hermione.on(hermione.events.NEW_WORKER_PROCESS, (worker) => {

--- a/packages/allure-hermione/src/utils.ts
+++ b/packages/allure-hermione/src/utils.ts
@@ -35,6 +35,24 @@ export const sendMetadata = async (testId: string, metadata: MetadataMessage): P
     );
   });
 
+export const setDisplayName = async (testId: string, displayName: string) => {
+  await sendMetadata(testId, {
+    displayName,
+  });
+};
+
+export const setDescription = async (testId: string, description: string) => {
+  await sendMetadata(testId, {
+    description,
+  });
+};
+
+export const setDescriptionHtml = async (testId: string, descriptionHtml: string) => {
+  await sendMetadata(testId, {
+    descriptionHtml,
+  });
+};
+
 export const addLabel = async (testId: string, name: string, value: string) => {
   await sendMetadata(testId, {
     labels: [{ name, value }],

--- a/packages/allure-hermione/test/fixtures/description.js
+++ b/packages/allure-hermione/test/fixtures/description.js
@@ -1,0 +1,7 @@
+it("markdown description", async ({ browser, currentTest }) => {
+  await browser.description(currentTest.id, "foo");
+});
+
+it("html description", async ({ browser, currentTest }) => {
+  await browser.descriptionHtml(currentTest.id, "foo");
+});

--- a/packages/allure-hermione/test/fixtures/displayName.js
+++ b/packages/allure-hermione/test/fixtures/displayName.js
@@ -1,0 +1,3 @@
+it("display name", async ({ browser, currentTest }) => {
+  await browser.displayName(currentTest.id, "foo");
+});

--- a/packages/allure-hermione/test/spec/description.test.ts
+++ b/packages/allure-hermione/test/spec/description.test.ts
@@ -1,0 +1,30 @@
+import { TestResult } from "allure-js-commons";
+import { expect } from "chai";
+import Hermione from "hermione";
+import { before, describe, it } from "mocha";
+import { getTestResultByName } from "../runner";
+import { HermioneAllure } from "../types";
+
+describe("description", () => {
+  let results: TestResult[];
+
+  before(async () => {
+    const hermione = new Hermione("./test/.hermione.conf.js") as HermioneAllure;
+
+    await hermione.run(["./test/fixtures/description.js"], {});
+
+    results = hermione.allure.writer.results;
+  });
+
+  it("adds `foo` markdown description", () => {
+    const { description } = getTestResultByName(results, "markdown description");
+
+    expect(description).eq("foo");
+  });
+
+  it("adds `foo` html description", () => {
+    const { descriptionHtml } = getTestResultByName(results, "html description");
+
+    expect(descriptionHtml).eq("foo");
+  });
+});

--- a/packages/allure-hermione/test/spec/displayName.test.ts
+++ b/packages/allure-hermione/test/spec/displayName.test.ts
@@ -1,0 +1,25 @@
+import { TestResult } from "allure-js-commons";
+import { expect } from "chai";
+import Hermione from "hermione";
+import { before, describe, it } from "mocha";
+import { getTestResultByName } from "../runner";
+import { HermioneAllure } from "../types";
+
+describe("displayName", () => {
+  let results: TestResult[];
+
+  before(async () => {
+    const hermione = new Hermione("./test/.hermione.conf.js") as HermioneAllure;
+
+    await hermione.run(["./test/fixtures/displayName.js"], {});
+
+    results = hermione.allure.writer.results;
+  });
+
+  it("sets custom test name", () => {
+    const { name, fullName } = getTestResultByName(results, "foo");
+
+    expect(name).eq("foo");
+    expect(fullName).eq("display name");
+  });
+});

--- a/packages/allure-hermione/test/spec/labels.test.ts
+++ b/packages/allure-hermione/test/spec/labels.test.ts
@@ -1,9 +1,9 @@
 import { Label, LabelName, TestResult } from "allure-js-commons";
 import { expect } from "chai";
-import { beforeEach, before, describe, it } from "mocha";
 import Hermione from "hermione";
-import { HermioneAllure } from "../types";
+import { before, describe, it } from "mocha";
 import { getTestResultByName } from "../runner";
+import { HermioneAllure } from "../types";
 
 describe("labels", () => {
   let results: TestResult[];

--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -15,6 +15,7 @@ export interface StepMetadata extends Omit<ExecutableItem, "attachments" | "step
 
 export interface MetadataMessage {
   attachments?: AttachmentMetadata[];
+  displayName?: string;
   labels?: Label[];
   links?: Link[];
   parameter?: Parameter[];


### PR DESCRIPTION
add ability to set description for hermione tests

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

fixes #715, #714

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
