### PR TITLE
[Vitest] Use actual test duration

### DIFF
--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -167,15 +167,7 @@ export default class AllureReporter implements Reporter {
       }
     }
 
-    const actualDuration = task.result
-      ? Math.max(0, task.file.collectDuration || 0) +
-        Math.max(0, task.file.setupDuration || 0) +
-        Math.max(0, task.result?.duration || 0) +
-        Math.max(0, task.file.environmentLoad || 0) +
-        Math.max(0, task.file.prepareDuration || 0)
-      : 0;
-
     test.calculateHistoryId();
-    test.endTest(task.result.startTime + actualDuration);
+    test.endTest(task.result.startTime + task.result?.duration || 0);
   }
 }


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
fixes #899
<!---
Describe the problem or feature in addition to a link to the issues
-->

I decided to get rid of the complicated logic of test duration calculation in favour of native test duration.

**Vitest output**

<img width="973" alt="image" src="https://github.com/allure-framework/allure-js/assets/13414205/44d46424-d337-4636-9cbf-17a70f36ac0d">

**Allure report**

<img width="1399" alt="image" src="https://github.com/allure-framework/allure-js/assets/13414205/3c057c90-21db-480c-9cb6-204f5bd26925">


#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
