### PR TITLE
Back compatibility with old style jasmine runtime API

### DIFF
--- a/packages/allure-jasmine/README.md
+++ b/packages/allure-jasmine/README.md
@@ -19,7 +19,7 @@ For usage example see `test/Setup.ts`
 Use your favorite node package manager to install required packages:
 
 ```bash
-npm add -D jest-jasmine2 allure-jasmine allure-js-commons @types/jasmine
+npm add -D jest-jasmine2 allure-jasmine @types/jasmine
 ```
 
 Create `allure-setup.ts` file:

--- a/packages/allure-jasmine/README.md
+++ b/packages/allure-jasmine/README.md
@@ -12,43 +12,109 @@
 
 ---
 
-For usage example see `test/Setup.ts`
-
-## Usage with Jest (`jest@<27`)
+## Installation
 
 Use your favorite node package manager to install required packages:
 
 ```bash
-npm add -D jest-jasmine2 allure-jasmine @types/jasmine
+npm add -D allure-jasmine
 ```
 
-Create `allure-setup.ts` file:
+Create `spec/helpers/setup.ts` file with following content:
 
 ```ts
-import { JasmineAllureReporter } from "allure-jasmine";
-import { JasmineAllureInterface } from "allure-jasmine/dist/src/JasmineAllureReporter";
+const AllureJasmineReporter = require("allure-jasmine");
 
-const reporter = new JasmineAllureReporter({ resultsDir: "allure-results" });
+const reporter = new AllureJasmineReporter();
 
 jasmine.getEnv().addReporter(reporter);
-// @ts-expect-error
-global.allure = reporter.getInterface();
-
-declare global {
-  const allure: JasmineAllureInterface;
-}
 ```
 
-Change your `jest.config.js` file:
+Check that the helper matches with `helper` field in your `spec/support/jasmine.json` file.
+
+## Use Allure runtime Api
+
+The plugin provides custom commands which allow to add additional info inside your tests:
+
+```javascript
+import { epic, attachment, parameter } from "allure-js-commons";
+
+it("my test", async () => {
+  await attachment("Attachment name", "Hello world!", "text/plain");
+  await epic("my_epic");
+  await parameter("parameter_name", "parameter_value", {
+    mode: "hidden",
+    excluded: false,
+  });
+});
+```
+
+## Links usage
 
 ```js
-module.exports = {
-  preset: "ts-jest",
-+  testRunner: "jest-jasmine2",
-+  setupFilesAfterEnv: ["./allure-setup.ts"],
-};
+import { link, issue, tms } from "allure-js-commons";
+
+it("basic test", async () => {
+  await link("https://allurereport.org", "link type", "Allure Report");
+  await issue("https://github.com/allure-framework/allure-js/issues/352", "Issue Name", );
+  await tms("https://github.com/allure-framework/allure-js/tasks/352", "Task Name");
+});
 ```
 
