### PR TITLE
Change link template config type from an array to a record. Support link template functions

### DIFF
--- a/packages/allure-codeceptjs/test/spec/runtime/legacy/links.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/legacy/links.test.ts
@@ -30,16 +30,14 @@ it("sets runtime links", async () => {
             require: require.resolve("allure-codeceptjs"),
             testMode: true,
             enabled: true,
-            links: [
-              {
-                type: "${LinkType.ISSUE}",
+            links: {
+              ${LinkType.ISSUE}: {
                 urlTemplate: "https://example.org/issues/%s",
               },
-              {
-                type: "${LinkType.TMS}",
+              ${LinkType.TMS}: {
                 urlTemplate: "https://example.org/tasks/%s",
               }
-            ]
+            }
           },
         },
         helpers: {

--- a/packages/allure-codeceptjs/test/spec/runtime/legacy/links.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/legacy/links.test.ts
@@ -31,10 +31,10 @@ it("sets runtime links", async () => {
             testMode: true,
             enabled: true,
             links: {
-              ${LinkType.ISSUE}: {
+              issue: {
                 urlTemplate: "https://example.org/issues/%s",
               },
-              ${LinkType.TMS}: {
+              tms: {
                 urlTemplate: "https://example.org/tasks/%s",
               }
             }

--- a/packages/allure-codeceptjs/test/spec/runtime/modern/links.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/modern/links.test.ts
@@ -31,16 +31,14 @@ it("sets runtime links", async () => {
             require: require.resolve("allure-codeceptjs"),
             testMode: true,
             enabled: true,
-            links: [
-              {
-                type: "${LinkType.ISSUE}",
+            links: {
+              ${LinkType.ISSUE}: {
                 urlTemplate: "https://example.org/issues/%s",
               },
-              {
-                type: "${LinkType.TMS}",
+              ${LinkType.TMS}: {
                 urlTemplate: "https://example.org/tasks/%s",
               }
-            ]
+            }
           },
         },
         helpers: {

--- a/packages/allure-codeceptjs/test/spec/runtime/modern/links.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/modern/links.test.ts
@@ -32,10 +32,10 @@ it("sets runtime links", async () => {
             testMode: true,
             enabled: true,
             links: {
-              ${LinkType.ISSUE}: {
+              issue: {
                 urlTemplate: "https://example.org/issues/%s",
               },
-              ${LinkType.TMS}: {
+              tms: {
                 urlTemplate: "https://example.org/tasks/%s",
               }
             }

--- a/packages/allure-cucumberjs/src/model.ts
+++ b/packages/allure-cucumberjs/src/model.ts
@@ -1,5 +1,5 @@
-import type { LabelName, LinkType } from "allure-js-commons";
-import type { Config } from "allure-js-commons/sdk/reporter";
+import type { LabelName } from "allure-js-commons";
+import type { Config, LinkConfig, LinkTypeOptions } from "allure-js-commons/sdk/reporter";
 
 export const ALLURE_SETUP_REPORTER_HOOK = "__allure_reporter_setup_hook__";
 
@@ -8,14 +8,10 @@ export type LabelConfig = {
   name: LabelName | string;
 };
 
-export type LinkConfig = {
-  pattern: RegExp[];
-  urlTemplate: string;
-  type: LinkType | string;
-};
+export type AllureCucumberLinkConfig = LinkConfig<LinkTypeOptions & { pattern: RegExp[] }>;
 
 export interface AllureCucumberReporterConfig extends Omit<Config, "writer" | "links"> {
   testMode?: boolean;
-  links?: LinkConfig[];
+  links?: AllureCucumberLinkConfig;
   labels?: LabelConfig[];
 }

--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -17,9 +17,8 @@ import {
   getWorstStepResultStatus,
   md5,
 } from "allure-js-commons/sdk/reporter";
-import type { Config } from "allure-js-commons/sdk/reporter";
 import { AllureCucumberWorld } from "./legacy.js";
-import type { AllureCucumberReporterConfig, LabelConfig, LinkConfig } from "./model.js";
+import type { AllureCucumberLinkConfig, AllureCucumberReporterConfig, LabelConfig } from "./model.js";
 import { ALLURE_SETUP_REPORTER_HOOK } from "./model.js";
 
 const { ALLURE_THREAD_NAME } = process.env;
@@ -28,7 +27,7 @@ export default class AllureCucumberReporter extends Formatter {
   private readonly afterHooks: Record<string, TestCaseHookDefinition> = {};
   private readonly beforeHooks: Record<string, TestCaseHookDefinition> = {};
 
-  private linksConfigs: LinkConfig[] = [];
+  private linksConfigs: AllureCucumberLinkConfig = {};
   private labelsConfigs: LabelConfig[] = [];
   private allureRuntime: ReporterRuntime;
 
@@ -59,10 +58,10 @@ export default class AllureCucumberReporter extends Formatter {
         : new FileSystemWriter({
             resultsDir,
           }),
-      links: links as Config["links"] | undefined,
+      links,
       ...rest,
     });
-    this.linksConfigs = links || [];
+    this.linksConfigs = links || {};
     this.labelsConfigs = labels || [];
 
     options.eventBroadcaster.on("envelope", this.parseEnvelope.bind(this));
@@ -85,8 +84,8 @@ export default class AllureCucumberReporter extends Formatter {
 
   private get tagsIgnorePatterns(): RegExp[] {
     const { labelsConfigs, linksConfigs } = this;
-
-    return [...labelsConfigs, ...linksConfigs].flatMap(({ pattern }) => pattern);
+    const linkConfigEntries = Object.entries(linksConfigs).map(([, v]) => v);
+    return [...labelsConfigs, ...linkConfigEntries].flatMap(({ pattern }) => pattern);
   }
 
   private parseEnvelope(envelope: messages.Envelope) {
@@ -155,18 +154,18 @@ export default class AllureCucumberReporter extends Formatter {
     const tagKeyRe = /^@\S+=/;
     const links: Link[] = [];
 
-    if (this.linksConfigs.length === 0) {
+    if (Object.keys(this.linksConfigs).length === 0) {
       return links;
     }
 
-    this.linksConfigs.forEach((matcher) => {
+    Object.entries(this.linksConfigs).forEach(([type, matcher]) => {
       const matchedTags = tags.filter((tag) => matcher.pattern.some((pattern) => pattern.test(tag.name)));
       const matchedLinks = matchedTags.map((tag) => {
         const tagValue = tag.name.replace(tagKeyRe, "");
 
         return {
           url: matcher.urlTemplate.replace(/%s$/, tagValue) || tagValue,
-          type: matcher.type,
+          type,
         };
       });
 

--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -13,10 +13,10 @@ import {
   FileSystemWriter,
   MessageWriter,
   ReporterRuntime,
+  applyLinkTemplate,
   createStepResult,
   getWorstStepResultStatus,
   md5,
-  applyLinkTemplate,
 } from "allure-js-commons/sdk/reporter";
 import { AllureCucumberWorld } from "./legacy.js";
 import type { AllureCucumberLinkConfig, AllureCucumberReporterConfig, LabelConfig } from "./model.js";

--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -16,6 +16,7 @@ import {
   createStepResult,
   getWorstStepResultStatus,
   md5,
+  applyLinkTemplate,
 } from "allure-js-commons/sdk/reporter";
 import { AllureCucumberWorld } from "./legacy.js";
 import type { AllureCucumberLinkConfig, AllureCucumberReporterConfig, LabelConfig } from "./model.js";
@@ -164,7 +165,7 @@ export default class AllureCucumberReporter extends Formatter {
         const tagValue = tag.name.replace(tagKeyRe, "");
 
         return {
-          url: matcher.urlTemplate.replace(/%s$/, tagValue) || tagValue,
+          url: applyLinkTemplate(matcher.urlTemplate, tagValue) || tagValue,
           type,
         };
       });

--- a/packages/allure-cucumberjs/test/utils.ts
+++ b/packages/allure-cucumberjs/test/utils.ts
@@ -34,18 +34,16 @@ export const runCucumberInlineTest = async (
               name: "severity",
             },
           ],
-          links: [
-            {
+          links: {
+            issue: {
               pattern: [/@issue=(.*)/],
-              type: "issue",
               urlTemplate: "https://example.com/issues/%s",
             },
-            {
+            tms: {
               pattern: [/@tms=(.*)/],
-              type: "tms",
               urlTemplate: "https://example.com/tasks/%s",
             },
-          ],
+          },
         }
       }
     }

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -2,14 +2,12 @@ import type Cypress from "cypress";
 import { ContentType, LabelName, Stage } from "allure-js-commons";
 import { extractMetadataFromString } from "allure-js-commons/sdk";
 import { FileSystemWriter, ReporterRuntime, getSuiteLabels } from "allure-js-commons/sdk/reporter";
+import type { LinkConfig } from "allure-js-commons/sdk/reporter";
 import type { CypressRuntimeMessage, CypressTestEndRuntimeMessage, CypressTestStartRuntimeMessage } from "./model.js";
 
 export type AllureCypressConfig = {
   resultsDir?: string;
-  links?: {
-    type: string;
-    urlTemplate: string;
-  }[];
+  links?: LinkConfig;
 };
 
 export class AllureCypress {

--- a/packages/allure-cypress/test/utils.ts
+++ b/packages/allure-cypress/test/utils.ts
@@ -32,16 +32,14 @@ export const runCypressInlineTest = async (
         viewportWidth: 1240,
         setupNodeEvents: (on, config) => {
           const reporter = allureCypress(on, {
-            links: [
-              {
-                type: "issue",
+            links: {
+              issue: {
                 urlTemplate: "https://allurereport.org/issues/%s"
               },
-              {
-                type: "tms",
+              tms: {
                 urlTemplate: "https://allurereport.org/tasks/%s"
               },
-            ]
+            }
           });
 
           on("after:spec", (spec, result) => {

--- a/packages/allure-jasmine/test/fixtures/spec/helpers/legacy/allure.cjs
+++ b/packages/allure-jasmine/test/fixtures/spec/helpers/legacy/allure.cjs
@@ -3,16 +3,14 @@ const fixture = `
 
   const reporter = new AllureJasmineReporter({
     testMode: true,
-    links: [
-      {
-        type: "issue",
+    links: {
+      issue: {
         urlTemplate: "https://example.org/issues/%s",
       },
-      {
-        type: "tms",
+      tms: {
         urlTemplate: "https://example.org/tasks/%s",
       }
-    ],
+    },
     categories: [
       {
         name: "Sad tests",

--- a/packages/allure-jasmine/test/fixtures/spec/helpers/modern/allure.cjs
+++ b/packages/allure-jasmine/test/fixtures/spec/helpers/modern/allure.cjs
@@ -3,16 +3,14 @@ const fixture = `
 
   const reporter = new AllureJasmineReporter({
     testMode: true,
-    links: [
-      {
-        type: "issue",
+    links: {
+      issue: {
         urlTemplate: "https://example.org/issues/%s",
       },
-      {
-        type: "tms",
+      tms: {
         urlTemplate: "https://example.org/tasks/%s",
       }
-    ],
+    },
     categories: [
       {
         name: "Sad tests",

--- a/packages/allure-jest/test/utils.ts
+++ b/packages/allure-jest/test/utils.ts
@@ -14,16 +14,14 @@ export const runJestInlineTest = async (test: string): Promise<AllureResults> =>
       testEnvironment: require.resolve("allure-jest/node"),
       testEnvironmentOptions: {
         testMode: true,
-        links: [
-          {
-            type: "issue",
+        links: {
+          issue: {
             urlTemplate: "https://example.org/issues/%s",
           },
-          {
-            type: "tms",
+          tms: {
             urlTemplate: "https://example.org/tasks/%s",
           }
-        ]
+        }
       },
     };
 

--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -151,6 +151,7 @@ export enum ContentType {
 
 /* eslint-disable no-shadow */
 export enum LinkType {
+  DEFAULT = "link",
   ISSUE = "issue",
   TMS = "tms",
 }

--- a/packages/allure-js-commons/src/sdk/reporter/ReporterRuntime.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/ReporterRuntime.ts
@@ -1,6 +1,6 @@
 /* eslint max-lines: 0 */
 import { extname } from "path";
-import type { Attachment, AttachmentOptions, FixtureResult, Link, StepResult, TestResult } from "../../model.js";
+import type { Attachment, AttachmentOptions, FixtureResult, StepResult, TestResult } from "../../model.js";
 import { Stage } from "../../model.js";
 import type {
   Category,
@@ -20,7 +20,7 @@ import { MutableAllureContextHolder, StaticContextProvider } from "./context/Sta
 import type { AllureContextProvider } from "./context/types.js";
 import { createFixtureResult, createStepResult, createTestResult } from "./factory.js";
 import type { Config, FixtureType, FixtureWrapper, LinkConfig, TestScope, Writer } from "./types.js";
-import { deepClone, randomUuid } from "./utils.js";
+import { deepClone, formatLinks, randomUuid } from "./utils.js";
 import { getTestResultHistoryId, getTestResultTestCaseId } from "./utils.js";
 import { buildAttachmentFileName } from "./utils/attachments.js";
 import { resolveWriter } from "./writer/loader.js";
@@ -144,7 +144,7 @@ type MessageTargets = {
 export class ReporterRuntime {
   private readonly state = new LifecycleState();
   private notifier: Notifier;
-  private links: LinkConfig[] = [];
+  private links: LinkConfig;
   private contextProvider: AllureContextProvider;
   writer: Writer;
   categories?: Category[];
@@ -153,7 +153,7 @@ export class ReporterRuntime {
   constructor({
     writer,
     listeners = [],
-    links = [],
+    links = {},
     environmentInfo,
     categories,
     contextProvider = StaticContextProvider.wrap(new MutableAllureContextHolder()),
@@ -784,7 +784,7 @@ export class ReporterRuntime {
 
   private handleMetadataMessage = (message: RuntimeMetadataMessage, { test, root, step }: MessageTargets) => {
     const { links = [], attachments = [], displayName, parameters = [], labels = [], ...rest } = message.data;
-    const formattedLinks = this.formatLinks(links);
+    const formattedLinks = formatLinks(this.links, links);
 
     if (displayName) {
       root.name = displayName;
@@ -1045,41 +1045,6 @@ export class ReporterRuntime {
       // eslint-disable-next-line no-console
       console.error(`No current step to ${op}!`);
     }
-  };
-
-  private formatLinks = (links: Link[]) => {
-    if (!this.links.length) {
-      return links;
-    }
-
-    return links.map((link) => {
-      // TODO:
-      // @ts-ignore
-      const matcher = this.links?.find?.(({ type }) => type === link.type);
-
-      // TODO:
-      if (!matcher || link.url.startsWith("http")) {
-        return link;
-      }
-
-      const url = matcher.urlTemplate.replace("%s", link.url);
-
-      // we shouldn't need to reassign already assigned name
-      if (link.name || !matcher.nameTemplate) {
-        return {
-          ...link,
-          url,
-        };
-      }
-
-      const name = matcher.nameTemplate.replace("%s", link.url);
-
-      return {
-        ...link,
-        name,
-        url,
-      };
-    });
   };
 
   private introduceTestIntoScopes = (testUuid: string, scopeUuid: string) => {

--- a/packages/allure-js-commons/src/sdk/reporter/types.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/types.ts
@@ -62,9 +62,11 @@ export interface LifecycleListener {
   afterStepStop?: (result: StepResult) => void;
 }
 
+export type LinkTemplate = string | ((url: string) => string);
+
 export type LinkTypeOptions = {
-  urlTemplate: string;
-  nameTemplate?: string;
+  urlTemplate: LinkTemplate;
+  nameTemplate?: LinkTemplate;
 };
 
 export type LinkConfig<TOpts extends LinkTypeOptions = LinkTypeOptions> = Partial<Record<LinkType, TOpts>> &

--- a/packages/allure-js-commons/src/sdk/reporter/types.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/types.ts
@@ -2,6 +2,7 @@ import type {
   FixtureResult,
   Label,
   Link,
+  LinkType,
   Parameter,
   StepResult,
   TestResult,
@@ -61,11 +62,13 @@ export interface LifecycleListener {
   afterStepStop?: (result: StepResult) => void;
 }
 
-export interface LinkConfig {
-  type: string;
+export type LinkTypeOptions = {
   urlTemplate: string;
   nameTemplate?: string;
-}
+};
+
+export type LinkConfig<TOpts extends LinkTypeOptions = LinkTypeOptions> = Partial<Record<LinkType, TOpts>> &
+  Record<string, TOpts>;
 
 export type WriterDescriptor = [cls: string, ...args: readonly unknown[]] | string;
 
@@ -74,7 +77,7 @@ export interface Config {
   readonly writer: Writer | WriterDescriptor;
   // TODO: handle lifecycle hooks here
   readonly testMapper?: (test: TestResult) => TestResult | null;
-  readonly links?: LinkConfig[];
+  readonly links?: LinkConfig;
   readonly listeners?: LifecycleListener[];
   readonly environmentInfo?: EnvironmentInfo;
   readonly categories?: Category[];

--- a/packages/allure-js-commons/src/sdk/reporter/utils.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/utils.ts
@@ -6,7 +6,7 @@ import process from "node:process";
 import properties from "properties";
 import type { Label, Link, Status, StepResult, TestResult } from "../../model.js";
 import { LabelName, LinkType, StatusByPriority } from "../../model.js";
-import type { LinkConfig } from "./types.js";
+import type { LinkConfig, LinkTemplate } from "./types.js";
 
 export const randomUuid = () => {
   return randomUUID();
@@ -202,7 +202,7 @@ export const escapeRegExp = (value: string): string => {
 export const parseProperties = properties.parse;
 export const stringifyProperties = (data: any): string => properties.stringify(data, { unicode: true }).toString();
 
-// TODO: consider using URL.canParse instead (requires node.js v18.17, v19.9, or higher)
+// TODO: may also use URL.canParse instead (requires node.js v18.17, v19.9, or higher)
 const isUrl = (potentialUrl: string) => {
   // Short-circuits the check for many short URL cases, bypassing the try-catch logic.
   if (potentialUrl.indexOf(":") === -1) {
@@ -219,22 +219,25 @@ const isUrl = (potentialUrl: string) => {
   }
 };
 
+export const applyLinkTemplate = (template: LinkTemplate, value: string) =>
+  typeof template === "string" ? template.replace("%s", value) : template(value);
+
 export const formatLink = (templates: LinkConfig, link: Link) => {
-  const { url, name, type } = link;
-  if (isUrl(url)) {
+  const { url: originalUrl, name, type } = link;
+  if (isUrl(originalUrl)) {
     return link;
   } else {
     const formattedLink = { ...link };
     const { urlTemplate, nameTemplate } = templates[type ?? LinkType.DEFAULT] ?? {};
     if (urlTemplate !== undefined) {
-      formattedLink.url = urlTemplate.replace("%s", url);
+      formattedLink.url = applyLinkTemplate(urlTemplate, originalUrl);
     }
     if (name === undefined && nameTemplate !== undefined) {
-      formattedLink.name = nameTemplate.replace("%s", url);
+      formattedLink.name = applyLinkTemplate(nameTemplate, originalUrl);
     }
     return formattedLink;
   }
 };
 
 export const formatLinks = (templates: LinkConfig, links: readonly Link[]) =>
-  links.map<Link>((link) => formatLink(templates, link));
+  links.map((link) => formatLink(templates, link));

--- a/packages/allure-js-commons/src/sdk/reporter/utils.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/utils.ts
@@ -4,9 +4,9 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import properties from "properties";
-import type { Status, StepResult, TestResult } from "../../model.js";
-import { LabelName, StatusByPriority } from "../../model.js";
-import type { Label } from "../../model.js";
+import type { Label, Link, Status, StepResult, TestResult } from "../../model.js";
+import { LabelName, LinkType, StatusByPriority } from "../../model.js";
+import type { LinkConfig } from "./types.js";
 
 export const randomUuid = () => {
   return randomUUID();
@@ -201,3 +201,40 @@ export const escapeRegExp = (value: string): string => {
 
 export const parseProperties = properties.parse;
 export const stringifyProperties = (data: any): string => properties.stringify(data, { unicode: true }).toString();
+
+// TODO: consider using URL.canParse instead (requires node.js v18.17, v19.9, or higher)
+const isUrl = (potentialUrl: string) => {
+  // Short-circuits the check for many short URL cases, bypassing the try-catch logic.
+  if (potentialUrl.indexOf(":") === -1) {
+    return false;
+  }
+
+  // There is ':' in the string: a potential scheme separator.
+  // The string might be a proper URL already.
+  try {
+    new URL(potentialUrl);
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+export const formatLink = (templates: LinkConfig, link: Link) => {
+  const { url, name, type } = link;
+  if (isUrl(url)) {
+    return link;
+  } else {
+    const formattedLink = { ...link };
+    const { urlTemplate, nameTemplate } = templates[type ?? LinkType.DEFAULT] ?? {};
+    if (urlTemplate !== undefined) {
+      formattedLink.url = urlTemplate.replace("%s", url);
+    }
+    if (name === undefined && nameTemplate !== undefined) {
+      formattedLink.name = nameTemplate.replace("%s", url);
+    }
+    return formattedLink;
+  }
+};
+
+export const formatLinks = (templates: LinkConfig, links: readonly Link[]) =>
+  links.map<Link>((link) => formatLink(templates, link));

--- a/packages/allure-js-commons/test/sdk/reporter/ReporterRuntime.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/ReporterRuntime.spec.ts
@@ -113,18 +113,16 @@ describe("ReporterRuntime", () => {
       const writer = mockWriter();
       const runtime = new ReporterRuntime({
         writer,
-        links: [
-          {
-            type: "issue",
+        links: {
+          issue: {
             urlTemplate: "https://allurereport.org/issues/%s",
             nameTemplate: "Issue %s",
           },
-          {
-            type: "tms",
+          tms: {
             urlTemplate: "https://allurereport.org/tasks/%s",
             nameTemplate: "Task %s",
           },
-        ],
+        },
       });
 
       runtime.startTest({});

--- a/packages/allure-js-commons/test/sdk/reporter/utils/links.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/utils/links.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { LinkType } from "../../../../src/model.js";
-import { formatLinks } from "../../../../src/sdk/reporter/utils.js";
 import type { LinkConfig } from "../../../../src/sdk/reporter/types.js";
+import { formatLinks } from "../../../../src/sdk/reporter/utils.js";
 
 describe("formatLinks", () => {
   describe("with no templates", () => {

--- a/packages/allure-js-commons/test/sdk/reporter/utils/links.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/utils/links.spec.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { LinkType } from "../../../../src/model.js";
+import { formatLinks } from "../../../../src/sdk/reporter/utils.js";
+
+describe("formatLinks", () => {
+  describe("with no patterns", () => {
+    it("shouldn't affect any link", () => {
+      const links = [{ url: "foo" }, { url: "foo", name: "bar" }, { url: "foo", name: "bar", type: "baz" }];
+      expect(formatLinks({}, links)).toEqual(links);
+    });
+  });
+
+  describe("with the URL-only default link pattern", () => {
+    const patterns = { [LinkType.DEFAULT]: { urlTemplate: "https://qux/%s" } };
+
+    it("should affect the URL of a link with no type specified", () => {
+      expect(formatLinks(patterns, [{ url: "foo" }])).toEqual([{ url: "https://qux/foo" }]);
+    });
+
+    it("should affect the URL of a link with the explicit default type", () => {
+      expect(formatLinks(patterns, [{ url: "foo", type: LinkType.DEFAULT }])).toEqual([
+        { url: "https://qux/foo", type: LinkType.DEFAULT },
+      ]);
+    });
+
+    it("should ignore links of other types", () => {
+      const links = [
+        { url: "foo", type: "bar" },
+        { url: "bar", type: "quux" },
+      ];
+      expect(formatLinks(patterns, links)).toEqual(links);
+    });
+  });
+
+  describe("with the URL and name pattern", () => {
+    const patterns = {
+      qux: {
+        urlTemplate: "https://qux/%s",
+        nameTemplate: "qux-%s",
+      },
+    };
+
+    it("should affect the name if not set", () => {
+      expect(formatLinks(patterns, [{ url: "foo", type: "qux" }])).toEqual([
+        { url: "https://qux/foo", name: "qux-foo", type: "qux" },
+      ]);
+    });
+
+    it("shouldn't affect the name if set", () => {
+      expect(formatLinks(patterns, [{ url: "foo", name: "bar", type: "qux" }])).toEqual([
+        { url: "https://qux/foo", name: "bar", type: "qux" },
+      ]);
+    });
+
+    it("should ignore links with a proper URL", () => {
+      const links = [
+        { url: "http://foo", type: "qux" },
+        { url: "https://foo", type: "qux" },
+        { url: "ftp://foo", type: "qux" },
+        { url: "file:///foo", type: "qux" },
+        { url: "customapp:custompath?foo=bar&baz=qux", type: "qux" },
+      ];
+      expect(formatLinks(patterns, links)).toEqual(links);
+    });
+  });
+});

--- a/packages/allure-playwright/test/spec/runtime/legacy/links.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/legacy/links.spec.ts
@@ -24,16 +24,14 @@ it("sets runtime links", async () => {
                resultsDir: "./allure-results",
                testMode: true,
                suiteTitle: true,
-               links: [
-                 {
-                   type: "issue",
+               links: {
+                 issue: {
                    urlTemplate: "https://example.org/issues/%s",
                  },
-                 {
-                   type: "tms",
+                 tms: {
                    urlTemplate: "https://example.org/tasks/%s",
                  }
-               ]
+               }
              },
            ],
            ["dot"],

--- a/packages/allure-playwright/test/spec/runtime/modern/links.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/links.spec.ts
@@ -26,16 +26,14 @@ it("sets runtime links", async () => {
                resultsDir: "./allure-results",
                testMode: true,
                suiteTitle: true,
-               links: [
-                 {
-                   type: "${LinkType.ISSUE}",
+               links: {
+                 ${LinkType.ISSUE}: {
                    urlTemplate: "https://example.org/issues/%s",
                  },
-                 {
-                   type: "${LinkType.TMS}",
+                 ${LinkType.TMS}: {
                    urlTemplate: "https://example.org/tasks/%s",
                  }
-               ]
+               }
              },
            ],
            ["dot"],

--- a/packages/allure-playwright/test/spec/runtime/modern/links.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/links.spec.ts
@@ -27,10 +27,10 @@ it("sets runtime links", async () => {
                testMode: true,
                suiteTitle: true,
                links: {
-                 ${LinkType.ISSUE}: {
+                 issue: {
                    urlTemplate: "https://example.org/issues/%s",
                  },
-                 ${LinkType.TMS}: {
+                 tms: {
                    urlTemplate: "https://example.org/tasks/%s",
                  }
                }

--- a/packages/allure-vitest/test/utils.ts
+++ b/packages/allure-vitest/test/utils.ts
@@ -35,16 +35,14 @@ export const runVitestInlineTest = async (
           "default",
           new AllureReporter({
             testMode: true,
-            links: [
-              {
-                type: "issue",
+            links: {
+              issue: {
                 urlTemplate: "https://example.org/issue/%s",
               },
-              {
-                type: "tms",
+              tms: {
                 urlTemplate: "https://example.org/tms/%s",
               },
-            ],
+            },
             resultsDir: "${join(testDir, "allure-results")}",
           }),
         ],


### PR DESCRIPTION
### Context
The PR changes the link patterns configuration type from the array to the record whose keys are either `LinkType` values or arbitrary strings. A link's template can now be an arbitrary function from `string` to `string`. `LinkConfig` is now defined as follows:

```ts
export type LinkConfig<TOpts extends LinkTypeOptions = LinkTypeOptions> =
  Partial<Record<LinkType, TOpts>> & Record<string, TOpts>;
```

1. A generic type argument is used to allow integrations to extend link options. Allure-cucumber does that to add an extra `pattern` field to the options.

2. Defining the config as an intersection allows us to:

      - keep IDE autocompletion
      - index the values with arbitrary string keys (TS infers the resulting type to be `TOpts` instead of `TOpts | undefined` in such cases, but that's how it works for any record without the `noUncheckedIndexedAccess` TS option).

Some examples:

```ts
import type { Config } from "allure-js-commons/sdk/reporter";
import { LinkType } from "allure-js-commons";

const config: Config = {
  issue: { // Hinted by IDE autocompletion
    urlTemplate: "https://foo/%s"
  },
  [LinkType.DEFAULT]: { // Enum as the key
    urlTemplate: "https://bar/%s"
  },
  custom: { // An arbitrary string
    urlTemplate: "https://baz/%s",
    nameTemplate: "CUSTOM-%s",
  },
  tms: { // Template functions
    urlTemplate: (v) => `https://baz/${v}`,
    nameTemplate: (v) => `CUSTOM-${v}`,
  }
};
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
