### PR TITLE
Fix link's order of arguments

### DIFF
--- a/packages/allure-codeceptjs/package.json
+++ b/packages/allure-codeceptjs/package.json
@@ -31,7 +31,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --declaration --emitDeclarationOnly",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/allure-codeceptjs/src/legacy.ts
+++ b/packages/allure-codeceptjs/src/legacy.ts
@@ -44,7 +44,7 @@ export const allureCodeceptJsLegacyApi: AllureCodeceptJsLegacyApi = {
   /**
    * @deprecated please use import { link } from "allure-js-commons" instead.
    */
-  link: (type, url, name) => Promise.resolve(allure.link(url, type, name)),
+  link: (type, url, name) => Promise.resolve(allure.link(url, name, type)),
   /**
    * @deprecated please use import { parameter } from "allure-js-commons" instead.
    */

--- a/packages/allure-codeceptjs/tsconfig.json
+++ b/packages/allure-codeceptjs/tsconfig.json
@@ -3,11 +3,13 @@
   "include": ["./src/**/*"],
   "compilerOptions": {
     "skipLibCheck": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["dom", "esnext"],
     "types": ["node", "jasmine"],
-    "outDir": "./dist"
+    "outDir": "./dist/types"
   }
 }

--- a/packages/allure-cucumberjs/package.json
+++ b/packages/allure-cucumberjs/package.json
@@ -37,7 +37,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --declaration --emitDeclarationOnly",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint --fix ./src ./test --ext .ts",

--- a/packages/allure-cucumberjs/src/world.ts
+++ b/packages/allure-cucumberjs/src/world.ts
@@ -42,7 +42,7 @@ export class AllureCucumberWorld extends World implements AllureCucumberLegacyAp
   /**
    * @deprecated please use import { link } from "allure-js-commons" instead.
    */
-  link = (type: string, url: string, name?: string) => allure.link(url, type, name);
+  link = (type: string, url: string, name?: string) => allure.link(url, name, type);
   /**
    * @deprecated please use import { parameter } from "allure-js-commons" instead.
    */

