### PR TITLE
Include suite name in Playwright testCaseId md5 hash (fixes #732)

### DIFF
--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -129,10 +129,9 @@ class AllureReporter implements Reporter {
 
     const nameSuites = suiteTitles.length > 0 ? `${suiteTitles.join(" ")} ` : "";
     const fullName = `${relativeFile}#${nameSuites}${test.title}`;
-    const testCaseIdSource = `${relativeFile}#${test.title}`;
 
     allureTest.fullName = fullName;
-    allureTest.testCaseId = md5(testCaseIdSource);
+    allureTest.testCaseId = md5(fullName);
     this.allureTestCache.set(test, allureTest);
   }
 

--- a/packages/allure-playwright/test/history.spec.ts
+++ b/packages/allure-playwright/test/history.spec.ts
@@ -12,14 +12,14 @@ test("historical data should be fine", async ({ runInlineTest }) => {
       });
       `,
   });
-  const testCaseIdSource = "a.test.ts#test";
+  const fullName = "a.test.ts#nested test";
 
   expect(results.tests).toEqual([
     expect.objectContaining({
       name: "test",
-      fullName: "a.test.ts#nested test",
-      testCaseId: md5(testCaseIdSource),
-      historyId: md5(testCaseIdSource) + ":" + md5("Project:project"),
+      fullName: fullName,
+      testCaseId: md5(fullName),
+      historyId: md5(fullName) + ":" + md5("Project:project"),
     }),
   ]);
 });


### PR DESCRIPTION
Fixes #732 

When the suite name is excluded from the source for the testCaseId hash, tests that are parametrized at the 'test.describe' level erroneously end up with duplicate testCaseIds.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
