### PR TITLE
Fix duplicated afterEach (#236)

### DIFF
--- a/packages/allure-mocha/src/AllureMochaReporter.ts
+++ b/packages/allure-mocha/src/AllureMochaReporter.ts
@@ -15,6 +15,7 @@ import {
 import { setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import { MochaTestRuntime } from "./MochaTestRuntime.js";
 import { setLegacyApiRuntime } from "./legacyUtils.js";
+import type { TestPlanIndices } from "./types.js";
 import {
   applyTestPlan,
   createTestPlanIndices,
@@ -30,7 +31,6 @@ import {
   resolveParallelModeSetupFile,
   setTestScope,
 } from "./utils.js";
-import type { TestPlanIndices } from "./utils.js";
 
 const {
   EVENT_SUITE_BEGIN,

--- a/packages/allure-mocha/src/types.ts
+++ b/packages/allure-mocha/src/types.ts
@@ -1,0 +1,15 @@
+import type { Label } from "allure-js-commons";
+
+export type AllureMochaTestData = {
+  isIncludedInTestRun: boolean;
+  fullName: string;
+  labels: readonly Label[];
+  displayName: string;
+  scope?: string;
+};
+
+export type HookCategory = "before" | "after";
+
+export type HookScope = "all" | "each";
+
+export type HookType = [category?: HookCategory, scope?: HookScope];

--- a/packages/allure-mocha/src/types.ts
+++ b/packages/allure-mocha/src/types.ts
@@ -1,5 +1,10 @@
 import type { Label } from "allure-js-commons";
 
+export type TestPlanIndices = {
+  fullNameIndex: ReadonlySet<string>;
+  idIndex: ReadonlySet<string>;
+};
+
 export type AllureMochaTestData = {
   isIncludedInTestRun: boolean;
   fullName: string;

--- a/packages/allure-mocha/src/utils.ts
+++ b/packages/allure-mocha/src/utils.ts
@@ -7,7 +7,7 @@ import { LabelName } from "allure-js-commons";
 import type { TestPlanV1, TestPlanV1Test } from "allure-js-commons/sdk";
 import { extractMetadataFromString } from "allure-js-commons/sdk";
 import { getHostLabel, getRelativePath, getThreadLabel, md5, parseTestPlan } from "allure-js-commons/sdk/reporter";
-import type { AllureMochaTestData, HookCategory, HookScope, HookType } from "./types.js";
+import type { AllureMochaTestData, HookCategory, HookScope, HookType, TestPlanIndices } from "./types.js";
 
 const filename = fileURLToPath(import.meta.url);
 
@@ -40,11 +40,6 @@ const createTestPlanIdIndex = (testplan: TestPlanV1) => createTestPlanIndex((e) 
 
 const createTestPlanIndex = <T>(keySelector: (entry: TestPlanV1Test) => T | undefined, testplan: TestPlanV1): Set<T> =>
   new Set(testplan.tests.map((e) => keySelector(e)).filter((v) => v)) as Set<T>;
-
-export type TestPlanIndices = {
-  fullNameIndex: ReadonlySet<string>;
-  idIndex: ReadonlySet<string>;
-};
 
 export const createTestPlanIndices = (): TestPlanIndices | undefined => {
   const testplan = parseTestPlan();

--- a/packages/allure-mocha/test/fixtures/samples/fixtures/afterEachTwoTests.spec.js
+++ b/packages/allure-mocha/test/fixtures/samples/fixtures/afterEachTwoTests.spec.js
@@ -1,0 +1,9 @@
+// cjs: const { afterEach, describe, it } = require("mocha");
+// esm: import { afterEach, describe, it } from "mocha";
+
+describe("a suite with afterEach", () => {
+  afterEach("an after each hook", async () => {});
+
+  it("the first test affected by afterEach", async () => {});
+  it("the second test affected by afterEach", async () => {});
+});

--- a/packages/allure-mocha/test/spec/defects/duplicatedAfterEach.spec.ts
+++ b/packages/allure-mocha/test/spec/defects/duplicatedAfterEach.spec.ts
@@ -1,0 +1,20 @@
+import { expect, it } from "vitest";
+import { issue } from "allure-js-commons";
+import { runMochaInlineTest } from "../../utils.js";
+
+it("should isolate afterEach containers", async () => {
+  await issue("236");
+
+  const { tests, groups } = await runMochaInlineTest(["fixtures", "afterEachTwoTests"]);
+
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        children: [tests[0].uuid],
+      }),
+      expect.objectContaining({
+        children: [tests[1].uuid],
+      }),
+    ]),
+  );
+});


### PR DESCRIPTION
### Context
The PR fixes afterEach fixtures being associated with all tests in the suite, which leads to multiple afterEach entries in the Tear Down section in the report. That was because we incorrectly assumed the following sequence of Mocha events:

```
onSuite
onTest
onHook (beforeEach)
onHookEnd (beforeEach)
onTestPassed
onHook (afterEach)
onHookEnd (afterEach)
onTestEnd
onSuiteEnd
```

The PR makes allure-mocha support the actual sequence:

```
onSuite
onTest
onHook (beforeEach)
onHookEnd (beforeEach)
onTestPassed
onTestEnd
onHook (afterEach)
onHookEnd (afterEach)
onSuiteEnd
```

This is done by storing the test's scope until `onSuiteEnd`, where scopes of all the suite's tests are written.

Fix #236

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
