### PR TITLE
History ID and metadata processing improvements

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -300,7 +300,6 @@ export class CucumberJSAllureFormatter extends Formatter {
     currentTest.name = pickle.name;
     currentTest.fullName = fullName;
     currentTest.testCaseId = testCaseId;
-    currentTest.historyId = testCaseId;
 
     currentTest.addLabel(LabelName.HOST, this.hostname);
     currentTest.addLabel(LabelName.LANGUAGE, "javascript");
@@ -399,56 +398,14 @@ export class CucumberJSAllureFormatter extends Formatter {
     step?: AllureStep;
     metadata: MetadataMessage;
   }) {
-    const {
-      labels = [],
-      links = [],
-      parameter = [],
-      steps = [],
-      description,
-      descriptionHtml,
-    } = payload.metadata;
+    payload.test.applyMetadata(payload.metadata, (step) => {
+      if (payload.step) {
+        payload.step.addStep(step);
+        return;
+      }
 
-    links.forEach((link) => payload.test.addLink(link.url, link.type, link.name));
-    labels.forEach((label) => payload.test.addLabel(label.name, label.value));
-    parameter.forEach(({ name, value, excluded, mode }) =>
-      payload.test.parameter(name, value, {
-        excluded,
-        mode,
-      }),
-    );
-    steps.forEach((step) => {
-      this.handleAllureStep({
-        test: payload.test,
-        step: payload.step,
-        stepMetadata: step,
-      });
+      payload.test.addStep(step);
     });
-
-    if (description) {
-      payload.test.description = description;
-    }
-
-    if (descriptionHtml) {
-      payload.test.descriptionHtml = descriptionHtml;
-    }
-  }
-
-  private handleAllureStep(payload: {
-    test: AllureTest;
-    step?: AllureStep;
-    stepMetadata: StepMetadata;
-  }) {
-    const step = AllureCommandStepExecutable.toExecutableItem(
-      this.allureRuntime,
-      payload.stepMetadata,
-    );
-
-    if (payload.step) {
-      payload.step.addStep(step);
-      return;
-    }
-
-    payload.test.addStep(step);
   }
 
   private onTestCaseFinished(data: messages.TestCaseFinished): void {

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -7,7 +7,6 @@ import * as messages from "@cucumber/messages";
 import { Tag, TestStepResultStatus } from "@cucumber/messages";
 import {
   Allure,
-  AllureCommandStepExecutable,
   AllureRuntime,
   AllureStep,
   AllureTest,
@@ -18,7 +17,6 @@ import {
   md5,
   MetadataMessage,
   Status,
-  StepMetadata,
 } from "allure-js-commons";
 import { ALLURE_METADATA_CONTENT_TYPE } from "allure-js-commons/internal";
 import { CucumberAllureWorld } from "./CucumberAllureWorld";

--- a/packages/allure-hermione/src/index.ts
+++ b/packages/allure-hermione/src/index.ts
@@ -25,6 +25,7 @@ import {
   addLabel,
   addLink,
   addParameter,
+  getFileSrcPath,
   getSuitePath,
   sendMetadata,
   setDescription,
@@ -84,21 +85,23 @@ const hermioneAllureReporter = (hermione: Hermione, opts: AllureReportOptions) =
     const { ALLURE_HOST_NAME, ALLURE_THREAD_NAME } = process.env;
     const thread = ALLURE_THREAD_NAME || test.sessionId;
     const hostnameLabel = ALLURE_HOST_NAME || hostname;
+    const fileSrcPath = getFileSrcPath(test.file!);
+    const testFullTitle = test.fullTitle();
     const currentTest = new AllureTest(runtime, Date.now());
     const suites = getSuitePath(test);
 
     currentTest.name = test.title;
-    currentTest.fullName = test.fullTitle();
+    currentTest.fullName = testFullTitle;
     currentTest.stage = Stage.RUNNING;
-
-    // TODO:
-    // currentTest.calculateTestCaseId(test.id());
-    // currentTest.testCaseId = test.id();
 
     currentTest.addLabel(LabelName.HOST, hostnameLabel);
     currentTest.addLabel(LabelName.LANGUAGE, "javascript");
     currentTest.addLabel(LabelName.FRAMEWORK, "hermione");
     currentTest.addParameter("browser", test.browserId);
+
+    if (!currentTest.testCaseId) {
+      currentTest.testCaseId = md5(`${fileSrcPath}#${testFullTitle}`);
+    }
 
     if (thread) {
       currentTest.addLabel(LabelName.THREAD, thread);

--- a/packages/allure-hermione/src/utils.ts
+++ b/packages/allure-hermione/src/utils.ts
@@ -1,5 +1,13 @@
+import { basename } from "path";
+import { cwd } from "process";
 import { MetadataMessage, ParameterOptions } from "allure-js-commons";
 import { ALLURE_METADATA_CONTENT_TYPE } from "allure-js-commons/internal";
+
+export const getFileSrcPath = (filePath: string): string => {
+  const baseDir = basename(cwd());
+
+  return filePath.replace(cwd(), baseDir);
+};
 
 export const getSuitePath = (test: Hermione.Test): string[] => {
   const path = [];
@@ -15,6 +23,7 @@ export const getSuitePath = (test: Hermione.Test): string[] => {
 
   return path;
 };
+
 export const sendMetadata = async (testId: string, metadata: MetadataMessage): Promise<void> =>
   new Promise((resolve, reject) => {
     process.send?.(

--- a/packages/allure-hermione/src/utils.ts
+++ b/packages/allure-hermione/src/utils.ts
@@ -53,6 +53,18 @@ export const setDescriptionHtml = async (testId: string, descriptionHtml: string
   });
 };
 
+export const setTestCaseId = async (testId: string, testCaseId: string) => {
+  await sendMetadata(testId, {
+    testCaseId,
+  });
+};
+
+export const setHistoryId = async (testId: string, historyId: string) => {
+  await sendMetadata(testId, {
+    historyId,
+  });
+};
+
 export const addLabel = async (testId: string, name: string, value: string) => {
   await sendMetadata(testId, {
     labels: [{ name, value }],

--- a/packages/allure-hermione/test/fixtures/historyId.js
+++ b/packages/allure-hermione/test/fixtures/historyId.js
@@ -1,0 +1,3 @@
+it("historyId", async ({ browser, currentTest }) => {
+  await browser.historyId(currentTest.id, "foo");
+});

--- a/packages/allure-hermione/test/fixtures/testCaseId.js
+++ b/packages/allure-hermione/test/fixtures/testCaseId.js
@@ -1,0 +1,3 @@
+it("testCaseId", async ({ browser, currentTest }) => {
+  await browser.testCaseId(currentTest.id, "foo");
+});

--- a/packages/allure-hermione/test/spec/historyId.test.ts
+++ b/packages/allure-hermione/test/spec/historyId.test.ts
@@ -1,0 +1,24 @@
+import { TestResult } from "allure-js-commons";
+import { expect } from "chai";
+import Hermione from "hermione";
+import { before, describe, it } from "mocha";
+import { getTestResultByName } from "../runner";
+import { HermioneAllure } from "../types";
+
+describe("historyId", () => {
+  let results: TestResult[];
+
+  before(async () => {
+    const hermione = new Hermione("./test/.hermione.conf.js") as HermioneAllure;
+
+    await hermione.run(["./test/fixtures/historyId.js"], {});
+
+    results = hermione.allure.writer.results;
+  });
+
+  it("sets custom history id", () => {
+    const { historyId } = getTestResultByName(results, "historyId");
+
+    expect(historyId).eq("foo");
+  });
+});

--- a/packages/allure-hermione/test/spec/steps.test.ts
+++ b/packages/allure-hermione/test/spec/steps.test.ts
@@ -1,9 +1,9 @@
 import { Status, TestResult } from "allure-js-commons";
 import { expect } from "chai";
-import { before, beforeEach, describe, it } from "mocha";
-import { HermioneAllure } from "../types";
-import { getTestResultByName } from "../runner";
 import Hermione from "hermione";
+import { before, beforeEach, describe, it } from "mocha";
+import { getTestResultByName } from "../runner";
+import { HermioneAllure } from "../types";
 
 describe("steps", () => {
   let results: TestResult[];
@@ -32,7 +32,7 @@ describe("steps", () => {
   });
 
   describe("failed steps", () => {
-    it("fails the test with original step error", async () => {
+    it("fails the test with original step error", () => {
       const { status, statusDetails, steps, labels } = getTestResultByName(results, "failed");
 
       expect(status).eq(Status.FAILED);

--- a/packages/allure-hermione/test/spec/testCaseId.test.ts
+++ b/packages/allure-hermione/test/spec/testCaseId.test.ts
@@ -1,0 +1,24 @@
+import { TestResult } from "allure-js-commons";
+import { expect } from "chai";
+import Hermione from "hermione";
+import { before, describe, it } from "mocha";
+import { getTestResultByName } from "../runner";
+import { HermioneAllure } from "../types";
+
+describe("testCaseId", () => {
+  let results: TestResult[];
+
+  before(async () => {
+    const hermione = new Hermione("./test/.hermione.conf.js") as HermioneAllure;
+
+    await hermione.run(["./test/fixtures/testCaseId.js"], {});
+
+    results = hermione.allure.writer.results;
+  });
+
+  it("sets custom test case id", () => {
+    const { testCaseId } = getTestResultByName(results, "testCaseId");
+
+    expect(testCaseId).eq("foo");
+  });
+});

--- a/packages/allure-js-commons/src/AllureTest.ts
+++ b/packages/allure-js-commons/src/AllureTest.ts
@@ -7,6 +7,7 @@ import { md5 } from "./utils";
 
 export class AllureTest extends ExecutableItemWrapper {
   private readonly testResult: TestResult;
+  private historyIdSetManually = false;
 
   constructor(private readonly runtime: AllureRuntime, start: number = Date.now()) {
     super(testResult());
@@ -25,6 +26,7 @@ export class AllureTest extends ExecutableItemWrapper {
   }
 
   set historyId(id: string) {
+    this.historyIdSetManually = true;
     this.testResult.historyId = id;
   }
 
@@ -57,7 +59,7 @@ export class AllureTest extends ExecutableItemWrapper {
    * Does nothing if `historyId` is already set
    */
   calculateHistoryId(): void {
-    if (this.testResult.historyId) {
+    if (this.historyIdSetManually) {
       return;
     }
 

--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -16,6 +16,8 @@ export interface StepMetadata extends Omit<ExecutableItem, "attachments" | "step
 export interface MetadataMessage {
   attachments?: AttachmentMetadata[];
   displayName?: string;
+  testCaseId?: string;
+  historyId?: string;
   labels?: Label[];
   links?: Link[];
   parameter?: Parameter[];


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

fixes #747 

- Adds ability to set `testCaseId` and `historyId` manually.
- Fixes problem with lack of `testCaseId` for `hermione`
- Introduces new test method to parse and apply metadata messages and uses the method for `hermione` and `cucumber` integrations

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