-You can find example setup and usage in this [repo](https://github.com/vovsemenv/allure-jest-example)
+You can also configure links formatters to make usage much more convenient. `%s`
+in `urlTemplate` parameter will be replaced by given value.
 
-[allure-jest]: https://github.com/allure-framework/allure-js/tree/master/packages/allure-jest
+```diff
+```ts
+const AllureJasmineReporter = require("allure-jasmine");
+
+const reporter = new AllureJasmineReporter({
++  links: [
++    {
++      type: "issue",
++      urlTemplate: "https://example.org/issues/%s"
++    },
++    {
++      type: "tms",
++      urlTemplate: "https://example.org/tasks/%s"
++    },
++    {
++      type: "custom",
++      urlTemplate: "https://example.org/custom/%s"
++    },
++  ],
+});
+
+jasmine.getEnv().addReporter(reporter);
+```
+
+Then you can assign link using shorter notation:
+
+```js
+import { link, issue, tms } from "allure-js-commons";
+
+it("basic test", async () => {
+  await issue("351");
+  await issue("352", "Issue Name");
+  await tms("351");
+  await tms("352", "Task Name");
+  await link("custom", "352");
+  await link("custom", "352", "Link name");
+});
+```
+
+## Steps usage
+
+The integration supports Allure steps, use them in following way:
+
+```js
+import { step } from "allure-js-commons";
+
+it("my test", async () => {
+  await step("foo", async () => {
+    await step("bar", async () => {
+      await step("baz", async () => {});
+    });
+  });
+});
+```

--- a/packages/allure-jasmine/src/index.ts
+++ b/packages/allure-jasmine/src/index.ts
@@ -1,4 +1,5 @@
 import { cwd } from "node:process";
+import * as allure from "allure-js-commons";
 import {
   AllureNodeReporterRuntime,
   ContentType,
@@ -20,7 +21,6 @@ import {
   isPromise,
   setGlobalTestRuntime,
 } from "allure-js-commons/sdk/node";
-import * as allure from "allure-js-commons";
 import { AllureJasmineConfig, JasmineBeforeAfterFn } from "./model.js";
 import { findAnyError, findMessageAboutThrow } from "./utils.js";
 

--- a/packages/allure-jasmine/src/index.ts
+++ b/packages/allure-jasmine/src/index.ts
@@ -20,6 +20,7 @@ import {
   isPromise,
   setGlobalTestRuntime,
 } from "allure-js-commons/sdk/node";
+import * as allure from "allure-js-commons";
 import { AllureJasmineConfig, JasmineBeforeAfterFn } from "./model.js";
 import { findAnyError, findMessageAboutThrow } from "./utils.js";
 
@@ -243,6 +244,10 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
     const specPath = this.getCurrentSpecPath().concat(spec.description).join(" > ");
 
     return `${specFilename}#${specPath}`;
+  }
+
+  getAllureInterface() {
+    return allure;
   }
 
   handleAllureRuntimeMessages(message: RuntimeMessage) {

--- a/packages/allure-jasmine/test/fixtures/spec/helpers/legacy/allure.cjs
+++ b/packages/allure-jasmine/test/fixtures/spec/helpers/legacy/allure.cjs
@@ -1,0 +1,51 @@
+const { LinkType, Status } = require("allure-js-commons/sdk/node");
+
+const fixture = `
+  const AllureJasmineReporter = require("allure-jasmine");
+
+  const reporter = new AllureJasmineReporter({
+    testMode: true,
+    links: [
+      {
+        type: "${LinkType.ISSUE}",
+        urlTemplate: "https://example.org/issues/%s",
+      },
+      {
+        type: "${LinkType.TMS}",
+        urlTemplate: "https://example.org/tasks/%s",
+      }
+    ],
+    categories: [
+      {
+        name: "Sad tests",
+        messageRegex: /.*Sad.*/,
+        matchedStatuses: ["${Status.FAILED}"],
+      },
+      {
+        name: "Infrastructure problems",
+        messageRegex: ".*RuntimeException.*",
+        matchedStatuses: ["${Status.BROKEN}"],
+      },
+      {
+        name: "Outdated tests",
+        messageRegex: ".*FileNotFound.*",
+        matchedStatuses: ["${Status.BROKEN}"],
+      },
+      {
+        name: "Regression",
+        messageRegex: ".*\\sException:.*",
+        matchedStatuses: ["${Status.BROKEN}"],
+      },
+    ],
+    environmentInfo: {
+      envVar1: "envVar1Value",
+      envVar2: "envVar2Value",
+    },
+  });
+
+  jasmine.getEnv().addReporter(reporter);
+
+  module.exports = { allure: reporter.getAllureInterface() };
+`;
+
+module.exports = fixture;

--- a/packages/allure-jasmine/test/fixtures/spec/helpers/modern/allure.cjs
+++ b/packages/allure-jasmine/test/fixtures/spec/helpers/modern/allure.cjs
@@ -1,0 +1,49 @@
+const { LinkType, Status } = require("allure-js-commons/sdk/node");
+
+const fixture = `
+  const AllureJasmineReporter = require("allure-jasmine");
+
+  const reporter = new AllureJasmineReporter({
+    testMode: true,
+    links: [
+      {
+        type: "${LinkType.ISSUE}",
+        urlTemplate: "https://example.org/issues/%s",
+      },
+      {
+        type: "${LinkType.TMS}",
+        urlTemplate: "https://example.org/tasks/%s",
+      }
+    ],
+    categories: [
+      {
+        name: "Sad tests",
+        messageRegex: /.*Sad.*/,
+        matchedStatuses: ["${Status.FAILED}"],
+      },
+      {
+        name: "Infrastructure problems",
+        messageRegex: ".*RuntimeException.*",
+        matchedStatuses: ["${Status.BROKEN}"],
+      },
+      {
+        name: "Outdated tests",
+        messageRegex: ".*FileNotFound.*",
+        matchedStatuses: ["${Status.BROKEN}"],
+      },
+      {
+        name: "Regression",
+        messageRegex: ".*\\sException:.*",
+        matchedStatuses: ["${Status.BROKEN}"],
+      },
+    ],
+    environmentInfo: {
+      envVar1: "envVar1Value",
+      envVar2: "envVar2Value",
+    },
+  });
+
+  jasmine.getEnv().addReporter(reporter);
+`;
+
+module.exports = fixture;

--- a/packages/allure-jasmine/test/fixtures/spec/support/jasmine.json
+++ b/packages/allure-jasmine/test/fixtures/spec/support/jasmine.json
@@ -1,0 +1,13 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.?(m)js"
+  ],
+  "helpers": [
+    "helpers/**/*.?(m)js"
+  ],
+  "env": {
+    "stopSpecOnExpectationFailure": false,
+    "random": true
+  }
+}

