### PR TITLE
Fix typescript-eslint issues

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -23,6 +23,12 @@ module.exports = {
   },
   plugins: ["n", "no-null", "prefer-arrow", "import", "jsdoc", "@typescript-eslint"],
   ignorePatterns: ["**/dist/**/*"],
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
   rules: {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/adjacent-overload-signatures": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,3 +1,4 @@
+/* eslint-disable id-blacklist */
 module.exports = {
   root: true,
   globals: {
@@ -164,11 +165,11 @@ module.exports = {
     "arrow-body-style": "off",
     "arrow-parens": ["off", "always"],
     "brace-style": ["error", "1tbs"],
-    complexity: "off",
+    "complexity": "off",
     "constructor-super": "error",
-    curly: "error",
+    "curly": "error",
     "eol-last": "error",
-    eqeqeq: ["error", "smart"],
+    "eqeqeq": ["error", "smart"],
     "guard-for-in": "error",
     "id-blacklist": [
       "error",
@@ -226,7 +227,7 @@ module.exports = {
     "prefer-const": "error",
     "prefer-template": "error",
     "quote-props": ["error", "consistent-as-needed"],
-    radix: "error",
+    "radix": "error",
     "space-before-function-paren": [
       "error",
       {

--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -6,7 +6,7 @@ import { URL as URL$1, fileURLToPath, pathToFileURL } from 'url';
 import path from 'path';
 import { createHash } from 'crypto';
 import { EOL } from 'os';
-import moduleExports, { isBuiltin } from 'module';
+import esmModule, { createRequire, isBuiltin } from 'module';
 import assert from 'assert';
 
 const SAFE_TIME = 456789e3;
@@ -1975,6 +1975,13 @@ function packageImportsResolve({ name, base, conditions, readFileSyncFn }) {
   throwImportNotDefined(name, packageJSONUrl, base);
 }
 
+let findPnpApi = esmModule.findPnpApi;
+if (!findPnpApi) {
+  const require = createRequire(import.meta.url);
+  const pnpApi = require(`./.pnp.cjs`);
+  pnpApi.setup();
+  findPnpApi = esmModule.findPnpApi;
+}
 const pathRegExp = /^(?![a-zA-Z]:[\\/]|\\\\|\.{0,2}(?:\/|$))((?:node:)?(?:@[^/]+\/)?[^/]+)\/*(.*|)$/;
 const isRelativeRegexp = /^\.{0,2}\//;
 function tryReadFile(filePath) {
@@ -2002,7 +2009,6 @@ async function resolvePrivateRequest(specifier, issuer, context, nextResolve) {
   }
 }
 async function resolve$1(originalSpecifier, context, nextResolve) {
-  const { findPnpApi } = moduleExports;
   if (!findPnpApi || isBuiltin(originalSpecifier))
     return nextResolve(originalSpecifier, context, nextResolve);
   let specifier = originalSpecifier;

--- a/packages/allure-codeceptjs/.eslintrc.cjs
+++ b/packages/allure-codeceptjs/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ["../../.eslintrc.cjs"],
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-codeceptjs/.eslintrc.cjs
+++ b/packages/allure-codeceptjs/.eslintrc.cjs
@@ -4,4 +4,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/allure-codeceptjs/src/reporter.ts
+++ b/packages/allure-codeceptjs/src/reporter.ts
@@ -39,7 +39,7 @@ export class AllureCodeceptJsReporter {
       }
 
       // @ts-ignore
-      result.parameters!.push({ name: "Repetition", value: `${test.retryNum + 1}` });
+      result.parameters.push({ name: "Repetition", value: `${test.retryNum + 1}` });
     }, this.currentAllureResultUuid);
 
     this.allureRuntime!.stopTest({ uuid: this.currentAllureResultUuid });
@@ -198,28 +198,28 @@ export class AllureCodeceptJsReporter {
       {
         name: `${step.actor} ${step.name}`,
       },
-      this.currentAllureResultUuid!,
+      this.currentAllureResultUuid,
     );
   }
 
   stepFailed() {
     this.allureRuntime!.updateStep((result) => {
       result.status = Status.FAILED;
-    }, this.currentAllureResultUuid!);
+    }, this.currentAllureResultUuid);
     this.closeCurrentAllureStep();
   }
 
   stepComment() {
     this.allureRuntime!.updateStep((result) => {
       result.status = Status.PASSED;
-    }, this.currentAllureResultUuid!);
+    }, this.currentAllureResultUuid);
     this.closeCurrentAllureStep();
   }
 
   stepPassed() {
     this.allureRuntime!.updateStep((result) => {
       result.status = Status.PASSED;
-    }, this.currentAllureResultUuid!);
+    }, this.currentAllureResultUuid);
     this.closeCurrentAllureStep();
   }
 

--- a/packages/allure-codeceptjs/test/spec/runtime/legacy/attachments.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/legacy/attachments.test.ts
@@ -24,7 +24,7 @@ it("handles attachments in tests", async () => {
     type: "text/plain",
     source: expect.any(String),
   });
-  expect(attachments).toHaveProperty(attachment.source as string);
+  expect(attachments).toHaveProperty(attachment.source);
   expect(Buffer.from(attachments[attachment.source] as string, "base64").toString("utf8")).toEqual("some data");
 });
 
@@ -56,6 +56,6 @@ it("handles attachments in runtime steps", async () => {
     type: "text/plain",
     source: expect.any(String),
   });
-  expect(attachments).toHaveProperty(attachment.source as string);
+  expect(attachments).toHaveProperty(attachment.source);
   expect(Buffer.from(attachments[attachment.source] as string, "base64").toString("utf8")).toEqual("some data");
 });

--- a/packages/allure-codeceptjs/test/spec/runtime/modern/attachments.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/modern/attachments.test.ts
@@ -24,7 +24,7 @@ it("handles attachments in tests", async () => {
     type: "text/plain",
     source: expect.any(String),
   });
-  expect(attachments).toHaveProperty(attachment.source as string);
+  expect(attachments).toHaveProperty(attachment.source);
   expect(Buffer.from(attachments[attachment.source] as string, "base64").toString("utf8")).toEqual("some data");
 });
 
@@ -56,6 +56,6 @@ it("handles attachments in runtime steps", async () => {
     type: "text/plain",
     source: expect.any(String),
   });
-  expect(attachments).toHaveProperty(attachment.source as string);
+  expect(attachments).toHaveProperty(attachment.source);
   expect(Buffer.from(attachments[attachment.source] as string, "base64").toString("utf8")).toEqual("some data");
 });

--- a/packages/allure-cucumberjs/.eslintrc.cjs
+++ b/packages/allure-cucumberjs/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ["../../.eslintrc.cjs"],
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-cucumberjs/.eslintrc.cjs
+++ b/packages/allure-cucumberjs/.eslintrc.cjs
@@ -4,4 +4,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -290,7 +290,7 @@ export default class AllureCucumberReporter extends Formatter {
 
     const testUuid = this.allureRuntime.startTest(result);
     this.testCaseStartedMap.set(data.id, data);
-    this.allureResultsUuids.set(data.id, testUuid as string);
+    this.allureResultsUuids.set(data.id, testUuid);
     this.allureRuntime.startScope();
 
     if (!scenario?.examples) {

--- a/packages/allure-cypress/.eslintrc.cjs
+++ b/packages/allure-cypress/.eslintrc.cjs
@@ -8,6 +8,7 @@ module.exports = {
     "cypress/globals": true,
   },
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-cypress/.eslintrc.cjs
+++ b/packages/allure-cypress/.eslintrc.cjs
@@ -11,4 +11,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/allure-cypress/test/spec/screenshots.test.ts
+++ b/packages/allure-cypress/test/spec/screenshots.test.ts
@@ -18,7 +18,7 @@ it("attaches screenshots for failed specs", async () => {
 
   expect(attachment.name).toBe("Screenshot");
   expect(attachment.type).toBe(ContentType.PNG);
-  expect(attachments).toHaveProperty((attachment).source);
+  expect(attachments).toHaveProperty(attachment.source);
 });
 
 it("attaches runtime screenshots", async () => {
@@ -37,5 +37,5 @@ it("attaches runtime screenshots", async () => {
 
   expect(attachment.name).toBe("foo");
   expect(attachment.type).toBe(ContentType.PNG);
-  expect(attachments).toHaveProperty((attachment).source);
+  expect(attachments).toHaveProperty(attachment.source);
 });

--- a/packages/allure-cypress/test/spec/screenshots.test.ts
+++ b/packages/allure-cypress/test/spec/screenshots.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { type Attachment, ContentType } from "allure-js-commons";
+import { ContentType } from "allure-js-commons";
 import { runCypressInlineTest } from "../utils.js";
 
 it("attaches screenshots for failed specs", async () => {
@@ -18,7 +18,7 @@ it("attaches screenshots for failed specs", async () => {
 
   expect(attachment.name).toBe("Screenshot");
   expect(attachment.type).toBe(ContentType.PNG);
-  expect(attachments).toHaveProperty((attachment as Attachment).source);
+  expect(attachments).toHaveProperty((attachment).source);
 });
 
 it("attaches runtime screenshots", async () => {
@@ -37,5 +37,5 @@ it("attaches runtime screenshots", async () => {
 
   expect(attachment.name).toBe("foo");
   expect(attachment.type).toBe(ContentType.PNG);
-  expect(attachments).toHaveProperty((attachment as Attachment).source);
+  expect(attachments).toHaveProperty((attachment).source);
 });

--- a/packages/allure-jasmine/.eslintrc.cjs
+++ b/packages/allure-jasmine/.eslintrc.cjs
@@ -4,6 +4,7 @@ module.exports = {
     jasmine: true,
   },
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-jasmine/.eslintrc.cjs
+++ b/packages/allure-jasmine/.eslintrc.cjs
@@ -7,4 +7,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/allure-jasmine/src/index.ts
+++ b/packages/allure-jasmine/src/index.ts
@@ -79,7 +79,7 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
     const allureRuntime = this.allureRuntime;
     const globalJasmine = globalThis.jasmine;
     const currentAllureResultUuidGetter = () => this.currentAllureTestUuid;
-    const currentAllureStepResultGetter = () => this.allureRuntime.getCurrentStep(currentAllureResultUuidGetter()!);
+    const currentAllureStepResultGetter = () => this.allureRuntime.getCurrentStep(currentAllureResultUuidGetter());
     // @ts-ignore
     const originalExpectationHandler = globalJasmine.Spec.prototype.addExpectationResult;
 
@@ -92,7 +92,7 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
         allureRuntime.updateStep((result) => {
           result.status = Status.FAILED;
           result.stage = Stage.FINISHED;
-        }, currentAllureResultUuidGetter()!);
+        }, currentAllureResultUuidGetter());
       }
 
       originalExpectationHandler.call(this, passed, data, isError);
@@ -156,9 +156,9 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
         result.status = Status.BROKEN;
         return;
       }
-    }, this.currentAllureTestUuid!);
+    }, this.currentAllureTestUuid);
     this.allureRuntime.stopTest({ uuid: this.currentAllureTestUuid! });
-    this.allureRuntime.writeTest(this.currentAllureTestUuid!);
+    this.allureRuntime.writeTest(this.currentAllureTestUuid);
     this.currentAllureTestUuid = undefined;
   }
 

--- a/packages/allure-jest/.eslintrc.cjs
+++ b/packages/allure-jest/.eslintrc.cjs
@@ -10,4 +10,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
-}
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
+};

--- a/packages/allure-jest/.eslintrc.cjs
+++ b/packages/allure-jest/.eslintrc.cjs
@@ -7,6 +7,7 @@ module.exports = {
     jest: true,
   },
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 }

--- a/packages/allure-jest/src/environmentFactory.ts
+++ b/packages/allure-jest/src/environmentFactory.ts
@@ -174,7 +174,7 @@ const createJestEnvironment = <T extends typeof JestEnvironment>(Base: T): T => 
         return;
       }
 
-      this.allureUuidsByTestIds.set(newTestId, testUuid as string);
+      this.allureUuidsByTestIds.set(newTestId, testUuid);
     }
 
     private handleTestStart(test: Circus.TestEntry) {

--- a/packages/allure-js-commons/.eslintrc.cjs
+++ b/packages/allure-js-commons/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ["../../.eslintrc.cjs"],
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-js-commons/.eslintrc.cjs
+++ b/packages/allure-js-commons/.eslintrc.cjs
@@ -4,4 +4,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/allure-js-commons/tsconfig.test.json
+++ b/packages/allure-js-commons/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["./test/**/*"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/allure-mocha/.eslintrc.cjs
+++ b/packages/allure-mocha/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ["../../.eslintrc.cjs"],
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
   overrides: [

--- a/packages/allure-mocha/.eslintrc.cjs
+++ b/packages/allure-mocha/.eslintrc.cjs
@@ -6,6 +6,10 @@ module.exports = {
   },
   overrides: [
     {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    },
+    {
       files: ["**/*.cjs", "**/*.js"],
       rules: {
         "@typescript-eslint/no-require-imports": "off",

--- a/packages/allure-mocha/src/AllureMochaReporter.ts
+++ b/packages/allure-mocha/src/AllureMochaReporter.ts
@@ -175,7 +175,7 @@ export class AllureMochaReporter extends Mocha.reporters.Base {
   private onHookEnd = (hook: Mocha.Hook) => {
     if (this.runtime.hasFixture()) {
       this.runtime.updateFixture((r) => {
-        const error = hook.error();
+        const error: Error | undefined = hook.error();
         if (error) {
           r.status = getStatusFromError(error);
           r.statusDetails = {

--- a/packages/allure-mocha/src/legacy.ts
+++ b/packages/allure-mocha/src/legacy.ts
@@ -53,7 +53,7 @@ class LegacyAllureApi {
    * @deprecated please use import { parameter } from "allure-js-commons" instead.
    */
   parameter = (name: string, value: any, options?: ParameterOptions) =>
-    Promise.resolve(commons.parameter(name, serialize(value) as string, options));
+    Promise.resolve(commons.parameter(name, serialize(value), options));
   /**
    * @deprecated please use import { link } from "allure-js-commons" instead.
    */

--- a/packages/allure-mocha/test/spec/api/runtime/legacy/links.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/legacy/links.test.ts
@@ -13,7 +13,7 @@ describe("legacy link API", () => {
       ["legacy", "links", "tms"],
     );
     for (const test of tests) {
-      testMap.set(test.name as string, test as TestResult);
+      testMap.set(test.name as string, test);
     }
   });
 

--- a/packages/allure-mocha/test/spec/api/runtime/legacy/parameters.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/legacy/parameters.test.ts
@@ -13,9 +13,9 @@ describe("legacy runtime parameters API", () => {
     );
     for (const testResult of results.tests) {
       if (testMap.has(testResult.name as string)) {
-        testMap.get(testResult.name as string)!.push(testResult as TestResult);
+        testMap.get(testResult.name as string)!.push(testResult);
       } else {
-        testMap.set(testResult.name as string, [testResult as TestResult]);
+        testMap.set(testResult.name as string, [testResult]);
       }
     }
   });

--- a/packages/allure-mocha/test/spec/api/runtime/legacy/steps.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/legacy/steps.test.ts
@@ -24,7 +24,7 @@ describe("step", () => {
       ["legacy", "steps", "stepReturnsPromise"],
     );
     for (const testResult of results.tests) {
-      testMap.set(testResult.name as string, testResult as TestResult);
+      testMap.set(testResult.name as string, testResult);
     }
     attachments = results.attachments;
   });

--- a/packages/allure-mocha/test/spec/api/runtime/legacy/suites.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/legacy/suites.test.ts
@@ -12,7 +12,7 @@ describe("legacy suites API", () => {
       ["legacy", "labels", "suites", "subSuite"],
     );
     for (const testResult of tests) {
-      testMap.set(testResult.name as string, testResult as TestResult);
+      testMap.set(testResult.name as string, testResult);
     }
   });
 

--- a/packages/allure-mocha/test/spec/api/runtime/links.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/links.test.ts
@@ -16,7 +16,7 @@ describe("link", () => {
       ["links", "multipleLinks"],
     );
     for (const test of tests) {
-      testMap.set(test.name as string, test as TestResult);
+      testMap.set(test.name as string, test);
     }
   });
 

--- a/packages/allure-mocha/test/spec/api/runtime/parameters.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/parameters.test.ts
@@ -13,9 +13,9 @@ describe("runtime parameter", () => {
     );
     for (const testResult of results.tests) {
       if (testMap.has(testResult.name as string)) {
-        testMap.get(testResult.name as string)!.push(testResult as TestResult);
+        testMap.get(testResult.name as string)!.push(testResult);
       } else {
-        testMap.set(testResult.name as string, [testResult as TestResult]);
+        testMap.set(testResult.name as string, [testResult]);
       }
     }
   });

--- a/packages/allure-mocha/test/spec/api/runtime/steps.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/steps.test.ts
@@ -23,7 +23,7 @@ describe("step", () => {
       ["steps", "stepReturnsPromise"],
     );
     for (const testResult of results.tests) {
-      testMap.set(testResult.name as string, testResult as TestResult);
+      testMap.set(testResult.name as string, testResult);
     }
     attachments = results.attachments;
   });

--- a/packages/allure-mocha/test/spec/api/runtime/suites.test.ts
+++ b/packages/allure-mocha/test/spec/api/runtime/suites.test.ts
@@ -20,7 +20,7 @@ describe("suites", () => {
       ["labels", "suites", "subSuiteNestedScope"],
     );
     for (const testResult of tests) {
-      testMap.set(testResult.name as string, testResult as TestResult);
+      testMap.set(testResult.name as string, testResult);
     }
   });
 

--- a/packages/allure-mocha/test/spec/framework/statuses.test.ts
+++ b/packages/allure-mocha/test/spec/framework/statuses.test.ts
@@ -13,7 +13,7 @@ describe("test status", () => {
       ["plain-mocha", "skippedTest"],
     );
     for (const test of tests) {
-      testMap.set(test.name as string, test as TestResult);
+      testMap.set(test.name as string, test);
     }
   });
 

--- a/packages/allure-playwright/.eslintrc.cjs
+++ b/packages/allure-playwright/.eslintrc.cjs
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ["../../.eslintrc.cjs"],
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-playwright/.eslintrc.cjs
+++ b/packages/allure-playwright/.eslintrc.cjs
@@ -4,4 +4,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -100,7 +100,7 @@ export class AllureReporter implements ReporterV2 {
     const cliArgs: string[] = [];
 
     testsWithSelectors.forEach((test) => {
-      if (!/#/.test(test.selector as string)) {
+      if (!/#/.test(test.selector)) {
         v2ReporterTests.push(test);
         return;
       }
@@ -114,7 +114,7 @@ export class AllureReporter implements ReporterV2 {
         .map((test) => test.selector.replace(/:\d+$/, ""))
         .map((selector) => escapeRegExp(selector));
 
-      cliArgs.push(...(v2SelectorsArgs as string[]));
+      cliArgs.push(...(v2SelectorsArgs));
     }
 
     if (v1ReporterTests.length) {
@@ -123,7 +123,7 @@ export class AllureReporter implements ReporterV2 {
         .map((test) => test.selector.split("#")[0])
         .map((selector) => escapeRegExp(selector));
 
-      cliArgs.push(...(v1SelectorsArgs as string[]));
+      cliArgs.push(...(v1SelectorsArgs));
     }
 
     if (!cliArgs.length) {
@@ -187,8 +187,8 @@ export class AllureReporter implements ReporterV2 {
 
     const testUuid = this.allureRuntime!.startTest(result);
 
-    this.allureResultsUuids.set(test.id, testUuid as string);
-    this.startedTestCasesTitlesCache.push(titleMetadata.cleanTitle as string);
+    this.allureResultsUuids.set(test.id, testUuid);
+    this.startedTestCasesTitlesCache.push(titleMetadata.cleanTitle);
   }
 
   onStepBegin(test: TestCase, _result: PlaywrightTestResult, step: TestStep): void {
@@ -249,15 +249,15 @@ export class AllureReporter implements ReporterV2 {
       testResult.labels.push({ name: LabelName.HOST, value: this.hostname });
       testResult.labels.push({ name: LabelName.THREAD, value: thread });
 
-      if (projectSuiteTitle && !hasLabel(testResult as TestResult, LabelName.PARENT_SUITE)) {
+      if (projectSuiteTitle && !hasLabel(testResult, LabelName.PARENT_SUITE)) {
         testResult.labels.push({ name: LabelName.PARENT_SUITE, value: projectSuiteTitle });
       }
 
-      if (this.options.suiteTitle && fileSuiteTitle && !hasLabel(testResult as TestResult, LabelName.SUITE)) {
+      if (this.options.suiteTitle && fileSuiteTitle && !hasLabel(testResult, LabelName.SUITE)) {
         testResult.labels.push({ name: LabelName.SUITE, value: fileSuiteTitle });
       }
 
-      if (suiteTitles.length > 0 && !hasLabel(testResult as TestResult, LabelName.SUB_SUITE)) {
+      if (suiteTitles.length > 0 && !hasLabel(testResult, LabelName.SUB_SUITE)) {
         testResult.labels.push({ name: LabelName.SUB_SUITE, value: suiteTitles.join(" > ") });
       }
 
@@ -276,7 +276,7 @@ export class AllureReporter implements ReporterV2 {
     if (result.stdout.length > 0) {
       this.allureRuntime!.writeAttachment(
         "stdout",
-        Buffer.from(stripAnsi(result.stdout.join("")) as string, "utf-8"),
+        Buffer.from(stripAnsi(result.stdout.join("")), "utf-8"),
         {
           contentType: ContentType.TEXT,
         },
@@ -287,7 +287,7 @@ export class AllureReporter implements ReporterV2 {
     if (result.stderr.length > 0) {
       this.allureRuntime!.writeAttachment(
         "stderr",
-        Buffer.from(stripAnsi(result.stderr.join("")) as string, "utf-8"),
+        Buffer.from(stripAnsi(result.stderr.join("")), "utf-8"),
         {
           contentType: ContentType.TEXT,
         },
@@ -307,7 +307,7 @@ export class AllureReporter implements ReporterV2 {
 
         return acc;
       }, {});
-      const newLabels = Object.keys(mappedLabels as Record<string, Label[]>).flatMap((labelName) => {
+      const newLabels = Object.keys(mappedLabels).flatMap((labelName) => {
         const labelsGroup = mappedLabels[labelName];
 
         if (
@@ -332,7 +332,7 @@ export class AllureReporter implements ReporterV2 {
     const unprocessedCases = this.suite.allTests().filter(({ title }) => {
       const titleMetadata = extractMetadataFromString(title);
 
-      return !this.startedTestCasesTitlesCache.includes(titleMetadata.cleanTitle as string);
+      return !this.startedTestCasesTitlesCache.includes(titleMetadata.cleanTitle);
     });
 
     for (const testCase of unprocessedCases) {

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -114,7 +114,7 @@ export class AllureReporter implements ReporterV2 {
         .map((test) => test.selector.replace(/:\d+$/, ""))
         .map((selector) => escapeRegExp(selector));
 
-      cliArgs.push(...(v2SelectorsArgs));
+      cliArgs.push(...v2SelectorsArgs);
     }
 
     if (v1ReporterTests.length) {
@@ -123,7 +123,7 @@ export class AllureReporter implements ReporterV2 {
         .map((test) => test.selector.split("#")[0])
         .map((selector) => escapeRegExp(selector));
 
-      cliArgs.push(...(v1SelectorsArgs));
+      cliArgs.push(...v1SelectorsArgs);
     }
 
     if (!cliArgs.length) {

--- a/packages/allure-playwright/test/spec/runtime/legacy/attachments.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/legacy/attachments.spec.ts
@@ -103,8 +103,8 @@ it("should add attachments into steps", async () => {
   const [attachment1] = tests[0].steps[0].steps[0].steps[0].attachments;
   const [attachment2] = tests[0].steps[1].steps[1].steps[0].attachments;
 
-  expect(attachments).toHaveProperty(attachment1.source as string);
-  expect(attachments).toHaveProperty(attachment2.source as string);
+  expect(attachments).toHaveProperty(attachment1.source);
+  expect(attachments).toHaveProperty(attachment2.source);
   expect(Buffer.from(attachments[attachment1.source] as string, "base64").toString()).toEqual("some-data");
   expect(Buffer.from(attachments[attachment2.source] as string, "base64").toString()).toEqual("other-data");
 });
@@ -208,8 +208,8 @@ it("doesn't not report detail steps for attachments", async () => {
   const [attachment1] = tests[0].steps[2].steps[0].steps[0].attachments;
   const [attachment2] = tests[0].steps[3].steps[1].steps[0].attachments;
 
-  expect(attachments).toHaveProperty(attachment1.source as string);
-  expect(attachments).toHaveProperty(attachment2.source as string);
+  expect(attachments).toHaveProperty(attachment1.source);
+  expect(attachments).toHaveProperty(attachment2.source);
   expect(Buffer.from(attachments[attachment1.source] as string, "base64").toString()).toEqual("some-data");
   expect(Buffer.from(attachments[attachment2.source] as string, "base64").toString()).toEqual("other-data");
 });

--- a/packages/allure-playwright/test/spec/runtime/legacy/labelOverride.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/legacy/labelOverride.spec.ts
@@ -16,7 +16,7 @@ it("overrides suite label", async () => {
 
   expect(tests).toHaveLength(1);
 
-  const suiteLabels = tests[0]!.labels.filter((label: Label) => label.name === LabelName.SUITE);
+  const suiteLabels = tests[0].labels.filter((label: Label) => label.name === LabelName.SUITE);
 
   expect(suiteLabels).toHaveLength(1);
   expect(suiteLabels[0]).toEqual({ name: LabelName.SUITE, value: "SUITE Override" });
@@ -35,7 +35,7 @@ it("overrides parent-suite label", async () => {
 
   expect(tests).toHaveLength(1);
 
-  const parentSuiteLabels = tests[0]!.labels.filter((label: Label) => label.name === LabelName.PARENT_SUITE);
+  const parentSuiteLabels = tests[0].labels.filter((label: Label) => label.name === LabelName.PARENT_SUITE);
 
   expect(parentSuiteLabels).toHaveLength(1);
   expect(parentSuiteLabels[0]).toEqual({
@@ -57,7 +57,7 @@ it("overrides sub-suite label", async () => {
 
   expect(tests).toHaveLength(1);
 
-  const subSuiteLabels = tests[0]!.labels.filter((label: Label) => label.name === LabelName.SUB_SUITE);
+  const subSuiteLabels = tests[0].labels.filter((label: Label) => label.name === LabelName.SUB_SUITE);
 
   expect(subSuiteLabels).toHaveLength(1);
   expect(subSuiteLabels[0]).toEqual({ name: LabelName.SUB_SUITE, value: "SUB SUITE Override" });

--- a/packages/allure-playwright/test/spec/runtime/modern/attachments.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/attachments.spec.ts
@@ -102,8 +102,8 @@ it("should add attachments into steps", async () => {
   const [attachment1] = tests[0].steps[0].steps[0].steps[0].attachments;
   const [attachment2] = tests[0].steps[1].steps[1].steps[0].attachments;
 
-  expect(attachments).toHaveProperty(attachment1.source as string);
-  expect(attachments).toHaveProperty(attachment2.source as string);
+  expect(attachments).toHaveProperty(attachment1.source);
+  expect(attachments).toHaveProperty(attachment2.source);
   expect(Buffer.from(attachments[attachment1.source] as string, "base64").toString()).toEqual("some-data");
   expect(Buffer.from(attachments[attachment2.source] as string, "base64").toString()).toEqual("other-data");
 });
@@ -208,8 +208,8 @@ it("doesn't not report detail steps for attachments", async () => {
   const [attachment1] = tests[0].steps[2].steps[0].steps[0].attachments;
   const [attachment2] = tests[0].steps[3].steps[1].steps[0].attachments;
 
-  expect(attachments).toHaveProperty(attachment1.source as string);
-  expect(attachments).toHaveProperty(attachment2.source as string);
+  expect(attachments).toHaveProperty(attachment1.source);
+  expect(attachments).toHaveProperty(attachment2.source);
   expect(Buffer.from(attachments[attachment1.source] as string, "base64").toString()).toEqual("some-data");
   expect(Buffer.from(attachments[attachment2.source] as string, "base64").toString()).toEqual("other-data");
 });

--- a/packages/allure-playwright/test/spec/runtime/modern/labelOverride.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/labelOverride.spec.ts
@@ -16,7 +16,7 @@ it("overrides suite label", async () => {
 
   expect(tests).toHaveLength(1);
 
-  const suiteLabels = tests[0]!.labels.filter((label) => label.name === LabelName.SUITE);
+  const suiteLabels = tests[0].labels.filter((label) => label.name === LabelName.SUITE);
 
   expect(suiteLabels).toHaveLength(1);
   expect(suiteLabels[0]).toEqual({ name: LabelName.SUITE, value: "SUITE Override" });
@@ -36,7 +36,7 @@ it("overrides parent-suite label", async () => {
 
   expect(tests).toHaveLength(1);
 
-  const parentSuiteLabels = tests[0]!.labels.filter((label) => label.name === LabelName.PARENT_SUITE);
+  const parentSuiteLabels = tests[0].labels.filter((label) => label.name === LabelName.PARENT_SUITE);
 
   expect(parentSuiteLabels).toHaveLength(1);
   expect(parentSuiteLabels[0]).toEqual({ name: LabelName.PARENT_SUITE, value: "PARENT SUITE Override" });
@@ -56,7 +56,7 @@ it("overrides sub-suite label", async () => {
 
   expect(tests).toHaveLength(1);
 
-  const subSuiteLabels = tests[0]!.labels.filter((label) => label.name === LabelName.SUB_SUITE);
+  const subSuiteLabels = tests[0].labels.filter((label) => label.name === LabelName.SUB_SUITE);
 
   expect(subSuiteLabels).toHaveLength(1);
   expect(subSuiteLabels[0]).toEqual({ name: LabelName.SUB_SUITE, value: "SUB SUITE Override" });

--- a/packages/allure-playwright/test/spec/stdio.spec.ts
+++ b/packages/allure-playwright/test/spec/stdio.spec.ts
@@ -31,10 +31,10 @@ it("reports stdout", async () => {
 
   expect(stdout.name).toBe("stdout");
   expect(stdout.type).toBe(ContentType.TEXT);
-  expect(attachments).toHaveProperty(stdout.source as string);
+  expect(attachments).toHaveProperty(stdout.source);
   expect(stderr.name).toBe("stderr");
   expect(stderr.type).toBe(ContentType.TEXT);
-  expect(attachments).toHaveProperty(stderr.source as string);
+  expect(attachments).toHaveProperty(stderr.source);
   expect(Buffer.from(attachments[stdout.source] as string, "base64").toString("utf-8")).toBe(
     "Test log\nTest log 2\n{ foo: 'bar' }\n[ 1, 2, 3, 'test' ]\nTest nested log\n",
   );

--- a/packages/allure-vitest/.eslintrc.cjs
+++ b/packages/allure-vitest/.eslintrc.cjs
@@ -5,6 +5,7 @@ module.exports = {
     allure: true,
   },
   parserOptions: {
+    tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
 };

--- a/packages/allure-vitest/.eslintrc.cjs
+++ b/packages/allure-vitest/.eslintrc.cjs
@@ -8,4 +8,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };

--- a/packages/newman-reporter-allure/.eslintrc.cjs
+++ b/packages/newman-reporter-allure/.eslintrc.cjs
@@ -4,4 +4,10 @@ module.exports = {
     tsconfigRootDir: __dirname,
     project: ["./tsconfig.json", "./tsconfig.test.json"],
   },
+  overrides: [
+    {
+      extends: ["plugin:@typescript-eslint/disable-type-checked"],
+      files: [".eslintrc.cjs"],
+    }
+  ],
 };


### PR DESCRIPTION
### Context
The PR fixes invalid tsconfig resolution by package's typescript-eslint configurations. Previously, each package's `parserOptions.project` option (except the one of `newman-reporter-allure`) was resolved to the root `tsconfig.json` leading to typing issues when accessing a package's sub-paths (e.g., `import type { /* ... */ } from "allure-js-commons/sdk"`). That was because of `"moduleResolution": "node"` in the root config which doesn't support exports in package.json.

The fix is to provide `parserOptions.tsconfigRootDir` together with `parserOptions.project` for each package.

### Additional changes
The PR also addressed the following previously hidden linting-related issues:

  - Parsing error: ESLint was configured to run on <tsconfigRootDir>/.eslintrc.cjs using parserOptions.project: However, none of those TSConfigs include this file
    **Note:** *fixed by disabling the typed checks since we don't need them much in a config file. Another option would be to include `.eslintrc.cjs` in each `tsconfig.test.json` (see [here](https://typescript-eslint.io/troubleshooting/#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file)).*
  - Missing `tsconfig.test.json` in allure-js-commons.
  - In the root `.eslintrc.cjs`: [quote-props](https://eslint.org/docs/latest/rules/quote-props).
  - In `packages/allure-codeceptjs/src/reporter.ts`, `packages/allure-codeceptjs/test/spec/runtime/legacy/attachments.test.ts`, and `packages/allure-codeceptjs/test/spec/runtime/modern/attachments.test.ts`: [@typescript-eslint/no-unnecessary-type-assertion](https://typescript-eslint.io/rules/no-unnecessary-type-assertion).