### PR TITLE
Don't add extra suite label in allure-cucumberjs to fix #999

### DIFF
--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -281,13 +281,6 @@ export default class AllureCucumberReporter extends Formatter {
       });
     }
 
-    if (scenario) {
-      result.labels!.push({
-        name: LabelName.SUITE,
-        value: scenario.name,
-      });
-    }
-
     const pickleLabels = this.parsePickleTags(pickle.tags || []);
     const featureLabels = this.parseTagsLabels(doc?.feature?.tags || []);
     const featureLinks = this.parseTagsLinks(doc?.feature?.tags || []);


### PR DESCRIPTION
### Context
As described in #999 and comments to it, allure-cucumberjs adds the `suite` label with value of `scenario.name`, which makes no sense in both cases:

- if a user sets their own suite, they get a duplicate in the report due to 2 `suite` labels;
- otherwise (since scenario names are unique), it creates an excessive level of nesting: suite has the same name as the only element in it, see the screen in the original issue.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