--- a/packages/allure-jasmine/test/spec/runtime/legacy/attachments.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/attachments.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "vitest";
+import { Status, LinkType } from "allure-js-commons/sdk/node";
+import { resolve } from "node:path";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("handles json attachment", async () => {
+  const { tests, attachments } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { allure } = require("../helpers/allure");
+
+    it("json", async () => {
+      await allure.attachment("Request body", JSON.stringify({ foo: "bar" }), "application/json");
+    });
+  `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].attachments).toHaveLength(1);
+
+  const [attachment] = tests[0].attachments;
+
+  expect(attachment.name).toBe("Request body");
+  expect(Buffer.from(attachments[attachment.source] as string, "base64").toString("utf8")).toBe(
+    JSON.stringify({ foo: "bar" }),
+  );
+});

--- a/packages/allure-jasmine/test/spec/runtime/legacy/attachments.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/attachments.test.ts
@@ -1,6 +1,6 @@
-import { expect, it } from "vitest";
-import { Status, LinkType } from "allure-js-commons/sdk/node";
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
+import { expect, it } from "vitest";
 import { runJasmineInlineTest } from "../../../utils";
 
 it("handles json attachment", async () => {

--- a/packages/allure-jasmine/test/spec/runtime/legacy/description.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/description.test.ts
@@ -1,5 +1,6 @@
-import { expect, it } from "vitest";
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
+import { expect, it } from "vitest";
 import { runJasmineInlineTest } from "../../../utils";
 
 it("sets description", async () => {

--- a/packages/allure-jasmine/test/spec/runtime/legacy/description.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/description.test.ts
@@ -1,15 +1,17 @@
 import { expect, it } from "vitest";
-import { runJasmineInlineTest } from "../utils";
+import { resolve } from "node:path";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("sets description", async () => {
   const { tests } = await runJasmineInlineTest({
     "spec/test/sample.spec.js": `
-      const { description } = require("allure-js-commons");
+      const { allure } = require("../helpers/allure");
 
       it("description", async () => {
-        await description("foo");
+        await allure.description("foo");
       })
     `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -19,12 +21,13 @@ it("sets description", async () => {
 it("sets html description", async () => {
   const { tests } = await runJasmineInlineTest({
     "spec/test/sample.spec.js": `
-      const { descriptionHtml } = require("allure-js-commons");
+      const { allure } = require("../helpers/allure");
 
       it("descriptionHtml", async () => {
-        await descriptionHtml("foo");
+        await allure.descriptionHtml("foo");
       })
     `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);

--- a/packages/allure-jasmine/test/spec/runtime/legacy/historyId.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/historyId.test.ts
@@ -1,0 +1,19 @@
+import { resolve } from "node:path";
+import { expect, it } from "vitest";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("sets historyId", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { allure } = require("../helpers/allure");
+
+      it("historyId", async () => {
+        await allure.historyId("foo");
+      })
+    `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].historyId).toBe("foo");
+});

