### PR TITLE
Allure Mocha: testplan support, env info and categories, metadata

### DIFF
--- a/packages/allure-mocha/package.json
+++ b/packages/allure-mocha/package.json
@@ -46,7 +46,7 @@
     "compile:fixup": "node ./scripts/fixup.mjs",
     "lint": "eslint ./src ./test --ext .ts",
     "lint:fix": "eslint ./src ./test --ext .ts --fix",
-    "test": "run-s 'test:*'",
+    "test": "run-s --print-name 'test:*'",
     "test:serial": "vitest run",
     "test:parallel": "ALLURE_MOCHA_TEST_PARALLEL=true vitest run",
     "test:runner": "ALLURE_MOCHA_TEST_RUNNER=cjs ALLURE_MOCHA_TEST_SPEC_FORMAT=cjs vitest run",

--- a/packages/allure-mocha/src/AllureMochaReporter.ts
+++ b/packages/allure-mocha/src/AllureMochaReporter.ts
@@ -22,6 +22,8 @@ import {
   getAllureFullName,
   isIncludedInTestRun,
   getAllureDisplayName,
+  getAllureMetaLabels,
+  getTestCaseId,
   createTestPlanIndices,
 } from "./utils.js";
 import type { TestPlanIndices } from "./utils.js";
@@ -92,7 +94,8 @@ export class AllureMochaReporter extends Mocha.reporters.Base {
   private onTest = (test: Mocha.Test) => {
     const globalLabels = getEnvironmentLabels().filter((label) => !!label.value);
     const initialLabels: Label[] = getInitialLabels();
-    const labels = globalLabels.concat(initialLabels);
+    const metaLabels = getAllureMetaLabels(test);
+    const labels = globalLabels.concat(initialLabels, metaLabels);
 
     if (test.file) {
       const testPath = getRelativePath(test.file);
@@ -106,6 +109,7 @@ export class AllureMochaReporter extends Mocha.reporters.Base {
         stage: Stage.RUNNING,
         fullName: getAllureFullName(test),
         labels,
+        testCaseId: getTestCaseId(test),
       },
       { dedicatedScope: true },
     );

--- a/packages/allure-mocha/src/AllureMochaReporter.ts
+++ b/packages/allure-mocha/src/AllureMochaReporter.ts
@@ -67,6 +67,12 @@ export class AllureMochaReporter extends Mocha.reporters.Base {
     }
   }
 
+  override done(failures: number, fn?: ((failures: number) => void) | undefined): void {
+    this.runtime.writeEnvironmentInfo();
+    this.runtime.writeCategoriesDefinitions();
+    return fn?.(failures);
+  }
+
   private applyListeners = () => {
     this.runner
       .on(EVENT_SUITE_BEGIN, this.onSuite)

--- a/packages/allure-mocha/src/AllureMochaReporter.ts
+++ b/packages/allure-mocha/src/AllureMochaReporter.ts
@@ -15,16 +15,16 @@ import { setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import { MochaTestRuntime } from "./MochaTestRuntime.js";
 import { setLegacyApiRuntime } from "./legacyUtils.js";
 import {
+  applyTestPlan,
+  createTestPlanIndices,
+  getAllureDisplayName,
+  getAllureFullName,
+  getAllureMetaLabels,
   getInitialLabels,
   getSuitesOfMochaTest,
-  resolveParallelModeSetupFile,
-  applyTestPlan,
-  getAllureFullName,
-  isIncludedInTestRun,
-  getAllureDisplayName,
-  getAllureMetaLabels,
   getTestCaseId,
-  createTestPlanIndices,
+  isIncludedInTestRun,
+  resolveParallelModeSetupFile,
 } from "./utils.js";
 import type { TestPlanIndices } from "./utils.js";
 

--- a/packages/allure-mocha/src/utils.ts
+++ b/packages/allure-mocha/src/utils.ts
@@ -72,6 +72,9 @@ export const getAllureFullName = (test: Mocha.Test) =>
 export const isIncludedInTestRun = (test: Mocha.Test) =>
   getAllureData(test).isIncludedInTestRun;
 
+export const getAllureMetaLabels = (test: Mocha.Test) =>
+  getAllureData(test).labels;
+
 export const getAllureId = (data: AllureMochaTestData) => {
   const values = data.labels.filter((l) => l.name === LabelName.ALLURE_ID).map((l) => l.value);
   if (values.length) {
@@ -93,6 +96,11 @@ export const getInitialLabels = (): Label[] => [
   getHostLabel(),
   getThreadLabel(env.MOCHA_WORKER_ID),
 ];
+
+export const getTestCaseId = (test: Mocha.Test) => {
+  const suiteTitles = test.titlePath().slice(0, -1);
+  return md5(JSON.stringify([...suiteTitles, getAllureDisplayName(test)]));
+};
 
 export const applyTestPlan = (ids: ReadonlySet<string>, selectors: ReadonlySet<string>, rootSuite: Mocha.Suite) => {
   const suiteQueue = [];

--- a/packages/allure-mocha/src/utils.ts
+++ b/packages/allure-mocha/src/utils.ts
@@ -3,10 +3,10 @@ import { dirname, extname, join } from "node:path";
 import { env } from "node:process";
 import { fileURLToPath } from "node:url";
 import type { Label } from "allure-js-commons";
+import { LabelName } from "allure-js-commons";
 import type { TestPlanV1, TestPlanV1Test } from "allure-js-commons/sdk";
 import { extractMetadataFromString } from "allure-js-commons/sdk";
-import { LabelName } from "allure-js-commons";
-import { getHostLabel, getThreadLabel, getRelativePath, md5, parseTestPlan } from "allure-js-commons/sdk/reporter";
+import { getHostLabel, getRelativePath, getThreadLabel, md5, parseTestPlan } from "allure-js-commons/sdk/reporter";
 
 const filename = fileURLToPath(import.meta.url);
 
@@ -40,16 +40,12 @@ const createAllureFullName = (test: Mocha.Test) => {
   return test.file ? `${getRelativePath(test.file)}: ${titlePath}` : titlePath;
 };
 
-const createTestPlanSelectorIndex = (testplan: TestPlanV1) =>
-  createTestPlanIndex((e) => e.selector, testplan);
+const createTestPlanSelectorIndex = (testplan: TestPlanV1) => createTestPlanIndex((e) => e.selector, testplan);
 
-const createTestPlanIdIndex = (testplan: TestPlanV1) =>
-  createTestPlanIndex((e) => e.id?.toString(), testplan);
+const createTestPlanIdIndex = (testplan: TestPlanV1) => createTestPlanIndex((e) => e.id?.toString(), testplan);
 
 const createTestPlanIndex = <T>(keySelector: (entry: TestPlanV1Test) => T, testplan: TestPlanV1) =>
-  new Set(
-    testplan.tests.map((e) => keySelector(e)).filter((v) => v) as readonly T[]
-  );
+  new Set(testplan.tests.map((e) => keySelector(e)).filter((v) => v) as readonly T[]);
 
 export type TestPlanIndices = {
   fullNameIndex: ReadonlySet<string>;
@@ -66,14 +62,11 @@ export const createTestPlanIndices = (): TestPlanIndices | undefined => {
   }
 };
 
-export const getAllureFullName = (test: Mocha.Test) =>
-  getAllureData(test).fullName;
+export const getAllureFullName = (test: Mocha.Test) => getAllureData(test).fullName;
 
-export const isIncludedInTestRun = (test: Mocha.Test) =>
-  getAllureData(test).isIncludedInTestRun;
+export const isIncludedInTestRun = (test: Mocha.Test) => getAllureData(test).isIncludedInTestRun;
 
-export const getAllureMetaLabels = (test: Mocha.Test) =>
-  getAllureData(test).labels;
+export const getAllureMetaLabels = (test: Mocha.Test) => getAllureData(test).labels;
 
 export const getAllureId = (data: AllureMochaTestData) => {
   const values = data.labels.filter((l) => l.name === LabelName.ALLURE_ID).map((l) => l.value);
@@ -82,8 +75,7 @@ export const getAllureId = (data: AllureMochaTestData) => {
   }
 };
 
-export const getAllureDisplayName = (test: Mocha.Test) =>
-  getAllureData(test).displayName;
+export const getAllureDisplayName = (test: Mocha.Test) => getAllureData(test).displayName;
 
 export const getSuitesOfMochaTest = (test: Mocha.Test) => test.titlePath().slice(0, -1);
 

--- a/packages/allure-mocha/src/utils.ts
+++ b/packages/allure-mocha/src/utils.ts
@@ -3,10 +3,84 @@ import { dirname, extname, join } from "node:path";
 import { env } from "node:process";
 import { fileURLToPath } from "node:url";
 import type { Label } from "allure-js-commons";
+import type { TestPlanV1, TestPlanV1Test } from "allure-js-commons/sdk";
+import { extractMetadataFromString } from "allure-js-commons/sdk";
 import { LabelName } from "allure-js-commons";
-import { getHostLabel, getThreadLabel } from "allure-js-commons/sdk/reporter";
+import { getHostLabel, getThreadLabel, getRelativePath, md5, parseTestPlan } from "allure-js-commons/sdk/reporter";
 
 const filename = fileURLToPath(import.meta.url);
+
+const allureMochaDataKey = Symbol("Used to access Allure extra data in Mocha objects");
+
+type AllureMochaTestData = {
+  isIncludedInTestRun: boolean;
+  fullName: string;
+  labels: readonly Label[];
+  displayName: string;
+};
+
+const getAllureData = (item: Mocha.Test): AllureMochaTestData => {
+  const data = (item as any)[allureMochaDataKey];
+  if (!data) {
+    const meta = extractMetadataFromString(item.title);
+    const defaultData: AllureMochaTestData = {
+      isIncludedInTestRun: true,
+      fullName: createAllureFullName(item),
+      labels: meta.labels,
+      displayName: meta.cleanTitle,
+    };
+    (item as any)[allureMochaDataKey] = defaultData;
+    return defaultData;
+  }
+  return data;
+};
+
+const createAllureFullName = (test: Mocha.Test) => {
+  const titlePath = test.titlePath().join(" > ");
+  return test.file ? `${getRelativePath(test.file)}: ${titlePath}` : titlePath;
+};
+
+const createTestPlanSelectorIndex = (testplan: TestPlanV1) =>
+  createTestPlanIndex((e) => e.selector, testplan);
+
+const createTestPlanIdIndex = (testplan: TestPlanV1) =>
+  createTestPlanIndex((e) => e.id?.toString(), testplan);
+
+const createTestPlanIndex = <T>(keySelector: (entry: TestPlanV1Test) => T, testplan: TestPlanV1) =>
+  new Set(
+    testplan.tests.map((e) => keySelector(e)).filter((v) => v) as readonly T[]
+  );
+
+export type TestPlanIndices = {
+  fullNameIndex: ReadonlySet<string>;
+  idIndex: ReadonlySet<string>;
+};
+
+export const createTestPlanIndices = (): TestPlanIndices | undefined => {
+  const testplan = parseTestPlan();
+  if (testplan) {
+    return {
+      fullNameIndex: createTestPlanSelectorIndex(testplan),
+      idIndex: createTestPlanIdIndex(testplan),
+    };
+  }
+};
+
+export const getAllureFullName = (test: Mocha.Test) =>
+  getAllureData(test).fullName;
+
+export const isIncludedInTestRun = (test: Mocha.Test) =>
+  getAllureData(test).isIncludedInTestRun;
+
+export const getAllureId = (data: AllureMochaTestData) => {
+  const values = data.labels.filter((l) => l.name === LabelName.ALLURE_ID).map((l) => l.value);
+  if (values.length) {
+    return values[0];
+  }
+};
+
+export const getAllureDisplayName = (test: Mocha.Test) =>
+  getAllureData(test).displayName;
 
 export const getSuitesOfMochaTest = (test: Mocha.Test) => test.titlePath().slice(0, -1);
 
@@ -19,3 +93,18 @@ export const getInitialLabels = (): Label[] => [
   getHostLabel(),
   getThreadLabel(env.MOCHA_WORKER_ID),
 ];
+
+export const applyTestPlan = (ids: ReadonlySet<string>, selectors: ReadonlySet<string>, rootSuite: Mocha.Suite) => {
+  const suiteQueue = [];
+  for (let s: Mocha.Suite | undefined = rootSuite; s; s = suiteQueue.shift()) {
+    for (const test of s.tests) {
+      const allureData = getAllureData(test);
+      const allureId = getAllureId(allureData);
+      if (!selectors.has(allureData.fullName) && (!allureId || !ids.has(allureId))) {
+        allureData.isIncludedInTestRun = false;
+        test.pending = true;
+      }
+    }
+    suiteQueue.push(...s.suites);
+  }
+};

--- a/packages/allure-mocha/src/utils.ts
+++ b/packages/allure-mocha/src/utils.ts
@@ -1,11 +1,10 @@
 import type * as Mocha from "mocha";
-import { hostname } from "node:os";
 import { dirname, extname, join } from "node:path";
-import { env, pid } from "node:process";
+import { env } from "node:process";
 import { fileURLToPath } from "node:url";
-import { isMainThread, threadId } from "node:worker_threads";
 import type { Label } from "allure-js-commons";
 import { LabelName } from "allure-js-commons";
+import { getHostLabel, getThreadLabel } from "allure-js-commons/sdk/reporter";
 
 const filename = fileURLToPath(import.meta.url);
 
@@ -14,23 +13,9 @@ export const getSuitesOfMochaTest = (test: Mocha.Test) => test.titlePath().slice
 export const resolveParallelModeSetupFile = () =>
   join(dirname(filename), `setupAllureMochaParallel${extname(filename)}`);
 
-export const resolveMochaWorkerId = () => env.MOCHA_WORKER_ID ?? (isMainThread ? pid : threadId).toString();
-
-const allureHostName = env.ALLURE_HOST_NAME || hostname();
-
-export const getHostLabel = (): Label => ({
-  name: LabelName.HOST,
-  value: allureHostName,
-});
-
-export const getWorkerIdLabel = (): Label => ({
-  name: LabelName.THREAD,
-  value: resolveMochaWorkerId(),
-});
-
 export const getInitialLabels = (): Label[] => [
   { name: LabelName.LANGUAGE, value: "javascript" },
   { name: LabelName.FRAMEWORK, value: "mocha" },
   getHostLabel(),
-  getWorkerIdLabel(),
+  getThreadLabel(env.MOCHA_WORKER_ID),
 ];

--- a/packages/allure-mocha/test/fixtures/reporter.cjs
+++ b/packages/allure-mocha/test/fixtures/reporter.cjs
@@ -8,9 +8,7 @@ class ProcessMessageAllureReporter extends AllureMochaReporter {
     }
     for (const key of ["environmentInfo", "categories"]) {
       if (typeof opts.reporterOptions?.[key] === "string") {
-        opts.reporterOptions[key] = JSON.parse(
-          Buffer.from(opts.reporterOptions[key], "base64Url").toString()
-        );
+        opts.reporterOptions[key] = JSON.parse(Buffer.from(opts.reporterOptions[key], "base64Url").toString());
       }
     }
     super(runner, opts);

--- a/packages/allure-mocha/test/fixtures/reporter.cjs
+++ b/packages/allure-mocha/test/fixtures/reporter.cjs
@@ -1,13 +1,17 @@
 /* eslint @typescript-eslint/no-unsafe-argument: 0 */
 const AllureMochaReporter = require("allure-mocha");
-const path = require("path");
 
 class ProcessMessageAllureReporter extends AllureMochaReporter {
   constructor(runner, opts) {
     if (opts.reporterOptions?.emitFiles !== "true") {
-      opts.reporterOptions = {
-        writer: opts.parallel ? path.join(__dirname, "./AllureMochaParallelWriter.cjs") : "MessageWriter",
-      };
+      (opts.reporterOptions ??= {}).writer = "MessageWriter";
+    }
+    for (const key of ["environmentInfo", "categories"]) {
+      if (typeof opts.reporterOptions?.[key] === "string") {
+        opts.reporterOptions[key] = JSON.parse(
+          Buffer.from(opts.reporterOptions[key], "base64Url").toString()
+        );
+      }
     }
     super(runner, opts);
   }

--- a/packages/allure-mocha/test/fixtures/runner.js
+++ b/packages/allure-mocha/test/fixtures/runner.js
@@ -14,11 +14,12 @@
 let emitFiles = false;
 let parallel = false;
 const requires = [];
+const reporterOptions = {};
 
 const sepIndex = process.argv.indexOf("--");
 const args = sepIndex === -1 ? [] : process.argv.splice(sepIndex);
-for (const arg of args) {
-  switch (arg) {
+for (let i = 0; i < args.length; i++) {
+  switch (args[i]) {
     case "--emit-files":
       emitFiles = true;
       break;
@@ -28,14 +29,22 @@ for (const arg of args) {
       // esm: await import("./setupParallel.cjs");
       requires.push(path.join(dirname, "setupParallel.cjs"));
       break;
+    case "--environment-info":
+      reporterOptions.environmentInfo = JSON.parse(Buffer.from(args[++i], "base64url").toString());
+      break;
+    case "--categories":
+      reporterOptions.categories = JSON.parse(Buffer.from(args[++i], "base64url").toString());
+      break;
   }
+}
+
+if (!emitFiles) {
+  reporterOptions.writer = "MessageWriter";
 }
 
 const mocha = new Mocha({
   reporter: AllureReporter,
-  reporterOptions: {
-    writer: emitFiles ? undefined : "MessageWriter",
-  },
+  reporterOptions,
   parallel,
   require: requires,
   color: false,

--- a/packages/allure-mocha/test/fixtures/samples/labels/meta/change.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/labels/meta/change.spec.js
@@ -1,0 +1,6 @@
+// cjs: const { it } = require("mocha");
+// esm: import { it } from "mocha";
+
+it("a test a changing meta @allure.label.foo:bar", async () => {});
+
+it("a test a changing meta @allure.label.foo:baz", async () => {});

--- a/packages/allure-mocha/test/fixtures/samples/labels/meta/id/1004.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/labels/meta/id/1004.spec.js
@@ -1,0 +1,4 @@
+// cjs: const { it } = require("mocha");
+// esm: import { it } from "mocha";
+
+it("a test with ID 1004 @allure.id:1004", async () => {});

--- a/packages/allure-mocha/test/fixtures/samples/labels/meta/id/1005.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/labels/meta/id/1005.spec.js
@@ -1,0 +1,4 @@
+// cjs: const { it } = require("mocha");
+// esm: import { it } from "mocha";
+
+it("a test with ID 1005 @allure.id:1005", async () => {});

--- a/packages/allure-mocha/test/fixtures/samples/labels/meta/multiple.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/labels/meta/multiple.spec.js
@@ -1,0 +1,4 @@
+// cjs: const { it } = require("mocha");
+// esm: import { it } from "mocha";
+
+it("a test two embedded custom label @allure.label.foo:bar @allure.label.baz:qux", async () => {});

--- a/packages/allure-mocha/test/fixtures/samples/labels/meta/single.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/labels/meta/single.spec.js
@@ -1,0 +1,4 @@
+// cjs: const { it } = require("mocha");
+// esm: import { it } from "mocha";
+
+it("a test with an embedded custom label @allure.label.foo:bar", async () => {});

--- a/packages/allure-mocha/test/spec/api/metadata.test.ts
+++ b/packages/allure-mocha/test/spec/api/metadata.test.ts
@@ -61,8 +61,8 @@ describe("embedded metadata", () => {
 
   it("meta doesn't affect testCaseId and historyId", () => {
     const [
-      {testCaseId: testCaseIdBefore, historyId: historyIdBefore},
-      {testCaseId: testCaseIdAfter, historyId: historyIdAfter},
+      { testCaseId: testCaseIdBefore, historyId: historyIdBefore },
+      { testCaseId: testCaseIdAfter, historyId: historyIdAfter },
     ] = tests.filter((t) => t.name === "a test a changing meta");
 
     expect(testCaseIdBefore).toBe(testCaseIdAfter);

--- a/packages/allure-mocha/test/spec/api/metadata.test.ts
+++ b/packages/allure-mocha/test/spec/api/metadata.test.ts
@@ -1,0 +1,71 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { TestResult } from "allure-js-commons";
+import { runMochaInlineTest } from "../../utils.js";
+
+describe("embedded metadata", () => {
+  let tests: TestResult[];
+  beforeAll(async () => {
+    ({ tests } = await runMochaInlineTest(
+      ["labels", "meta", "id", "1004"],
+      ["labels", "meta", "single"],
+      ["labels", "meta", "multiple"],
+      ["labels", "meta", "change"],
+    ));
+  });
+
+  it("may apply an Allure ID", () => {
+    expect(tests).toContainEqual(
+      expect.objectContaining({
+        name: "a test with ID 1004",
+        labels: expect.arrayContaining([
+          {
+            name: "ALLURE_ID",
+            value: "1004",
+          },
+        ]),
+      }),
+    );
+  });
+
+  it("may apply a custom label", () => {
+    expect(tests).toContainEqual(
+      expect.objectContaining({
+        name: "a test with an embedded custom label",
+        labels: expect.arrayContaining([
+          {
+            name: "foo",
+            value: "bar",
+          },
+        ]),
+      }),
+    );
+  });
+
+  it("may apply multiple labels", () => {
+    expect(tests).toContainEqual(
+      expect.objectContaining({
+        name: "a test two embedded custom label",
+        labels: expect.arrayContaining([
+          {
+            name: "foo",
+            value: "bar",
+          },
+          {
+            name: "baz",
+            value: "qux",
+          },
+        ]),
+      }),
+    );
+  });
+
+  it("meta doesn't affect testCaseId and historyId", () => {
+    const [
+      {testCaseId: testCaseIdBefore, historyId: historyIdBefore},
+      {testCaseId: testCaseIdAfter, historyId: historyIdAfter},
+    ] = tests.filter((t) => t.name === "a test a changing meta");
+
+    expect(testCaseIdBefore).toBe(testCaseIdAfter);
+    expect(historyIdBefore).toBe(historyIdAfter);
+  });
+});

--- a/packages/allure-mocha/test/spec/api/testplan.test.ts
+++ b/packages/allure-mocha/test/spec/api/testplan.test.ts
@@ -1,0 +1,43 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import type { TestResult } from "allure-js-commons";
+import { runMochaInlineTest } from "../../utils.js";
+
+describe("testplan", () => {
+  describe("by selector", () => {
+    let tests: TestResult[];
+    beforeAll(async () => {
+      ({tests} = await runMochaInlineTest(
+        {
+          testplan: [
+            {selector: [["plain-mocha", "testInFileScope"], "a test in a file scope"]},
+          ]
+        },
+        ["plain-mocha", "testInFileScope"],
+        ["plain-mocha", "testInSuite"],
+      ));
+    });
+
+    it("selects only one test by fullName", () => {
+      expect(tests).toEqual([
+        expect.objectContaining({name: "a test in a file scope"}),
+      ]);
+    });
+  });
+
+  describe("by id", () => {
+    let tests: TestResult[];
+    beforeAll(async () => {
+      ({tests} = await runMochaInlineTest(
+        {testplan: [{id: 1004}]},
+        ["labels", "meta", "id", "1004"],
+        ["labels", "meta", "id", "1005"],
+      ));
+    });
+
+    it("selects only one test by ID", () => {
+      expect(tests).toEqual([
+        expect.objectContaining({name: "a test with ID 1004"}),
+      ]);
+    });
+  });
+});

--- a/packages/allure-mocha/test/spec/api/testplan.test.ts
+++ b/packages/allure-mocha/test/spec/api/testplan.test.ts
@@ -6,11 +6,9 @@ describe("testplan", () => {
   describe("by selector", () => {
     let tests: TestResult[];
     beforeAll(async () => {
-      ({tests} = await runMochaInlineTest(
+      ({ tests } = await runMochaInlineTest(
         {
-          testplan: [
-            {selector: [["plain-mocha", "testInFileScope"], "a test in a file scope"]},
-          ]
+          testplan: [{ selector: [["plain-mocha", "testInFileScope"], "a test in a file scope"] }],
         },
         ["plain-mocha", "testInFileScope"],
         ["plain-mocha", "testInSuite"],
@@ -18,26 +16,22 @@ describe("testplan", () => {
     });
 
     it("selects only one test by fullName", () => {
-      expect(tests).toEqual([
-        expect.objectContaining({name: "a test in a file scope"}),
-      ]);
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a file scope" })]);
     });
   });
 
   describe("by id", () => {
     let tests: TestResult[];
     beforeAll(async () => {
-      ({tests} = await runMochaInlineTest(
-        {testplan: [{id: 1004}]},
+      ({ tests } = await runMochaInlineTest(
+        { testplan: [{ id: 1004 }] },
         ["labels", "meta", "id", "1004"],
         ["labels", "meta", "id", "1005"],
       ));
     });
 
     it("selects only one test by ID", () => {
-      expect(tests).toEqual([
-        expect.objectContaining({name: "a test with ID 1004"}),
-      ]);
+      expect(tests).toEqual([expect.objectContaining({ name: "a test with ID 1004" })]);
     });
   });
 });

--- a/packages/allure-mocha/test/spec/config.test.ts
+++ b/packages/allure-mocha/test/spec/config.test.ts
@@ -1,0 +1,50 @@
+import { beforeAll, describe, expect, it } from "vitest";
+import { Status } from "allure-js-commons";
+import { runMochaInlineTest } from "../utils.js";
+
+describe("configuration", () => {
+  let envInfo: unknown, categories: unknown;
+  beforeAll(async () => {
+    ({ envInfo, categories } = await runMochaInlineTest(
+      {
+        environmentInfo: { foo: "bar", baz: "qux" },
+        categories: [{
+          name: "foo",
+          description: "bar",
+          messageRegex: "broken",
+          matchedStatuses: [Status.BROKEN],
+        }, {
+          name: "baz",
+          description: "qux",
+          messageRegex: "failure",
+          matchedStatuses: [Status.FAILED],
+        }],
+      },
+      ["plain-mocha", "testInFileScope"],
+    ));
+  });
+
+  it("applies environmentInfo", () => {
+    expect(envInfo).toMatchObject({
+      foo: "bar",
+      baz: "qux",
+    });
+  });
+
+  it("applies categories", () => {
+    expect(categories).toEqual([
+      {
+        name: "foo",
+        description: "bar",
+        messageRegex: "broken",
+        matchedStatuses: [Status.BROKEN],
+      },
+      {
+        name: "baz",
+        description: "qux",
+        messageRegex: "failure",
+        matchedStatuses: [Status.FAILED],
+      },
+    ]);
+  });
+});

--- a/packages/allure-mocha/test/spec/config.test.ts
+++ b/packages/allure-mocha/test/spec/config.test.ts
@@ -8,17 +8,20 @@ describe("configuration", () => {
     ({ envInfo, categories } = await runMochaInlineTest(
       {
         environmentInfo: { foo: "bar", baz: "qux" },
-        categories: [{
-          name: "foo",
-          description: "bar",
-          messageRegex: "broken",
-          matchedStatuses: [Status.BROKEN],
-        }, {
-          name: "baz",
-          description: "qux",
-          messageRegex: "failure",
-          matchedStatuses: [Status.FAILED],
-        }],
+        categories: [
+          {
+            name: "foo",
+            description: "bar",
+            messageRegex: "broken",
+            matchedStatuses: [Status.BROKEN],
+          },
+          {
+            name: "baz",
+            description: "qux",
+            messageRegex: "failure",
+            matchedStatuses: [Status.FAILED],
+          },
+        ],
       },
       ["plain-mocha", "testInFileScope"],
     ));

--- a/packages/allure-mocha/test/spec/framework/result.test.ts
+++ b/packages/allure-mocha/test/spec/framework/result.test.ts
@@ -14,7 +14,9 @@ describe("defaults", () => {
   });
 
   it("has fullName", () => {
-    const fnPattern = new RegExp(`^test/fixtures/run-results/[a-f0-9-]+/plain-mocha/testInFileScope\\.spec\\${SPEC_EXT}: a test in a file scope$`);
+    const fnPattern = new RegExp(
+      `^test/fixtures/run-results/[a-f0-9-]+/plain-mocha/testInFileScope\\.spec\\${SPEC_EXT}: a test in a file scope$`,
+    );
     expect(test.fullName).toMatch(fnPattern);
   });
 
@@ -35,7 +37,9 @@ describe("defaults", () => {
 
   it("has default labels", () => {
     const labels = test.labels;
-    const packagePattern = new RegExp(`^test\\.fixtures\\.run-results\\.[a-f0-9-]+\\.plain-mocha\\.testInFileScope\\.spec\\${SPEC_EXT}$`);
+    const packagePattern = new RegExp(
+      `^test\\.fixtures\\.run-results\\.[a-f0-9-]+\\.plain-mocha\\.testInFileScope\\.spec\\${SPEC_EXT}$`,
+    );
     expect(labels).toContainEqual({ name: "language", value: "javascript" });
     expect(labels).toContainEqual({ name: "framework", value: "mocha" });
     expect(labels).toContainEqual({ name: "host", value: expect.anything() });

--- a/packages/allure-mocha/test/spec/framework/result.test.ts
+++ b/packages/allure-mocha/test/spec/framework/result.test.ts
@@ -14,7 +14,7 @@ describe("defaults", () => {
   });
 
   it("has fullName", () => {
-    const fnPattern = new RegExp(`plain-mocha\\/testInFileScope\\.spec\\${SPEC_EXT}: a test in a file scope$`);
+    const fnPattern = new RegExp(`^test/fixtures/run-results/[a-f0-9-]+/plain-mocha/testInFileScope\\.spec\\${SPEC_EXT}: a test in a file scope$`);
     expect(test.fullName).toMatch(fnPattern);
   });
 
@@ -35,7 +35,7 @@ describe("defaults", () => {
 
   it("has default labels", () => {
     const labels = test.labels;
-    const packagePattern = new RegExp(`plain-mocha\\.testInFileScope\\.spec\\${SPEC_EXT}$`);
+    const packagePattern = new RegExp(`^test\\.fixtures\\.run-results\\.[a-f0-9-]+\\.plain-mocha\\.testInFileScope\\.spec\\${SPEC_EXT}$`);
     expect(labels).toContainEqual({ name: "language", value: "javascript" });
     expect(labels).toContainEqual({ name: "framework", value: "mocha" });
     expect(labels).toContainEqual({ name: "host", value: expect.anything() });

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -9,7 +9,7 @@ import { MessageReader } from "allure-js-commons/sdk/reporter";
 type MochaRunOptions = {
   env?: { [keys: string]: string };
   testplan?: readonly TestPlanEntryFixture[];
-  environmentInfo?: { [keys: string]: string};
+  environmentInfo?: { [keys: string]: string };
   categories?: readonly Category[];
 };
 
@@ -95,13 +95,17 @@ abstract class AllureMochaTestRunner {
       this.config.env ??= {};
       this.config.env.ALLURE_TESTPLAN_PATH = testplanPath;
       const selectorPrefix = path.relative(path.join(__dirname, ".."), testDir);
-      await writeFile(testplanPath, JSON.stringify({
-        version: "1.0",
-        tests: this.config.testplan.map((test) => ({
-          id: test.id,
-          selector: test.selector ? this.resolveTestplanSelector(selectorPrefix, test.selector) : undefined,
-        })),
-      }), { encoding: "utf-8" });
+      await writeFile(
+        testplanPath,
+        JSON.stringify({
+          version: "1.0",
+          tests: this.config.testplan.map((test) => ({
+            id: test.id,
+            selector: test.selector ? this.resolveTestplanSelector(selectorPrefix, test.selector) : undefined,
+          })),
+        }),
+        { encoding: "utf-8" },
+      );
     }
 
     const testProcess = fork(scriptPath, scriptArgs, {

--- a/packages/allure-mocha/vitest.config.mts
+++ b/packages/allure-mocha/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
     dir: "./test/spec",
     fileParallelism: false,
     testTimeout: 25000,
+    hookTimeout: 25000,
     reporters: ["default"],
     globalSetup: ["./test/setup.ts"],
     typecheck: {


### PR DESCRIPTION
### Context
Add test plan support to Allure Mocha.

### Extra changes

  - dump the environment info and categories when the test run is done
  - allure metadata (labels and a shorthand for ALLURE_ID) can now be specified via a test's name. That doesn't affect testCaseId and display name:
    ```js
    it("my test @allure.id:1001 @allure.label.owner:John", () => { /* ... */ });
    ```
    That's crucial for filtering by ID via a test plan.
  - hook timeout was increased when testing Allure Mocha (some combinations take around 10 seconds to complete on my machine - the default hook timeout value)
  - Redundant host and thread labels calculation was removed from allure-mocha. Allure-js-commons is used now.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
