### PR TITLE
impr(playwright): disable reporting of attach steps

### DIFF
--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -150,6 +150,10 @@ class AllureReporter implements Reporter {
     if (!this.options.detail && step.category !== "test.step") {
       return;
     }
+    // ignore attach steps since attachments are already in the report
+    if (step.category === "attach") {
+      return;
+    }
     const allureStep = this.ensureAllureStepCreated(step, allureTest);
     const name = allureStep.wrappedItem?.name;
     if (name?.match(stepAttachRegexp)) {

--- a/packages/allure-playwright/test/attachment-steps.spec.ts
+++ b/packages/allure-playwright/test/attachment-steps.spec.ts
@@ -68,3 +68,49 @@ test("should add attachments into steps", async ({ runInlineTest }) => {
   ] as string;
   expect(Buffer.from(content2, "base64").toString()).toEqual("other-data");
 });
+
+test("should not report detail steps for attachments", async ({ runInlineTest }) => {
+  const results = await runInlineTest({
+    "a.test.ts": /* ts */ `
+      import test from '@playwright/test';
+      import { allure } from '../../dist/index'
+      test('should add attachment', async ({}, testInfo) => {
+        await test.step('outer step 1', async () => {
+          await test.step('inner step 1.1', async () => {
+            await allure.attachment('some', 'some-data', 'text/plain');
+          });
+          await test.step('inner step 1.2', async () => {
+          });
+        });
+        await test.step('outer step 2', async () => {
+          await test.step('inner step 2.1', async () => {
+          });
+          await test.step('inner step 2.2', async () => {
+            await allure.attachment('some', 'other-data', 'text/plain');
+          });
+        });
+      });
+    `,
+    reporterOptions: JSON.stringify({ detail: true }),
+  });
+  const testResult = results.tests[0];
+
+  expect(testResult.steps[1].name).toBe("outer step 1");
+  expect(testResult.steps[1].steps[0].name).toBe("inner step 1.1");
+  expect(testResult.steps[1].steps[0].steps[0].name).toBe("some");
+
+  expect(testResult.steps[1].steps[0].steps[0].attachments).toEqual([
+    expect.objectContaining({ name: "some", type: "text/plain" }),
+  ]);
+  expect(testResult.steps[1].steps[0].steps[0].steps).toHaveLength(0);
+
+  expect(testResult.steps[2].name).toBe("outer step 2");
+  expect(testResult.steps[2].steps[1].name).toBe("inner step 2.2");
+  expect(testResult.steps[2].steps[1].steps[0].name).toBe("some");
+
+  expect(testResult.steps[2].steps[1].steps[0].attachments).toEqual([
+    expect.objectContaining({ name: "some", type: "text/plain" }),
+  ]);
+
+  expect(testResult.steps[2].steps[1].steps[0].steps).toHaveLength(0);
+});


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

When the `detail: true` option is set, Allure logs the `attach` steps. But since we already have attachments in the report such messages are nothing but noise. The proposed change disables reporting of `attach` steps completely.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2