--- a/packages/allure-jasmine/test/spec/runtime/legacy/historyId.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/historyId.test.ts
@@ -1,3 +1,4 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { runJasmineInlineTest } from "../../../utils";

--- a/packages/allure-jasmine/test/spec/runtime/legacy/labels.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/labels.test.ts
@@ -1,6 +1,7 @@
+import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { LabelName } from "allure-js-commons";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("sets labels", async () => {
   const { tests } = await runJasmineInlineTest({
@@ -37,6 +38,7 @@ it("sets labels", async () => {
         await labels({ name: "test", value: "testValue" }, { name: "test2", value: "testValue2" });
       })
     `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);

--- a/packages/allure-jasmine/test/spec/runtime/legacy/labels.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/labels.test.ts
@@ -1,3 +1,4 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { LabelName } from "allure-js-commons";

--- a/packages/allure-jasmine/test/spec/runtime/legacy/links.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/links.test.ts
@@ -1,3 +1,4 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { LinkType } from "allure-js-commons";

--- a/packages/allure-jasmine/test/spec/runtime/legacy/links.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/links.test.ts
@@ -1,6 +1,7 @@
+import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { LinkType } from "allure-js-commons";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("sets links", async () => {
   const { tests } = await runJasmineInlineTest({
@@ -16,6 +17,7 @@ it("sets links", async () => {
         await links(...[{ url:"https://allurereport.org/1" }, { url:"https://allurereport.org/2" }]);
       })
     `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);

--- a/packages/allure-jasmine/test/spec/runtime/legacy/parameters.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/parameters.test.ts
@@ -1,0 +1,41 @@
+import { expect, it } from "vitest";
+import { runJasmineInlineTest } from "../../../utils";
+import { resolve } from "node:path";
+
+it("sets parameters", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { parameter } = require("allure-js-commons");
+
+      it("parameter", async () => {
+        await parameter("param1", "paramValue1");
+        await parameter("param2", "paramValue2", {excluded:true});
+        await parameter("param3", "paramValue3", {mode:"masked", excluded:true});
+        await parameter("param4", "paramValue4", {mode:"hidden"});
+      })
+    `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        parameters: [
+          { name: "param1", value: "paramValue1" },
+          { excluded: true, name: "param2", value: "paramValue2" },
+          { excluded: true, mode: "masked", name: "param3", value: "paramValue3" },
+          { mode: "hidden", name: "param4", value: "paramValue4" },
+        ],
+      }),
+      expect.objectContaining({
+        parameters: [
+          { name: "param1", value: "paramValue1" },
+          { excluded: true, name: "param2", value: "paramValue2" },
+          { excluded: true, mode: "masked", name: "param3", value: "paramValue3" },
+          { mode: "hidden", name: "param4", value: "paramValue4" },
+        ],
+      }),
+    ]),
+  );
+});

--- a/packages/allure-jasmine/test/spec/runtime/legacy/parameters.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/parameters.test.ts
@@ -1,6 +1,7 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
+import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { runJasmineInlineTest } from "../../../utils";
-import { resolve } from "node:path";
 
 it("sets parameters", async () => {
   const { tests } = await runJasmineInlineTest({

--- a/packages/allure-jasmine/test/spec/runtime/legacy/steps.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/steps.test.ts
@@ -1,3 +1,4 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { Status } from "allure-js-commons";

--- a/packages/allure-jasmine/test/spec/runtime/legacy/steps.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/steps.test.ts
@@ -1,6 +1,7 @@
+import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { Status } from "allure-js-commons";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("single step", async () => {
   const { tests } = await runJasmineInlineTest({
@@ -13,6 +14,7 @@ it("single step", async () => {
       });
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -40,6 +42,7 @@ it("multiple steps", async () => {
       });
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -67,6 +70,7 @@ it("nested steps", async () => {
       });
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -90,6 +94,7 @@ it("step with attachments", async () => {
       })
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -120,6 +125,7 @@ it("step with assertion error", async () => {
       });
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -165,6 +171,7 @@ it("step with unexpected error", async () => {
       });
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);
@@ -208,6 +215,7 @@ it("step runtime api", async () => {
       });
     });
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);

--- a/packages/allure-jasmine/test/spec/runtime/legacy/testCaseId.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/testCaseId.test.ts
@@ -1,5 +1,6 @@
+import { resolve } from "node:path";
 import { expect, it } from "vitest";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("sets testCaseId", async () => {
   const { tests } = await runJasmineInlineTest({
@@ -10,6 +11,7 @@ it("sets testCaseId", async () => {
       await testCaseId("foo");
     })
   `,
+    "spec/helpers/allure.js": require(resolve(__dirname, "../../../fixtures/spec/helpers/legacy/allure.cjs")),
   });
 
   expect(tests).toHaveLength(1);

--- a/packages/allure-jasmine/test/spec/runtime/legacy/testCaseId.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/legacy/testCaseId.test.ts
@@ -1,3 +1,4 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { resolve } from "node:path";
 import { expect, it } from "vitest";
 import { runJasmineInlineTest } from "../../../utils";

--- a/packages/allure-jasmine/test/spec/runtime/modern/attachments.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/attachments.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("handles json attachment", async () => {
   const { tests, attachments } = await runJasmineInlineTest({

--- a/packages/allure-jasmine/test/spec/runtime/modern/description.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/description.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from "vitest";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("sets description", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { description } = require("allure-js-commons");
+
+      it("description", async () => {
+        await description("foo");
+      })
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].description).toBe("foo");
+});
+
+it("sets html description", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { descriptionHtml } = require("allure-js-commons");
+
+      it("descriptionHtml", async () => {
+        await descriptionHtml("foo");
+      })
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].descriptionHtml).toBe("foo");
+});

