### PR TITLE
Change plain logos in the README files into URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 > This project aggregates Allure Javascript commons and reporters.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 > This project aggregates Allure Javascript commons and reporters.
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-codeceptjs/README.md
+++ b/packages/allure-codeceptjs/README.md
@@ -2,7 +2,11 @@
 
 > Allure framework integration for CodeceptJS
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report
@@ -19,7 +23,7 @@ npm i -D allure-codeceptjs
 ```
 
 ## Usage
-Add the allure plugin inside you plugins section of your CodeceptJS config file. 
+Add the allure plugin inside you plugins section of your CodeceptJS config file.
 For instance the config file is `codecept.config.(js|ts)` then:
 ```
   plugins: {

--- a/packages/allure-codeceptjs/README.md
+++ b/packages/allure-codeceptjs/README.md
@@ -2,11 +2,7 @@
 
 > Allure framework integration for CodeceptJS
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-cucumberjs/README.md
+++ b/packages/allure-cucumberjs/README.md
@@ -2,11 +2,7 @@
 
 > Allure integration for `cucumber-js` compatible with `@cucumber/cucumber@^8.x.x` and Allure 2+.
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-cucumberjs/README.md
+++ b/packages/allure-cucumberjs/README.md
@@ -1,8 +1,12 @@
 # allure-cucumberjs
 
 > Allure integration for `cucumber-js` compatible with `@cucumber/cucumber@^8.x.x` and Allure 2+.
- 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-decorators/README.md
+++ b/packages/allure-decorators/README.md
@@ -2,11 +2,7 @@
 
 > Testdeck decorators integration for Allure framework
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-decorators/README.md
+++ b/packages/allure-decorators/README.md
@@ -2,7 +2,11 @@
 
 > Testdeck decorators integration for Allure framework
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report
@@ -129,14 +133,14 @@ You should pay attention to the following line:
 decorate<MochaAllure>(allure)
 ```
 
-To be able to use decorators, you have to call `decorate` function explicitly and set your reporter's instance in `before` hook. This was done intentionally to allow clients decide which reporter they want to use with decorators module.  
+To be able to use decorators, you have to call `decorate` function explicitly and set your reporter's instance in `before` hook. This was done intentionally to allow clients decide which reporter they want to use with decorators module.
 
 Note that `data` is a [testdeck](https://github.com/testdeck/testdeck) specific extension which allows injecting parameters into Allure scope.
 At the moment, **testdeck** supports only Mocha, Jest and Jasmine frameworks.
-If you want to add the other integration, feel free to contact Allure team to discuss the potential design options. 
+If you want to add the other integration, feel free to contact Allure team to discuss the potential design options.
 
 
 #### ToDo
 
-- [ ] Update [mocha-allure2-example](https://github.com/sskorol/mocha-allure2-example) with new `allure-decorators` dependency.   
+- [ ] Update [mocha-allure2-example](https://github.com/sskorol/mocha-allure2-example) with new `allure-decorators` dependency.
 - [ ] Explore potential `data` decorator extension for the other frameworks.

--- a/packages/allure-hermione/README.md
+++ b/packages/allure-hermione/README.md
@@ -2,11 +2,7 @@
 
 > Allure integration for `hermione@^5.x.x` and above
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-hermione/README.md
+++ b/packages/allure-hermione/README.md
@@ -2,7 +2,11 @@
 
 > Allure integration for `hermione@^5.x.x` and above
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-jasmine/README.md
+++ b/packages/allure-jasmine/README.md
@@ -2,7 +2,11 @@
 
 > Allure integration Jasmine framework
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-jasmine/README.md
+++ b/packages/allure-jasmine/README.md
@@ -2,11 +2,7 @@
 
 > Allure integration Jasmine framework
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-jest/README.md
+++ b/packages/allure-jest/README.md
@@ -2,7 +2,11 @@
 
 > Allure framework integration for Jest
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-jest/README.md
+++ b/packages/allure-jest/README.md
@@ -2,11 +2,7 @@
 
 > Allure framework integration for Jest
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-js-commons/README.md
+++ b/packages/allure-js-commons/README.md
@@ -2,11 +2,7 @@
 
 > Common utilities for Allure framework JavaScript integrations
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-js-commons/README.md
+++ b/packages/allure-js-commons/README.md
@@ -2,7 +2,11 @@
 
 > Common utilities for Allure framework JavaScript integrations
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-mocha/README.md
+++ b/packages/allure-mocha/README.md
@@ -2,7 +2,11 @@
 
 > Allure framewok integration for Mocha framework
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-mocha/README.md
+++ b/packages/allure-mocha/README.md
@@ -2,11 +2,7 @@
 
 > Allure framewok integration for Mocha framework
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -2,7 +2,11 @@
 
 > Allure framework integration for [Playwright Test](https://playwright.dev) framework
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -2,11 +2,7 @@
 
 > Allure framework integration for [Playwright Test](https://playwright.dev) framework
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/newman-reporter-allure/README.md
+++ b/packages/newman-reporter-allure/README.md
@@ -2,7 +2,11 @@
 
 > A newman reporter for generating nice and clean report using Allure framework
 
-<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
+  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
+</picture>
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report

--- a/packages/newman-reporter-allure/README.md
+++ b/packages/newman-reporter-allure/README.md
@@ -2,11 +2,7 @@
 
 > A newman reporter for generating nice and clean report using Allure framework
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <source media="(prefers-color-scheme: light)" srcset="https://allurereport.org/public/img/allure-report.svg">
-  <img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />
-</picture>
+[<img src="https://allurereport.org/public/img/allure-report.svg" height="85px" alt="Allure Report logo" align="right" />](https://allurereport.org "Allure Report")
 
 - Learn more about Allure Report at https://allurereport.org
 - 📚 [Documentation](https://allurereport.org/docs/) – discover official documentation for Allure Report


### PR DESCRIPTION
The PR wraps each Allure logo in the README files in the URL of allurereport.org.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure2
