### PR TITLE
fix(allure-jest): beforeEach/afterEach affect all tests in the suite, beforeAll/afterAll don't affect tests in sub-suites

### DIFF
--- a/packages/allure-jest/src/environmentFactory.ts
+++ b/packages/allure-jest/src/environmentFactory.ts
@@ -191,7 +191,6 @@ const createJestEnvironment = <T extends typeof JestEnvironment>(Base: T): T => 
         return;
       }
 
-      const scopeUuid = last(this.runContext.scopes);
       const threadLabel = ALLURE_THREAD_NAME || JEST_WORKER_ID || process.pid.toString();
       const hostLabel = ALLURE_HOST_NAME || hostname;
       const packageLabel = dirname(this.testPath).split(sep).join(".");
@@ -216,7 +215,7 @@ const createJestEnvironment = <T extends typeof JestEnvironment>(Base: T): T => 
             ...getEnvironmentLabels(),
           ],
         },
-        [scopeUuid],
+        this.runContext.scopes,
       );
 
       this.runtime.updateTest(testUuid, (result) => {

--- a/packages/allure-jest/test/spec/hooks.test.ts
+++ b/packages/allure-jest/test/spec/hooks.test.ts
@@ -111,6 +111,35 @@ it("reports before and after each hooks", async () => {
   );
 });
 
+it("should report beforeAll/afterAll for tests in sub-suites", async () => {
+  const { tests, groups } = await runJestInlineTest({
+    "sample.test.js": `
+      beforeAll(() => {});
+      afterAll(() => {});
+
+      describe("", () => {
+        it("foo", () => {});
+      });
+    `,
+  });
+
+  const [{ uuid: testUuid }] = tests;
+
+  expect(groups).toHaveLength(2);
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "beforeAll",
+        children: [testUuid],
+      }),
+      expect.objectContaining({
+        name: "afterAll",
+        children: [testUuid],
+      }),
+    ]),
+  );
+});
+
 it("reports failed hooks", async () => {
   const { tests, groups } = await runJestInlineTest({
     "sample.test.js": `

--- a/packages/allure-jest/test/spec/hooks.test.ts
+++ b/packages/allure-jest/test/spec/hooks.test.ts
@@ -111,6 +111,42 @@ it("reports before and after each hooks", async () => {
   );
 });
 
+it("should report one beforeEach/afterEach per test", async () => {
+  const { tests, groups } = await runJestInlineTest({
+    "sample.test.js": `
+      beforeEach(() => {});
+      afterEach(() => {});
+
+      it("foo", () => {});
+      it("bar", () => {});
+    `,
+  });
+
+  const [{ uuid: test1Uuid }, { uuid: test2Uuid }] = tests;
+
+  expect(groups).toHaveLength(4);
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "beforeEach",
+        children: [test1Uuid],
+      }),
+      expect.objectContaining({
+        name: "beforeEach",
+        children: [test2Uuid],
+      }),
+      expect.objectContaining({
+        name: "afterEach",
+        children: [test1Uuid],
+      }),
+      expect.objectContaining({
+        name: "afterEach",
+        children: [test2Uuid],
+      }),
+    ]),
+  );
+});
+
 it("should report beforeAll/afterAll for tests in sub-suites", async () => {
   const { tests, groups } = await runJestInlineTest({
     "sample.test.js": `


### PR DESCRIPTION
### Context
The PR fixes two defects in allure-jest hooks:

1. `beforeEach` and `afterEach` hooks are reported for all tests in the suite.
    In the following example, the tests receive two fixtures each:
    ```js
    beforeEach(() => {});
    it("foo", () => {});
    it("bar", () => {});
    ```
2. `beforeAll` and `afterAll` hooks aren't reported for tests in the sub-suites.
    In the following example, the test receives no fixture:
    ```js
    beforeAll(() => {});
    describe("foo", () => {
        it("bar", () => {});
    });
    ```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