--- a/packages/allure-jasmine/test/spec/runtime/modern/historyId.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/historyId.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("sets historyId", async () => {
   const { tests } = await runJasmineInlineTest({

--- a/packages/allure-jasmine/test/spec/runtime/modern/labels.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/labels.test.ts
@@ -1,0 +1,57 @@
+import { expect, it } from "vitest";
+import { LabelName } from "allure-js-commons";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("sets labels", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const {
+        label,
+        labels,
+        feature,
+        allureId,
+        epic,
+        layer,
+        owner,
+        parentSuite,
+        suite,
+        subSuite,
+        severity,
+        story,
+        tag,
+      } = require("allure-js-commons");
+
+      it("label", async () => {
+        await label("foo", "bar");
+        await allureId("foo");
+        await epic("foo");
+        await feature("foo");
+        await layer("foo");
+        await owner("foo");
+        await parentSuite("foo");
+        await subSuite("foo");
+        await suite("foo");
+        await severity("foo");
+        await story("foo");
+        await tag("foo");
+        await labels({ name: "test", value: "testValue" }, { name: "test2", value: "testValue2" });
+      })
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: "test", value: "testValue" });
+  expect(tests[0].labels).toContainEqual({ name: "test2", value: "testValue2" });
+});

--- a/packages/allure-jasmine/test/spec/runtime/modern/links.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/links.test.ts
@@ -1,0 +1,53 @@
+import { expect, it } from "vitest";
+import { LinkType } from "allure-js-commons";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("sets links", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { link, links, issue, tms } = require('allure-js-commons/');
+
+      it("link", async () => {
+        await link("https://allurereport.org");
+        await issue("1");
+        await issue("https://example.org/issues/2");
+        await tms("1");
+        await tms("https://example.org/tasks/2");
+        await links(...[{ url:"https://allurereport.org/1" }, { url:"https://allurereport.org/2" }]);
+      })
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests).toEqual([
+    expect.objectContaining({
+      links: [
+        {
+          url: "https://allurereport.org",
+        },
+        {
+          url: "https://example.org/issues/1",
+          type: LinkType.ISSUE,
+        },
+        {
+          url: "https://example.org/issues/2",
+          type: LinkType.ISSUE,
+        },
+        {
+          url: "https://example.org/tasks/1",
+          type: LinkType.TMS,
+        },
+        {
+          url: "https://example.org/tasks/2",
+          type: LinkType.TMS,
+        },
+        {
+          url: "https://allurereport.org/1",
+        },
+        {
+          url: "https://allurereport.org/2",
+        },
+      ],
+    }),
+  ]);
+});

