### PR TITLE
Cypress cucumber preprocessor support

### DIFF
--- a/packages/allure-cypress/src/index.ts
+++ b/packages/allure-cypress/src/index.ts
@@ -19,7 +19,6 @@ import {
   getSuitePath,
   isCommandShouldBeSkipped,
   isGlobalHook,
-  normalizeAttachmentContentEncoding,
   toReversed,
   uint8ArrayToBase64,
 } from "./utils.js";
@@ -103,11 +102,11 @@ export class AllureCypressTestRuntime implements TestRuntime {
     });
   }
 
-  attachment(name: string, content: Buffer | string, options: AttachmentOptions) {
+  // @ts-ignore
+  attachment(name: string, content: string, options: AttachmentOptions) {
     // @ts-ignore
     const attachmentRawContent: string | Uint8Array = content?.type === "Buffer" ? content.data : content;
-    const encoding = content instanceof Buffer ? "base64" : "utf-8";
-    const actualEncoding = normalizeAttachmentContentEncoding(attachmentRawContent, encoding);
+    const actualEncoding = typeof attachmentRawContent === "string" ? "utf8" : "base64";
     const attachmentContent = uint8ArrayToBase64(attachmentRawContent);
 
     return this.sendMessageAsync({
@@ -227,6 +226,7 @@ const initializeAllure = () => {
 
       Cypress.env("allureRuntimeMessages", []);
 
+      // @ts-ignore
       setGlobalTestRuntime(testRuntime);
     })
     .on(EVENT_HOOK_BEGIN, (hook: CypressHook) => {

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -64,7 +64,7 @@ export class AllureCypress {
   }
 
   endSpec(spec: Cypress.Spec, cypressVideoPath?: string) {
-    const specMessages = this.messagesByAbsolutePath.get(spec.absolute)!;
+    const specMessages = this.messagesByAbsolutePath.get(spec.absolute) ?? [];
     const runContext = this.runContextByAbsolutePath.get(spec.absolute)!;
 
     specMessages.forEach((message, i) => {

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -40,6 +40,10 @@ export const getSuitePath = (test: Mocha.Test): string[] => {
 };
 
 export const isCommandShouldBeSkipped = (command: CypressCommand) => {
+  if (last(command.attributes.args)?.log === false) {
+    return true;
+  }
+
   if (command.attributes.name === "task" && command.attributes.args[0] === "allureReportTest") {
     return true;
   }

--- a/packages/allure-cypress/test/spec/commands.test.ts
+++ b/packages/allure-cypress/test/spec/commands.test.ts
@@ -2,7 +2,7 @@ import { expect, it } from "vitest";
 import { Stage, Status } from "allure-js-commons";
 import { runCypressInlineTest } from "../utils.js";
 
-it("test with cypress command", async () => {
+it("reports test with cypress command", async () => {
   const { tests } = await runCypressInlineTest({
     "cypress/e2e/sample.cy.js": () => `
     it("with commands", () => {
@@ -58,4 +58,22 @@ it("test with cypress command", async () => {
       }),
     ]),
   );
+});
+
+it("doesn't report cypress command when they shouldn't be reported", async () => {
+  const { tests } = await runCypressInlineTest({
+    "cypress/e2e/sample.cy.js": () => `
+    it("with commands", () => {
+      cy.log(1, { log: false });
+      cy.log("2", { log: false });
+      cy.log([1, 2, 3], { log: false });
+      cy.log({ foo: 1, bar: 2, baz: 3 }, { log: false });
+    });
+  `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].status).toBe(Status.PASSED);
+  expect(tests[0].stage).toBe(Stage.FINISHED);
+  expect(tests[0].steps).toHaveLength(0);
 });


### PR DESCRIPTION
fix problem with buffer to support cucumber cypress preprocessor

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

Unfortunately, it's impossible to test cucumber preprocessor right in the project due to yarn pnp dependencies resolution.

See examples here:

- cjs: https://github.com/epszaw/allure-js-3-examples/tree/master/cypress-cucumber-cjs-javascript
- esm: https://github.com/epszaw/allure-js-3-examples/tree/master/cypress-cucumber-esm-javascript

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