--- a/packages/allure-cucumberjs/test/fixtures/support/runtime/modern/links.cjs
+++ b/packages/allure-cucumberjs/test/fixtures/support/runtime/modern/links.cjs
@@ -4,7 +4,7 @@ const { link, issue, tms } = require("allure-js-commons");
 Given("a step", () => {});
 
 Given("a step with runtime link", async () => {
-  await link("https://example.com", "custom", "Custom link");
+  await link("https://example.com", "Custom link", "custom");
 });
 
 Given("a step with runtime issue links", async () => {

--- a/packages/allure-cucumberjs/tsconfig.json
+++ b/packages/allure-cucumberjs/tsconfig.json
@@ -3,11 +3,13 @@
   "include": ["./src/**/*"],
   "compilerOptions": {
     "skipLibCheck": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["dom", "esnext"],
     "types": ["node"],
-    "outDir": "./dist"
+    "outDir": "./dist/types"
   }
 }

--- a/packages/allure-cypress/package.json
+++ b/packages/allure-cypress/package.json
@@ -46,7 +46,7 @@
     "compile:cjs-node": "babel --config-file ./babel.cjs.json ./src --ignore './src/index.ts' --out-dir ./dist/cjs --extensions '.ts' --source-maps",
     "compile:esm-browser": "esbuild ./src/index.ts --bundle --minify --sourcemap --format=esm --outfile=./dist/esm/index.js --external:allure-playwright",
     "compile:cjs-browser": "esbuild ./src/index.ts --bundle --minify --sourcemap --format=cjs --outfile=./dist/cjs/index.js --external:allure-playwright",
-    "compile:types": "tsc --declaration --emitDeclarationOnly",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/allure-cypress/src/index.ts
+++ b/packages/allure-cypress/src/index.ts
@@ -1,5 +1,5 @@
 import { Stage, Status } from "allure-js-commons";
-import type { ContentType, Label, LabelName, Link, LinkType, ParameterMode, ParameterOptions } from "allure-js-commons";
+import type { ContentType, Label, Link, ParameterMode, ParameterOptions } from "allure-js-commons";
 import type { RuntimeMessage } from "allure-js-commons/sdk";
 import { getUnfinishedStepsMessages, hasStepMessage } from "allure-js-commons/sdk";
 import type { TestRuntime } from "allure-js-commons/sdk/runtime";
@@ -8,29 +8,11 @@ import type { CypressRuntimeMessage } from "./model.js";
 import { getSuitePath, normalizeAttachmentContentEncoding, uint8ArrayToBase64 } from "./utils.js";
 
 export class AllureCypressTestRuntime implements TestRuntime {
-  label(name: LabelName | string, value: string) {
-    return this.sendMessageAsync({
-      type: "metadata",
-      data: {
-        labels: [{ name, value }],
-      },
-    });
-  }
-
   labels(...labels: Label[]) {
     return this.sendMessageAsync({
       type: "metadata",
       data: {
         labels,
-      },
-    });
-  }
-
-  link(url: string, type?: LinkType | string, name?: string) {
-    return this.sendMessageAsync({
-      type: "metadata",
-      data: {
-        links: [{ type, url, name }],
       },
     });
   }

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -2,7 +2,7 @@ import type Cypress from "cypress";
 import { readFileSync } from "node:fs";
 import { ContentType, LabelName, Stage } from "allure-js-commons";
 import { extractMetadataFromString } from "allure-js-commons/sdk";
-import { FileSystemWriter, ReporterRuntime, getSuitesLabels } from "allure-js-commons/sdk/reporter";
+import { FileSystemWriter, ReporterRuntime, getSuiteLabels } from "allure-js-commons/sdk/reporter";
 import type { CypressRuntimeMessage, CypressTestEndRuntimeMessage, CypressTestStartRuntimeMessage } from "./model.js";
 
 export type AllureCypressConfig = {
@@ -45,7 +45,7 @@ export class AllureCypress {
           throw new Error("INTERNAL ERROR: Invalid message sequence");
         }
 
-        const suiteLabels = getSuitesLabels(startMessage.data.specPath.slice(0, -1));
+        const suiteLabels = getSuiteLabels(startMessage.data.specPath.slice(0, -1));
         const testTitle = startMessage.data.specPath[startMessage.data.specPath.length - 1];
         const titleMetadata = extractMetadataFromString(testTitle);
         const testUuid = this.runtime.startTest({

--- a/packages/allure-cypress/test/spec/runtime/legacy/links.test.ts
+++ b/packages/allure-cypress/test/spec/runtime/legacy/links.test.ts
@@ -21,8 +21,8 @@ it("adds all the possible links", async () => {
 
   expect(tests).toHaveLength(1);
   expect(tests[0].links).toContainEqual({
-    name: "bar",
-    type: "foo",
+    name: "foo",
+    type: "bar",
     url: "https://allurereport.org",
   });
   expect(tests[0].links).toContainEqual({

--- a/packages/allure-cypress/test/spec/runtime/modern/links.test.ts
+++ b/packages/allure-cypress/test/spec/runtime/modern/links.test.ts
@@ -21,8 +21,8 @@ it("adds all the possible links", async () => {
 
   expect(tests).toHaveLength(1);
   expect(tests[0].links).toContainEqual({
-    name: "bar",
-    type: "foo",
+    name: "foo",
+    type: "bar",
     url: "https://allurereport.org",
   });
   expect(tests[0].links).toContainEqual({

--- a/packages/allure-cypress/tsconfig.json
+++ b/packages/allure-cypress/tsconfig.json
@@ -2,13 +2,15 @@
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "skipLibCheck": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["dom", "esnext"],
     "types": ["node"],
-    "outDir": "./dist",
+    "outDir": "./dist/types",
     "isolatedModules": true
   }
 }

--- a/packages/allure-jasmine/package.json
+++ b/packages/allure-jasmine/package.json
@@ -31,7 +31,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm-babel": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs-babel": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --declarationDir ./dist/types",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/allure-jasmine/tsconfig.json
+++ b/packages/allure-jasmine/tsconfig.json
@@ -2,12 +2,14 @@
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "skipLibCheck": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["dom", "esnext"],
     "types": ["node", "jasmine"],
-    "outDir": "./dist"
+    "outDir": "./dist/types"
   }
 }

--- a/packages/allure-jest/package.json
+++ b/packages/allure-jest/package.json
@@ -38,7 +38,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm-babel": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs-babel": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --declarationDir ./dist/types",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/allure-jest/src/environmentFactory.ts
+++ b/packages/allure-jest/src/environmentFactory.ts
@@ -7,7 +7,7 @@ import * as allure from "allure-js-commons";
 import { LabelName, Stage, Status } from "allure-js-commons";
 import type { RuntimeMessage } from "allure-js-commons/sdk";
 import { getMessageAndTraceFromError, getStatusFromError } from "allure-js-commons/sdk";
-import { FileSystemWriter, MessageWriter, ReporterRuntime, getSuitesLabels } from "allure-js-commons/sdk/reporter";
+import { FileSystemWriter, MessageWriter, ReporterRuntime, getSuiteLabels } from "allure-js-commons/sdk/reporter";
 import { setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import { AllureJestTestRuntime } from "./AllureJestTestRuntime.js";
 import type { AllureJestConfig, AllureJestEnvironment } from "./model.js";
@@ -159,7 +159,7 @@ const createJestEnvironment = <T extends typeof JestEnvironment>(Base: T): T => 
           result.labels.push({ name: LabelName.HOST, value: hostLabel });
         }
 
-        result.labels.push(...getSuitesLabels(newTestSuitesPath));
+        result.labels.push(...getSuiteLabels(newTestSuitesPath));
       }, testUuid);
 
       /**

--- a/packages/allure-jest/tsconfig.json
+++ b/packages/allure-jest/tsconfig.json
@@ -2,11 +2,13 @@
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["dom", "esnext"],
     "types": ["node"],
-    "outDir": "./dist"
+    "outDir": "./dist/types"
   }
 }

--- a/packages/allure-js-commons/package.json
+++ b/packages/allure-js-commons/package.json
@@ -51,7 +51,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --declarationDir ./dist/types",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/allure-js-commons/src/facade.ts
+++ b/packages/allure-js-commons/src/facade.ts
@@ -36,7 +36,7 @@ export const labels = (...labelsList: Label[]) => {
   return callRuntimeMethod("labels", ...labelsList);
 };
 
-export const link = (url: string, type?: LinkType | string, name?: string) => {
+export const link = (url: string, name?: string, type?: LinkType | string) => {
   // const runtime = await getGlobalTestRuntimeWithAutoconfig();
   //
   // return runtime.links({ url, type, name });
@@ -123,9 +123,9 @@ export const step = <T = void>(name: string, body: (context: StepContext) => T |
   return callRuntimeMethod("step", name, () => body(stepContext()));
 };
 
-export const issue = (url: string, name?: string) => link(url, LinkType.ISSUE, name);
+export const issue = (url: string, name?: string) => link(url, name, LinkType.ISSUE);
 
-export const tms = (url: string, name?: string) => link(url, LinkType.TMS, name);
+export const tms = (url: string, name?: string) => link(url, name, LinkType.TMS);
 
 export const allureId = (value: string) => label(LabelName.ALLURE_ID, value);
 

--- a/packages/allure-js-commons/src/sdk/reporter/ReporterRuntime.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/ReporterRuntime.ts
@@ -20,7 +20,7 @@ import { MutableAllureContextHolder, StaticContextProvider } from "./context/Sta
 import type { AllureContextProvider } from "./context/types.js";
 import { createFixtureResult, createStepResult, createTestResult } from "./factory.js";
 import type { Config, FixtureType, FixtureWrapper, LinkConfig, TestScope, WellKnownWriters, Writer } from "./types.js";
-import { deepClone, getGlobalLabels, randomUuid, typeToExtension } from "./utils.js";
+import { deepClone, randomUuid, typeToExtension } from "./utils.js";
 import { getTestResultHistoryId, getTestResultTestCaseId, resolveWriter } from "./utils.js";
 import * as wellKnownCommonWriters from "./writer/wellKnownCommonWriters.js";
 
@@ -779,7 +779,6 @@ export class ReporterRuntime {
     return {
       ...createTestResult(uuid),
       start: Date.now(),
-      labels: getGlobalLabels(),
       ...deepClone(result),
     };
   }

--- a/packages/allure-js-commons/src/sdk/reporter/utils.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/utils.ts
@@ -3,7 +3,6 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
-import { env } from "process";
 import properties from "properties";
 import type { AttachmentOptions, ContentType, Status, StepResult, TestResult } from "../../model.js";
 import { LabelName, StatusByPriority } from "../../model.js";
@@ -124,20 +123,6 @@ const getKnownWriterCtor = (wellKnownWriters: WellKnownWriters, name: string) =>
 const requireWriterCtor = (modulePath: string): (new (...args: readonly unknown[]) => Writer) | Writer => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
   return require(modulePath);
-};
-
-export const getGlobalLabels = () => {
-  const ENV_NAME_PREFIX = "ALLURE_LABEL_";
-  let globalLabels: Label[];
-  const initGlobalLabels: () => Label[] = () =>
-    Object.keys(env)
-      .filter((varname) => varname.startsWith(ENV_NAME_PREFIX))
-      .map((varname) => ({
-        name: varname.substring(ENV_NAME_PREFIX.length),
-        value: env[varname] ?? "",
-      }))
-      .filter((l) => l.name && l.value);
-  return (globalLabels ??= initGlobalLabels());
 };
 
 const getProjectRoot = (() => {

--- a/packages/allure-js-commons/src/sdk/reporter/utils.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/utils.ts
@@ -227,8 +227,6 @@ export const getSuiteLabels = (suites: readonly string[]): Label[] => {
   return labels;
 };
 
-export const getSuitesLabels = getSuiteLabels;
-
 const suiteLabelNames: readonly string[] = [LabelName.PARENT_SUITE, LabelName.SUITE, LabelName.SUB_SUITE];
 
 export const ensureSuiteLabels = (test: Partial<TestResult>, defaultSuites: readonly string[]) => {

--- a/packages/allure-js-commons/test/sdk/reporter/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { LabelName } from "../../../src/model.js";
-import { getSuitesLabels, serialize, typeToExtension } from "../../../src/sdk/reporter/utils.js";
+import { getSuiteLabels, serialize, typeToExtension } from "../../../src/sdk/reporter/utils.js";
 
 describe("typeToExtension", () => {
   it("should respect provided file extension", () => {
@@ -46,16 +46,16 @@ describe("typeToExtension", () => {
   });
 });
 
-describe("getSuitesLabels", () => {
+describe("getSuiteLabels", () => {
   describe("with empty suites", () => {
     it("returns empty array", () => {
-      expect(getSuitesLabels([])).toEqual([]);
+      expect(getSuiteLabels([])).toEqual([]);
     });
   });
 
   describe("with single suite", () => {
     it("returns parent suite label as the first element", () => {
-      expect(getSuitesLabels(["foo"])).toEqual([
+      expect(getSuiteLabels(["foo"])).toEqual([
         {
           name: LabelName.PARENT_SUITE,
           value: "foo",
@@ -66,7 +66,7 @@ describe("getSuitesLabels", () => {
 
   describe("with two suites", () => {
     it("returns parent suite and suite labels as the first two elements", () => {
-      expect(getSuitesLabels(["foo", "bar"])).toEqual([
+      expect(getSuiteLabels(["foo", "bar"])).toEqual([
         {
           name: LabelName.PARENT_SUITE,
           value: "foo",
@@ -81,7 +81,7 @@ describe("getSuitesLabels", () => {
 
   describe("with three or more suites", () => {
     it("returns list of three elements where last one is a sub suite label", () => {
-      expect(getSuitesLabels(["foo", "bar", "baz", "beep", "boop"])).toEqual([
+      expect(getSuiteLabels(["foo", "bar", "baz", "beep", "boop"])).toEqual([
         {
           name: LabelName.PARENT_SUITE,
           value: "foo",

--- a/packages/allure-js-commons/tsconfig.json
+++ b/packages/allure-js-commons/tsconfig.json
@@ -5,11 +5,12 @@
   ],
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "lib": ["dom", "esnext"],
     "types": [
       "node"
     ],
-    "outDir": "./dist/esm",
+    "outDir": "./dist/types",
     "module": "es2020",
     "moduleResolution": "bundler",
     "target": "es2020"

--- a/packages/allure-mocha/package.json
+++ b/packages/allure-mocha/package.json
@@ -42,7 +42,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm-babel": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs-babel": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --declarationDir ./dist/types",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/allure-mocha/src/legacy.ts
+++ b/packages/allure-mocha/src/legacy.ts
@@ -27,7 +27,7 @@ class LegacyAllureApi {
   label = (name: string, value: string) => Promise.resolve(commons.label(name, value));
   parameter = (name: string, value: any, options?: ParameterOptions) =>
     Promise.resolve(commons.parameter(name, serialize(value) as string, options));
-  link = (url: string, name?: string, type?: string) => Promise.resolve(commons.link(url, type, name));
+  link = (url: string, name?: string, type?: string) => Promise.resolve(commons.link(url, name, type));
   issue = (name: string, url: string) => Promise.resolve(commons.issue(url, name));
   tms = (name: string, url: string) => Promise.resolve(commons.tms(url, name));
   description = (markdown: string) => Promise.resolve(commons.description(markdown));

--- a/packages/allure-mocha/test/fixtures/samples/links/namedLink.spec.mjs
+++ b/packages/allure-mocha/test/fixtures/samples/links/namedLink.spec.mjs
@@ -2,5 +2,5 @@ import { it } from "mocha";
 import { link } from "allure-js-commons";
 
 it("a test with a named link", async () => {
-  await link("https://foo.bar", "link", "baz");
+  await link("https://foo.bar", "baz");
 });

--- a/packages/allure-mocha/test/fixtures/samples/links/urlTypeLink.spec.mjs
+++ b/packages/allure-mocha/test/fixtures/samples/links/urlTypeLink.spec.mjs
@@ -2,5 +2,5 @@ import { it } from "mocha";
 import { link } from "allure-js-commons";
 
 it("a test with a link of a custom type", async () => {
-  await link("https://foo.bar", "baz");
+  await link("https://foo.bar", "baz", "qux");
 });

--- a/packages/allure-mocha/test/spec/api/runtime/links.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/links.test.ts
@@ -34,7 +34,8 @@ describe("link", () => {
     expect(links).toEqual([
       {
         url: "https://foo.bar",
-        type: "baz",
+        name: "baz",
+        type: "qux",
       },
     ]);
   });
@@ -44,7 +45,6 @@ describe("link", () => {
     expect(links).toEqual([
       {
         url: "https://foo.bar",
-        type: "link",
         name: "baz",
       },
     ]);

--- a/packages/allure-mocha/tsconfig.json
+++ b/packages/allure-mocha/tsconfig.json
@@ -2,11 +2,13 @@
   "extends": "../../tsconfig.json",
   "include": ["./src/**/*"],
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
     "lib": ["dom", "esnext"],
     "types": ["node"],
-    "outDir": "./dist"
+    "outDir": "./dist/types"
   }
 }

--- a/packages/allure-playwright/src/legacy.ts
+++ b/packages/allure-playwright/src/legacy.ts
@@ -52,7 +52,7 @@ export const allurePlaywrightLegacyApi: AllurePlaywrightLegacyApi = {
   /**
    * @deprecated please use import { link } from "allure-js-commons" instead.
    */
-  link: (type, url, name) => allure.link(url, type, name),
+  link: (type, url, name) => allure.link(url, name, type),
   /**
    * @deprecated please use import { links } from "allure-js-commons" instead.
    */

--- a/packages/allure-vitest/src/legacy.ts
+++ b/packages/allure-vitest/src/legacy.ts
@@ -44,7 +44,7 @@ export const allureVitestLegacyApi: AllureVitestLegacyApi = {
   /**
    * @deprecated please use import { link } from "allure-js-commons" instead.
    */
-  link: (type, url, name) => Promise.resolve(allure.link(url, type, name)),
+  link: (type, url, name) => Promise.resolve(allure.link(url, name, type)),
   /**
    * @deprecated please use import { parameter } from "allure-js-commons" instead.
    */

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -12,7 +12,7 @@ import {
   ReporterRuntime,
   getEnvironmentLabels,
   getHostLabel,
-  getSuitesLabels,
+  getSuiteLabels,
   getThreadLabel,
 } from "allure-js-commons/sdk/reporter";
 import { getSuitePath, getTestFullName } from "./utils.js";
@@ -107,7 +107,7 @@ export default class AllureVitestReporter implements Reporter {
         value: "javascript",
       });
       result.labels.push(...titleMetadata.labels);
-      result.labels.push(...getSuitesLabels(suitePath));
+      result.labels.push(...getSuiteLabels(suitePath));
       result.labels.push(...getEnvironmentLabels());
       result.labels.push(getHostLabel());
       result.labels.push(getThreadLabel(VITEST_POOL_ID && `vitest-worker-${VITEST_POOL_ID}`));

--- a/packages/allure-vitest/test/spec/runtime/modern/links.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/links.test.ts
@@ -17,8 +17,8 @@ describe("links", () => {
 
     expect(tests).toHaveLength(1);
     expect(tests[0].links).toContainEqual({
-      name: "bar",
-      type: "foo",
+      name: "foo",
+      type: "bar",
       url: "https://example.org",
     });
   });

--- a/packages/newman-reporter-allure/package.json
+++ b/packages/newman-reporter-allure/package.json
@@ -41,7 +41,7 @@
     "compile": "run-s 'compile:*'",
     "compile:esm": "babel --config-file ./babel.esm.json ./src --out-dir ./dist/esm --extensions '.ts' --source-maps",
     "compile:cjs": "babel --config-file ./babel.cjs.json ./src --out-dir ./dist/cjs --extensions '.ts' --source-maps",
-    "compile:types": "tsc --project ./tsconfig.json --emitDeclarationOnly --declarationDir ./dist/types",
+    "compile:types": "tsc",
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",

--- a/packages/newman-reporter-allure/tsconfig.json
+++ b/packages/newman-reporter-allure/tsconfig.json
@@ -4,6 +4,8 @@
     "./src/**/*",
   ],
   "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "module": "ES2022",
     "target": "ES2022",
     "moduleResolution": "bundler",
@@ -14,6 +16,6 @@
     "types": [
       "node"
     ],
-    "outDir": "./dist"
+    "outDir": "./dist/types"
   }
 }


### PR DESCRIPTION
### Context
`link(url, type, name)` now is `link(url, name, type)`. The new order is backward-compatible with Jasmine, Jest, and Cypress. The previous one isn't.

### Additional changes

  - The output folder of type declarations is changed from `dist` to `dist/types` for codeceptjs, cucumberjs, and cypress. Some parameters are moved from `package.json` to `tsconfig.json`.
  - Grammar fix: `getSuitesLabels` is renamed to `getSuiteLabels`.
  - Remove duplicated env labels from newly created test results; remove `getGlobalLabels` from reporter utils.
  - Remove `link` and `label` from `AllureCypressTestRuntime` (they aren't in use now).

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
