### PR TITLE
Allure-mocha: fix test result overwritten when a test is skipped dynamically

### DIFF
--- a/packages/allure-mocha/src/AllureMochaReporter.ts
+++ b/packages/allure-mocha/src/AllureMochaReporter.ts
@@ -139,7 +139,9 @@ export class AllureMochaReporter extends Mocha.reporters.Base {
 
   private onPending = (test: Mocha.Test) => {
     if (isIncludedInTestRun(test)) {
-      this.onTest(test);
+      if (!this.runtime.hasTest()) {
+        this.onTest(test);
+      }
       this.runtime.updateTest((r) => {
         r.status = Status.SKIPPED;
         r.statusDetails = {

--- a/packages/allure-mocha/test/fixtures/samples/labels/skippedAtRuntime.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/labels/skippedAtRuntime.spec.js
@@ -1,0 +1,9 @@
+// cjs: const { it } = require("mocha");
+// cjs: const { tag } = require("allure-js-commons");
+// esm: import { it } from "mocha";
+// esm: import { tag } from "allure-js-commons";
+
+it("a skipped test with a tag", async function () {
+  await tag("foo");
+  this.skip();
+});

--- a/packages/allure-mocha/test/fixtures/samples/legacy/labels/skippedAtRuntime.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/legacy/labels/skippedAtRuntime.spec.js
@@ -1,0 +1,9 @@
+// cjs: const { it } = require("mocha");
+// cjs: const { allure } = require("allure-mocha/runtime");
+// esm: import { it } from "mocha";
+// esm: import { allure } from "allure-mocha/runtime";
+
+it("a skipped test with a tag", function () {
+  allure.tag("foo");
+  this.skip();
+});

--- a/packages/allure-mocha/test/spec/defects/dynamicSkip.spec.ts
+++ b/packages/allure-mocha/test/spec/defects/dynamicSkip.spec.ts
@@ -1,0 +1,14 @@
+import { expect, it } from "vitest";
+import { issue } from "allure-js-commons";
+import { runMochaInlineTest } from "../../utils.js";
+
+it("shouldn't overwrite the result of a dynamically skipped test", async () => {
+  const { tests } = await runMochaInlineTest(["labels", "skippedAtRuntime"], ["legacy", "labels", "skippedAtRuntime"]);
+
+  expect(tests).toHaveLength(2);
+  for (const test of tests) {
+    expect(test).toMatchObject({
+      labels: expect.arrayContaining([expect.objectContaining({ name: "tag", value: "foo" })]),
+    });
+  }
+});

--- a/packages/allure-mocha/test/spec/defects/dynamicSkip.spec.ts
+++ b/packages/allure-mocha/test/spec/defects/dynamicSkip.spec.ts
@@ -3,6 +3,8 @@ import { issue } from "allure-js-commons";
 import { runMochaInlineTest } from "../../utils.js";
 
 it("shouldn't overwrite the result of a dynamically skipped test", async () => {
+  await issue("457");
+
   const { tests } = await runMochaInlineTest(["labels", "skippedAtRuntime"], ["legacy", "labels", "skippedAtRuntime"]);
 
   expect(tests).toHaveLength(2);

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -54,6 +54,7 @@ abstract class AllureMochaTestRunner {
     // TODO parameter should accept any type
     await parameter("parallel", `${RUN_IN_PARALLEL}`);
     await parameter("module", SPEC_FORMAT);
+    await parameter("runner", RUNNER);
 
     const testDir = path.join(this.runResultsDir, randomUUID());
 

--- a/packages/allure-mocha/vitest.config.mts
+++ b/packages/allure-mocha/vitest.config.mts
@@ -8,7 +8,16 @@ export default defineConfig({
     hookTimeout: 25000,
     globalSetup: ["./test/setup.ts"],
     setupFiles: ["./vitest-setup.ts"],
-    reporters: ["default", ["allure-vitest/reporter", { resultsDir: "./out/allure-results" }]],
+    reporters: [
+      "default",
+      [
+        "allure-vitest/reporter",
+        {
+          resultsDir: "./out/allure-results",
+          links: { issue: { urlTemplate: "https://github.com/allure-framework/allure-js/issues/%s" } },
+        },
+      ],
+    ],
     typecheck: {
       enabled: true,
       tsconfig: "./tsconfig.test.json",


### PR DESCRIPTION
### Context
If a test is skipped at runtime (with `this.skip();`), the test result gets overwritten, and all the data (links, labels, etc) is lost.
In such cases, `onTest` is called before `onPending` so there is no need to create a new test result.

Also, we might want to implement a countermeasure of some sort (a warning or an error) if we dismiss the currently running test result.

### Other changes

  - Issue template was added for allure-mocha.
  - The runner parameter is now added to allure-mocha test results (we test against three types of runners: the CLI runner and two code runners, in the CommonJS and ESM formats).

Fixes #457

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
