### PR TITLE
Enable cross-browser testing in Cucumber reporter

### DIFF
--- a/packages/allure-cucumberjs/README.md
+++ b/packages/allure-cucumberjs/README.md
@@ -208,3 +208,17 @@ Given(/my step/, async function () {
   });
 });
 ```
+
+## Cross-browser testing
+
+For cross-browser testing simply add a parameter using Allure API with the browser name to the `World` instance inside your scenario, i.e.:
+
+```js
+await this.parameter('Browser', 'firefox')
+```
+
+For better presentation, you can also group suites by browser names, i.e.:
+
+```js
+await this.parentSuite('Firefox')
+```

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -506,6 +506,7 @@ export class CucumberJSAllureFormatter extends Formatter {
       currentTest.status = Status.PASSED;
     }
 
+    currentTest.calculateHistoryId();
     currentTest.endTest(Date.now());
 
     this.currentTestsMap.delete(data.testCaseStartedId);

--- a/packages/allure-cucumberjs/test/specs/simple_test.ts
+++ b/packages/allure-cucumberjs/test/specs/simple_test.ts
@@ -32,7 +32,7 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
   parameterized: {
     supportCodeLibrary: buildSupportCodeLibrary(({ Given }) => {
       Given("a step", function () {
-        this.parameter("Browser", "Firefox");
+        this.parameter("Browser", "firefox");
       });
     }),
     sources: [

--- a/packages/allure-cucumberjs/test/specs/simple_test.ts
+++ b/packages/allure-cucumberjs/test/specs/simple_test.ts
@@ -29,6 +29,19 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
       },
     ],
   },
+  parameterized: {
+    supportCodeLibrary: buildSupportCodeLibrary(({ Given }) => {
+      Given("a step", function () {
+        this.parameter("Browser", "Firefox");
+      });
+    }),
+    sources: [
+      {
+        data: ["Feature: a", "Scenario: b", "Given a step"].join("\n"),
+        uri: "a.feature",
+      },
+    ],
+  },
 };
 
 describe("CucumberJSAllureReporter > simple", () => {
@@ -76,7 +89,7 @@ describe("CucumberJSAllureReporter > simple", () => {
     });
 
     it("sets fullName, testCaseId and historyId", async () => {
-      const results = await runFeatures(dataSet.passed);
+      const results = await runFeatures(dataSet.parameterized);
 
       expect(results.tests).length(1);
       const [testResult] = results.tests;
@@ -84,9 +97,12 @@ describe("CucumberJSAllureReporter > simple", () => {
 
       const name = source!.data.match(/\nScenario: (.+)\n/)?.[1];
       const fullName = `${source!.uri}#${name!}`;
+      const { name: paramName, value: paramValue } = testResult.parameters[0];
+      const paramsHash = md5(`${paramName}:${paramValue}`);
+      const historyId = `${testResult.testCaseId}:${paramsHash}`;
       expect(testResult.fullName).eq(fullName);
       expect(testResult.testCaseId).eq(md5(fullName));
-      expect(testResult.historyId).eq(testResult.testCaseId);
+      expect(testResult.historyId).eq(historyId);
     });
   });
 


### PR DESCRIPTION
This fixes cross-browser testing in Cucumber - currently results from multiple browsers land in Retries tab. 

History ID must be calculated based on added parameters for this to work. 

The fix is based on Playwright reporter implementation: 
https://github.com/allure-framework/allure-js/blob/38366df3346bd8428f99c539af9f881d36de34b9/packages/allure-playwright/src/index.ts#L272

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
