### PR TITLE
Add ability to configure jest reporter

### DIFF
--- a/packages/allure-jest/README.md
+++ b/packages/allure-jest/README.md
@@ -21,6 +21,9 @@ If you're using `jest` for testing `node` add following line to your `jest.confi
 /** @type {import('jest').Config} */
 const config = {
 +  testEnvironment: "allure-jest/node",
++  testEnvironmentOptions: {
++    resultsDir: "./allure-results"
++  }
 }
 
 module.exports = config
@@ -32,6 +35,9 @@ If you're using `jest` for testing browser code (`jsdom`) add next to your `jest
 /** @type {import('jest').Config} */
 const config = {
 +  testEnvironment: "allure-jest/jsdom",
++  testEnvironmentOptions: {
++    resultsDir: "./allure-results"
++  }
 }
 
 module.exports = config

--- a/packages/allure-jest/src/AllureJest.ts
+++ b/packages/allure-jest/src/AllureJest.ts
@@ -21,6 +21,10 @@ export interface AllureEnvironment extends JestEnvironment {
   handleAllureMetadata(payload: { currentTestName: string; metadata: MetadataMessage }): void;
 }
 
+export interface AllureEnvironmentConfig extends JestEnvironmentConfig {
+  resultsDir?: string;
+}
+
 const createJestEnvironment = <T extends typeof JestEnvironment>(Base: T): T => {
   // @ts-expect-error (ts(2545)) Incorrect assumption about a mixin class: https://github.com/microsoft/TypeScript/issues/37142
   return class extends Base {
@@ -28,12 +32,11 @@ const createJestEnvironment = <T extends typeof JestEnvironment>(Base: T): T => 
     runtime: AllureRuntime;
     runningTests: Map<string, AllureTest> = new Map();
 
-    constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    constructor(config: AllureEnvironmentConfig, context: EnvironmentContext) {
       super(config, context);
 
       this.runtime = new AllureRuntime({
-        // TODO: configure it later
-        resultsDir: "allure-results",
+        resultsDir: config.resultsDir || "allure-results",
       });
       this.global.allure = new AllureJestApi(this, this.global);
       this.testRootDirPath = config.projectConfig.rootDir;


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

Provides `resultsDir` configuration for jest reporter

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Now it's impossible to configure anything for jest reporter, but some options, like `resultsDir` are critical and should be available for users 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
