### PR TITLE
feat(allure-jest): Add ability to assign custom names for any attachments (feat #801)

### DIFF
--- a/packages/allure-jest/src/AllureJestApi.ts
+++ b/packages/allure-jest/src/AllureJestApi.ts
@@ -65,7 +65,7 @@ export class AllureJestApi implements AllureRuntimeApiInterface {
     this.sendMetadata({
       attachments: [
         {
-          name: name ? name: "Attachment",
+          name: name ? name : "Attachment",
           content: isBuffer ? content.toString("base64") : content,
           encoding: isBuffer ? "base64" : "utf8",
           type,

--- a/packages/allure-jest/src/AllureJestApi.ts
+++ b/packages/allure-jest/src/AllureJestApi.ts
@@ -59,13 +59,13 @@ export class AllureJestApi implements AllureRuntimeApiInterface {
     });
   }
 
-  attachment(content: string | Buffer, type: string): void {
+  attachment(content: string | Buffer, type: string, name?: string): void {
     const isBuffer = Buffer.isBuffer(content);
 
     this.sendMetadata({
       attachments: [
         {
-          name: "Attachment",
+          name: name ? name: "Attachment",
           content: isBuffer ? content.toString("base64") : content,
           encoding: isBuffer ? "base64" : "utf8",
           type,

--- a/packages/allure-jest/src/AllureJestApi.ts
+++ b/packages/allure-jest/src/AllureJestApi.ts
@@ -65,7 +65,7 @@ export class AllureJestApi implements AllureRuntimeApiInterface {
     this.sendMetadata({
       attachments: [
         {
-          name: name ? name : "Attachment",
+          name: name || "Attachment",
           content: isBuffer ? content.toString("base64") : content,
           encoding: isBuffer ? "base64" : "utf8",
           type,

--- a/packages/allure-jest/test/fixtures/attachments.test.js
+++ b/packages/allure-jest/test/fixtures/attachments.test.js
@@ -1,3 +1,7 @@
 it("json", () => {
   allure.attachment(JSON.stringify({ foo: "bar" }), "application/json");
 });
+
+it("name", () => {
+  allure.attachment(JSON.stringify({ foo: "bar" }), "application/json", 'Request Body');
+});

--- a/packages/allure-jest/test/fixtures/attachments.test.js
+++ b/packages/allure-jest/test/fixtures/attachments.test.js
@@ -2,6 +2,6 @@ it("json", () => {
   allure.attachment(JSON.stringify({ foo: "bar" }), "application/json");
 });
 
-it("name", () => {
+it("with name", () => {
   allure.attachment(JSON.stringify({ foo: "bar" }), "application/json", "Request Body");
 });

--- a/packages/allure-jest/test/fixtures/attachments.test.js
+++ b/packages/allure-jest/test/fixtures/attachments.test.js
@@ -3,5 +3,5 @@ it("json", () => {
 });
 
 it("name", () => {
-  allure.attachment(JSON.stringify({ foo: "bar" }), "application/json", 'Request Body');
+  allure.attachment(JSON.stringify({ foo: "bar" }), "application/json", "Request Body");
 });

--- a/packages/allure-jest/test/spec/attachments.test.ts
+++ b/packages/allure-jest/test/spec/attachments.test.ts
@@ -18,4 +18,15 @@ describe("attachments", () => {
       }),
     );
   });
+
+  it("adds markdown description with name", () => {
+    const { attachments } = results.name;
+
+    expect(attachments).toContainEqual(
+      expect.objectContaining({
+        name: "Request Body",
+        type: "application/json",
+      }),
+    );
+  });
 });

--- a/packages/allure-jest/test/spec/attachments.test.ts
+++ b/packages/allure-jest/test/spec/attachments.test.ts
@@ -20,7 +20,7 @@ describe("attachments", () => {
   });
 
   it("adds markdown description with name", () => {
-    const { attachments } = results.name;
+    const { attachments } = results["with name"];
 
     expect(attachments).toContainEqual(
       expect.objectContaining({

--- a/packages/allure-js-commons/src/AllureTest.ts
+++ b/packages/allure-js-commons/src/AllureTest.ts
@@ -146,7 +146,7 @@ export class AllureTest extends ExecutableItemWrapper {
       );
 
       this.addAttachment(
-        "Attachment",
+        attachment.name,
         {
           contentType: attachment.type,
         },


### PR DESCRIPTION
### Context

Add ability to assign custom names for any attachments #801


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2