--- a/packages/allure-jasmine/test/spec/runtime/modern/parameters.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/parameters.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { runJasmineInlineTest } from "../utils";
+import { runJasmineInlineTest } from "../../../utils";
 
 it("sets parameters", async () => {
   const { tests } = await runJasmineInlineTest({

--- a/packages/allure-jasmine/test/spec/runtime/modern/steps.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/steps.test.ts
@@ -1,0 +1,226 @@
+import { expect, it } from "vitest";
+import { Status } from "allure-js-commons";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("single step", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { label, step } = require("allure-js-commons");;
+
+    it("step", async () => {
+      await step("foo", async () => {
+        await label("foo", "bar");
+      });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
+  expect(tests[0].steps).toHaveLength(1);
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "foo" }));
+});
+
+it("multiple steps", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { label, step } = require("allure-js-commons");;
+
+    it("step", async () => {
+      await step("foo", async () => {
+        await label("foo", "1");
+      });
+
+      await step("bar", async () => {
+        await label("bar", "2");
+      });
+
+      await step("baz", async () => {
+        await label("baz", "3");
+      });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "1" }));
+  expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "bar", value: "2" }));
+  expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "baz", value: "3" }));
+  expect(tests[0].steps).toHaveLength(3);
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "foo" }));
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "bar" }));
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "baz" }));
+});
+
+it("nested steps", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { label, step } = require("allure-js-commons");;
+
+    it("step", async () => {
+      await step("foo", async () => {
+        await step("bar", async () => {
+           await step("baz", async () => {
+             await label("foo", "bar");
+           });
+        });
+      });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
+  expect(tests[0].steps).toHaveLength(1);
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "foo" }));
+  expect(tests[0].steps[0].steps).toHaveLength(1);
+  expect(tests[0].steps[0].steps).toContainEqual(expect.objectContaining({ name: "bar" }));
+  expect(tests[0].steps[0].steps[0].steps).toHaveLength(1);
+  expect(tests[0].steps[0].steps[0].steps).toContainEqual(expect.objectContaining({ name: "baz" }));
+});
+
+it("step with attachments", async () => {
+  const { tests, attachments } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { attachment, step } = require("allure-js-commons");;
+
+    it("text attachment", async () => {
+      await step("foo", async () => {
+        await attachment("foo.txt", "bar", "text/plain");
+      })
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].attachments).toHaveLength(0);
+  expect(tests[0].steps).toHaveLength(1);
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "foo" }));
+
+  const [attachment] = tests[0].steps[0].attachments;
+
+  expect(attachment.name).toBe("foo.txt");
+  expect(Buffer.from(attachments[attachment.source] as string, "base64").toString("utf8")).toBe("bar");
+});
+
+it("step with assertion error", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { step } = require("allure-js-commons");;
+
+    it("step", async () => {
+      await step("foo", async () => {
+        await step("bar", async () => {
+          expect(1).toBe(1);
+        });
+
+        await step("baz", async () => {
+          expect(1).toBe(2);
+        });
+      });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toEqual(
+    expect.objectContaining({
+      name: "step",
+      status: Status.FAILED,
+      statusDetails: expect.objectContaining({
+        message: "Expected 1 to be 2.",
+      }),
+      steps: [
+        expect.objectContaining({
+          name: "foo",
+          status: Status.PASSED,
+          steps: [
+            expect.objectContaining({
+              name: "bar",
+              status: Status.PASSED,
+            }),
+            expect.objectContaining({
+              name: "baz",
+              status: Status.FAILED,
+            }),
+          ],
+        }),
+      ],
+    }),
+  );
+});
+
+it("step with unexpected error", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { step } = require("allure-js-commons");;
+
+    it("step", async () => {
+      await step("foo", async () => {
+        await step("bar", async () => {
+          await step("baz", async () => {
+            throw new Error("foo");
+          });
+        });
+      });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toEqual(
+    expect.objectContaining({
+      status: Status.BROKEN,
+      steps: [
+        expect.objectContaining({
+          name: "foo",
+          status: Status.BROKEN,
+          steps: [
+            expect.objectContaining({
+              name: "bar",
+              status: Status.BROKEN,
+              steps: [
+                expect.objectContaining({
+                  name: "baz",
+                  status: Status.BROKEN,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ],
+    }),
+  );
+});
+
+it("step runtime api", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { step } = require("allure-js-commons");;
+
+    it("step", async () => {
+      await step("step", (ctx) => {
+        ctx.displayName("bar");
+        ctx.parameter("p1", "v1");
+        ctx.parameter("p2", "v2", "default");
+        ctx.parameter("p3", "v3", "masked");
+        ctx.parameter("p4", "v4", "hidden");
+      });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].status).toEqual("passed");
+  expect(tests[0].steps).toHaveLength(1);
+  const actualStep = tests[0].steps[0];
+  expect(actualStep.status).toEqual("passed");
+  expect(actualStep.name).toEqual("bar");
+  expect(actualStep.parameters).toHaveLength(4);
+  expect(actualStep.parameters).toEqual([
+    { name: "p1", value: "v1" },
+    { name: "p2", value: "v2", mode: "default" },
+    { name: "p3", value: "v3", mode: "masked" },
+    { name: "p4", value: "v4", mode: "hidden" },
+  ]);
+});

--- a/packages/allure-jasmine/test/spec/runtime/modern/testCaseId.test.ts
+++ b/packages/allure-jasmine/test/spec/runtime/modern/testCaseId.test.ts
@@ -1,0 +1,17 @@
+import { expect, it } from "vitest";
+import { runJasmineInlineTest } from "../../../utils";
+
+it("sets testCaseId", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+    const { testCaseId } = require("allure-js-commons");
+
+    it("testCaseId", async () => {
+      await testCaseId("foo");
+    })
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].testCaseId).toBe("foo");
+});

--- a/packages/allure-jasmine/test/spec/simple.test.ts
+++ b/packages/allure-jasmine/test/spec/simple.test.ts
@@ -1,0 +1,44 @@
+import { expect, it } from "vitest";
+import { Stage, Status } from "allure-js-commons/sdk/node";
+import { runJasmineInlineTest } from "../utils";
+
+it("handles jasmine tests", async () => {
+  const { tests, groups } = await runJasmineInlineTest({
+    "spec/test/sample1.spec.js": `
+      it("should pass", () => {
+        expect(true).toBe(true);
+      });
+    `,
+    "spec/test/sample2.spec.js": `
+      it("should fail", () => {
+        expect(true).toBe(false);
+      });
+    `,
+    "spec/test/sample3.spec.js": `
+      it("should break", () => {
+        throw new Error("foo");
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(3);
+  expect(tests).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "should pass",
+        status: Status.PASSED,
+        stage: Stage.FINISHED,
+      }),
+      expect.objectContaining({
+        name: "should fail",
+        status: Status.FAILED,
+        stage: Stage.FINISHED,
+      }),
+      expect.objectContaining({
+        name: "should break",
+        status: Status.BROKEN,
+        stage: Stage.FINISHED,
+      }),
+    ]),
+  );
+});

--- a/packages/allure-jasmine/test/spec/simple.test.ts
+++ b/packages/allure-jasmine/test/spec/simple.test.ts
@@ -1,9 +1,10 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { expect, it } from "vitest";
 import { Stage, Status } from "allure-js-commons/sdk/node";
 import { runJasmineInlineTest } from "../utils";
 
 it("handles jasmine tests", async () => {
-  const { tests, groups } = await runJasmineInlineTest({
+  const { tests } = await runJasmineInlineTest({
     "spec/test/sample1.spec.js": `
       it("should pass", () => {
         expect(true).toBe(true);

--- a/packages/allure-jasmine/test/utils.ts
+++ b/packages/allure-jasmine/test/utils.ts
@@ -1,6 +1,6 @@
 import { fork } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, rm, writeFile, readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parse } from "properties";
 import {
@@ -24,68 +24,10 @@ export const runJasmineInlineTest = async (files: Record<string, string>): Promi
     groups: [],
     attachments: {},
   };
-  const testDir = join(__dirname, "fixtures", randomUUID());
+  const testDir = join(__dirname, "temp", randomUUID());
   const testFiles = {
-    "spec/support/jasmine.json": `
-      {
-        "spec_dir": "spec",
-        "spec_files": [
-          "**/*[sS]pec.?(m)js"
-        ],
-        "helpers": [
-          "helpers/**/*.?(m)js"
-        ],
-        "env": {
-          "stopSpecOnExpectationFailure": false,
-          "random": true
-        }
-      }
-    `,
-    "spec/helpers/allure.js": `
-      const AllureJasmineReporter = require("allure-jasmine");
-
-      const reporter = new AllureJasmineReporter({
-        testMode: true,
-        links: [
-          {
-            type: "${LinkType.ISSUE}",
-            urlTemplate: "https://example.org/issues/%s",
-          },
-          {
-            type: "${LinkType.TMS}",
-            urlTemplate: "https://example.org/tasks/%s",
-          }
-        ],
-        categories: [
-          {
-            name: "Sad tests",
-            messageRegex: /.*Sad.*/,
-            matchedStatuses: ["${Status.FAILED}"],
-          },
-          {
-            name: "Infrastructure problems",
-            messageRegex: ".*RuntimeException.*",
-            matchedStatuses: ["${Status.BROKEN}"],
-          },
-          {
-            name: "Outdated tests",
-            messageRegex: ".*FileNotFound.*",
-            matchedStatuses: ["${Status.BROKEN}"],
-          },
-          {
-            name: "Regression",
-            messageRegex: ".*\\sException:.*",
-            matchedStatuses: ["${Status.BROKEN}"],
-          },
-        ],
-        environmentInfo: {
-          envVar1: "envVar1Value",
-          envVar2: "envVar2Value",
-        },
-      });
-
-      jasmine.getEnv().addReporter(reporter);
-    `,
+    "spec/support/jasmine.json": await readFile(join(__dirname, "./fixtures/spec/support/jasmine.json"), "utf8"),
+    "spec/helpers/allure.js": require("./fixtures/spec/helpers/modern/allure.cjs"),
     ...files,
   };
 

--- a/packages/allure-jasmine/test/utils.ts
+++ b/packages/allure-jasmine/test/utils.ts
@@ -1,16 +1,10 @@
+/* eslint  @typescript-eslint/no-require-imports: off */
 import { fork } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { mkdir, rm, writeFile, readFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { parse } from "properties";
-import {
-  AllureResults,
-  EnvironmentInfo,
-  LinkType,
-  Status,
-  TestResult,
-  TestResultContainer,
-} from "allure-js-commons/sdk/node";
+import { AllureResults, EnvironmentInfo, TestResult, TestResultContainer } from "allure-js-commons/sdk/node";
 
 export type TestResultsByFullName = Record<string, TestResult>;
 
@@ -37,7 +31,7 @@ export const runJasmineInlineTest = async (files: Record<string, string>): Promi
     const filePath = join(testDir, file);
 
     await mkdir(dirname(filePath), { recursive: true });
-    await writeFile(filePath, testFiles[file as keyof typeof testFiles], "utf8");
+    await writeFile(filePath, testFiles[file as keyof typeof testFiles] as string, "utf8");
   }
 
   const modulePath = require.resolve("jasmine/bin/jasmine");


### PR DESCRIPTION
- add back compatibility with old-style jasmine runtime api
- fix linters issues

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
