### PR TITLE
[newman-reporter-allure] Fix: Resolved the issue of formatting in JSON response content displaying in Allure reports.

### DIFF
--- a/packages/newman-reporter-allure/src/index.ts
+++ b/packages/newman-reporter-allure/src/index.ts
@@ -419,13 +419,18 @@ class AllureReporter {
     }
 
     if (response?.body) {
+      const contentTypeHeader = response.headers?.get("Content-Type") || "";
+      const isJsonResponse = /application\/json/i.test(contentTypeHeader);
+
+      const contentType = isJsonResponse ? ContentType.JSON : ContentType.TEXT;
+
       const attachment = this.allureRuntime.writeAttachment(response.body, {
-        contentType: ContentType.TEXT,
+      contentType: contentType,
       });
 
       this.currentExecutable.addAttachment(
         "Response Body",
-        { contentType: ContentType.TEXT },
+        { contentType: contentType },
         attachment,
       );
     }

--- a/packages/newman-reporter-allure/src/index.ts
+++ b/packages/newman-reporter-allure/src/index.ts
@@ -419,20 +419,29 @@ class AllureReporter {
     }
 
     if (response?.body) {
-      const contentTypeHeader = response.headers?.get("Content-Type") || "";
-      const isJsonResponse = /application\/json/i.test(contentTypeHeader);
+      const contentTypeHeader = response.headers || "";
 
-      const contentType = isJsonResponse ? ContentType.JSON : ContentType.TEXT;
+      if (/application\/json/i.test(contentTypeHeader)) {
+        const attachment = this.allureRuntime.writeAttachment(response.body, {
+          contentType: ContentType.JSON,
+        });
 
-      const attachment = this.allureRuntime.writeAttachment(response.body, {
-      contentType: contentType,
-      });
+        this.currentExecutable.addAttachment(
+          "Response Body",
+          { contentType: ContentType.JSON },
+          attachment,
+        );
+      } else {
+        const attachment = this.allureRuntime.writeAttachment(response.body, {
+          contentType: ContentType.TEXT,
+        });
 
-      this.currentExecutable.addAttachment(
-        "Response Body",
-        { contentType: contentType },
-        attachment,
-      );
+        this.currentExecutable.addAttachment(
+          "Response Body",
+          { contentType: ContentType.TEXT },
+          attachment,
+        );
+      }
     }
 
     const failedAssertions = this.currentRunningItem?.pmItem.failedAssertions;


### PR DESCRIPTION
**Context**
When the `Content-Type` of a response body is `application/json`, the formatting should be normal.

**Screenshot**
Postman:
![image](https://github.com/allure-framework/allure-js/assets/56353753/a8cca1fa-0218-4473-9ad4-0db3dbb6956f)
Postman Response body:
![image](https://github.com/allure-framework/allure-js/assets/56353753/2f411c05-7c85-46ac-8482-118f3ed07893)

Allure report (anonymised for privacy):
![image](https://github.com/allure-framework/allure-js/assets/56353753/f423b33a-beb5-4607-a1b7-8a9512a81b92)



#### Checklist
- [X] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
