### PR TITLE
fix(cucumber): add support for rule keyword

### DIFF
--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -242,9 +242,8 @@ export class CucumberJSAllureFormatter extends Formatter {
 
     data.feature?.children?.forEach((c) => {
       if (c.rule) {
-        this.onRule(c.rule);        
-      }
-      else if (c.scenario) {
+        this.onRule(c.rule);
+      } else if (c.scenario) {
         this.onScenario(c.scenario);
       }
     });

--- a/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
+++ b/packages/allure-cucumberjs/src/CucumberJSAllureReporter.ts
@@ -240,9 +240,20 @@ export class CucumberJSAllureFormatter extends Formatter {
       this.documentMap.set(data.uri, data);
     }
 
-    data.feature?.children?.forEach((fc) => {
-      if (fc.scenario) {
-        this.onScenario(fc.scenario);
+    data.feature?.children?.forEach((c) => {
+      if (c.rule) {
+        this.onRule(c.rule);        
+      }
+      else if (c.scenario) {
+        this.onScenario(c.scenario);
+      }
+    });
+  }
+
+  private onRule(data: messages.Rule): void {
+    data.children?.forEach((c) => {
+      if (c.scenario) {
+        this.onScenario(c.scenario);
       }
     });
   }

--- a/packages/allure-cucumberjs/test/specs/with_labels_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_labels_test.ts
@@ -12,14 +12,22 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
     sources: [
       {
         data:
-          "@severity:foo @feature:bar\n" +
+          "@severity:foo @feature:qux\n" +
           "Feature: a\n" +
           "\n" +
           "  @severity:bar @feature:foo @foo\n" +
           "  Scenario: b\n" +
           "    Given a step\n" +
           "    When do something\n" +
-          "    Then get something\n",
+          "    Then get something\n" +
+          "\n" +
+          "  Rule: c\n" +
+          "\n" +
+          "    @severity:qux @feature:bar @bar\n" +
+          "    Scenario: d\n" +,
+          "      Given a step\n" +
+          "      When do something\n" +
+          "      Then get something\n",
         uri: "withIssueLink.feature",
       },
     ],
@@ -51,10 +59,12 @@ describe("CucumberJSAllureReporter > examples", () => {
       .filter((label) => label.name === LabelName.FEATURE)
       .map(({ value }) => value);
 
-    expect(tags).length(1);
+    expect(tags).length(2);
     expect(severityLabels).contains("foo");
     expect(severityLabels).contains("bar");
+    expect(severityLabels).contains("qux");
     expect(featureLabels).contains("foo");
     expect(featureLabels).contains("bar");
+    expect(featureLabels).contains("qux");
   });
 });

--- a/packages/allure-cucumberjs/test/specs/with_labels_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_labels_test.ts
@@ -12,7 +12,7 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
     sources: [
       {
         data:
-          "@severity:foo @feature:qux\n" +
+          "@severity:foo @feature:bar\n" +
           "Feature: a\n" +
           "\n" +
           "  @severity:bar @feature:foo @foo\n" +

--- a/packages/allure-cucumberjs/test/specs/with_labels_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_labels_test.ts
@@ -24,7 +24,7 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
           "  Rule: c\n" +
           "\n" +
           "    @severity:qux @feature:bar @bar\n" +
-          "    Scenario: d\n" +,
+          "    Scenario: d\n" +
           "      Given a step\n" +
           "      When do something\n" +
           "      Then get something\n",

--- a/packages/allure-cucumberjs/test/specs/with_labels_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_labels_test.ts
@@ -19,12 +19,25 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
           "  Scenario: b\n" +
           "    Given a step\n" +
           "    When do something\n" +
-          "    Then get something\n" +
+          "    Then get something\n",
+        uri: "withIssueLink.feature",
+      },
+    ],
+  },
+  withLabelsAndRules: {
+    supportCodeLibrary: buildSupportCodeLibrary(({ Given }) => {
+      Given("a step", () => {});
+    }),
+    sources: [
+      {
+        data:
+          "@severity:foo @feature:bar\n" +
+          "Feature: a\n" +
           "\n" +
-          "  Rule: c\n" +
+          "  Rule: r\n" +
           "\n" +
-          "    @severity:qux @feature:bar @bar\n" +
-          "    Scenario: d\n" +
+          "    @severity:bar @feature:foo @foo\n" +
+          "    Scenario: b\n" +
           "      Given a step\n" +
           "      When do something\n" +
           "      Then get something\n",
@@ -59,12 +72,41 @@ describe("CucumberJSAllureReporter > examples", () => {
       .filter((label) => label.name === LabelName.FEATURE)
       .map(({ value }) => value);
 
-    expect(tags).length(2);
+    expect(tags).length(1);
     expect(severityLabels).contains("foo");
     expect(severityLabels).contains("bar");
-    expect(severityLabels).contains("qux");
     expect(featureLabels).contains("foo");
     expect(featureLabels).contains("bar");
-    expect(featureLabels).contains("qux");
+  });
+
+  it("should add labels when scenario is inside a rule", async () => {
+    const results = await runFeatures(dataSet.withLabelsAndRules, {
+      labels: [
+        {
+          pattern: [/@feature:(.*)/],
+          name: "feature",
+        },
+        {
+          pattern: [/@severity:(.*)/],
+          name: "severity",
+        },
+      ],
+    });
+    expect(results.tests).length(1);
+
+    const { labels } = results.tests[0];
+    const tags = labels.filter((label) => label.name === LabelName.TAG);
+    const severityLabels = labels
+      .filter((label) => label.name === LabelName.SEVERITY)
+      .map(({ value }) => value);
+    const featureLabels = labels
+      .filter((label) => label.name === LabelName.FEATURE)
+      .map(({ value }) => value);
+
+    expect(tags).length(1);
+    expect(severityLabels).contains("foo");
+    expect(severityLabels).contains("bar");
+    expect(featureLabels).contains("foo");
+    expect(featureLabels).contains("bar");
   });
 });

--- a/packages/allure-cucumberjs/test/specs/with_links_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_links_test.ts
@@ -19,7 +19,15 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
           "  Scenario: b\n" +
           "    Given a step\n" +
           "    When do something\n" +
-          "    Then get something\n",
+          "    Then get something\n" +
+          "\n" +
+          "  Rule: c\n" +
+          "\n" +
+          "    @issue=3 @tms=4\n" +
+          "    Scenario: d\n" +,
+          "      Given a step\n" +
+          "      When do something\n" +
+          "      Then get something\n",
         uri: "withIssueLink.feature",
       },
     ],
@@ -46,11 +54,15 @@ describe("CucumberJSAllureReporter > examples", () => {
 
     const { links } = results.tests[0];
 
-    expect(links).length(2);
+    expect(links).length(4);
     expect(links[0].type).eq("issue");
     expect(links[0].url).eq("https://example.org/issues/1");
     expect(links[1].type).eq("tms");
     expect(links[1].url).eq("https://example.org/tasks/2");
+    expect(links[2].type).eq("issue");
+    expect(links[2].url).eq("https://example.org/issues/3");
+    expect(links[3].type).eq("tms");
+    expect(links[3].url).eq("https://example.org/tasks/4");
 
     const tags = results.tests[0].labels.filter((label) => label.name === LabelName.TAG);
     expect(tags).length(1);

--- a/packages/allure-cucumberjs/test/specs/with_links_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_links_test.ts
@@ -24,7 +24,7 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
           "  Rule: c\n" +
           "\n" +
           "    @issue=3 @tms=4\n" +
-          "    Scenario: d\n" +,
+          "    Scenario: d\n" +
           "      Given a step\n" +
           "      When do something\n" +
           "      Then get something\n",

--- a/packages/allure-cucumberjs/test/specs/with_links_test.ts
+++ b/packages/allure-cucumberjs/test/specs/with_links_test.ts
@@ -19,12 +19,25 @@ const dataSet: { [name: string]: ITestFormatterOptions } = {
           "  Scenario: b\n" +
           "    Given a step\n" +
           "    When do something\n" +
-          "    Then get something\n" +
+          "    Then get something\n",
+        uri: "withIssueLink.feature",
+      },
+    ],
+  },
+  withLinksAndRules: {
+    supportCodeLibrary: buildSupportCodeLibrary(({ Given }) => {
+      Given("a step", () => {});
+    }),
+    sources: [
+      {
+        data:
+          "@foo\n" +
+          "Feature: a\n" +
           "\n" +
-          "  Rule: c\n" +
+          "  Rule: r\n" +
           "\n" +
-          "    @issue=3 @tms=4\n" +
-          "    Scenario: d\n" +
+          "    @issue=1 @tms=2\n" +
+          "    Scenario: b\n" +
           "      Given a step\n" +
           "      When do something\n" +
           "      Then get something\n",
@@ -54,15 +67,40 @@ describe("CucumberJSAllureReporter > examples", () => {
 
     const { links } = results.tests[0];
 
-    expect(links).length(4);
+    expect(links).length(2);
     expect(links[0].type).eq("issue");
     expect(links[0].url).eq("https://example.org/issues/1");
     expect(links[1].type).eq("tms");
     expect(links[1].url).eq("https://example.org/tasks/2");
-    expect(links[2].type).eq("issue");
-    expect(links[2].url).eq("https://example.org/issues/3");
-    expect(links[3].type).eq("tms");
-    expect(links[3].url).eq("https://example.org/tasks/4");
+
+    const tags = results.tests[0].labels.filter((label) => label.name === LabelName.TAG);
+    expect(tags).length(1);
+  });
+
+  it("should add links when scenario is inside a rule", async () => {
+    const results = await runFeatures(dataSet.withLinksAndRules, {
+      links: [
+        {
+          pattern: [/@issue=(.*)/],
+          urlTemplate: "https://example.org/issues/%s",
+          type: "issue",
+        },
+        {
+          pattern: [/@tms=(.*)/],
+          urlTemplate: "https://example.org/tasks/%s",
+          type: "tms",
+        },
+      ],
+    });
+    expect(results.tests).length(1);
+
+    const { links } = results.tests[0];
+
+    expect(links).length(2);
+    expect(links[0].type).eq("issue");
+    expect(links[0].url).eq("https://example.org/issues/1");
+    expect(links[1].type).eq("tms");
+    expect(links[1].url).eq("https://example.org/tasks/2");
 
     const tags = results.tests[0].labels.filter((label) => label.name === LabelName.TAG);
     expect(tags).length(1);


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Currently, on my Cucumber test repository, we are using the `Rule` keyword to group subscenarios on a `Feature`. However, we noticed that "tags as labels/links" (such as `@severity:critical`, `@issue=3` and `@feature:foo` ) are not being parsed by `Scenario`, only by `Feature`.

**Test outside rule:**
![image](https://github.com/allure-framework/allure-js/assets/56521026/81cbd07c-2118-4c63-a1b4-63d8375dbfca)

**Test inside rule:**
![image](https://github.com/allure-framework/allure-js/assets/56521026/c504604d-2758-45ef-a9a3-ad03610a2d89)

After debugging, we've found out that the report does not parse scenario's labels/links when they are under a `Rule`. I don't know if this is a known problem, but, as a token of gratitude for the open source community, I am sending a PR myself to address this issue if you like it :)

PS: I've updated the tests as well.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
