### PR TITLE
feat(allure-jest): compatibility with Jest >=24.8.0

### DIFF
--- a/packages/allure-jest/package.json
+++ b/packages/allure-jest/package.json
@@ -82,13 +82,17 @@
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
-    "jest": ">=28.0.0",
-    "jest-cli": ">=28.0.0",
-    "jest-environment-jsdom": ">=28.0.0",
-    "jest-environment-node": ">=28.0.0"
+    "jest": ">=24.8.0",
+    "jest-circus": ">=24.8.0",
+    "jest-cli": ">=24.8.0",
+    "jest-environment-jsdom": ">=24.8.0",
+    "jest-environment-node": ">=24.8.0"
   },
   "peerDependenciesMeta": {
     "jest": {
+      "optional": true
+    },
+    "jest-circus": {
       "optional": true
     },
     "jest-cli": {

--- a/packages/allure-jest/src/jsdom.ts
+++ b/packages/allure-jest/src/jsdom.ts
@@ -1,4 +1,4 @@
-import { TestEnvironment } from "jest-environment-jsdom";
+import TestEnvironment from "jest-environment-jsdom";
 import createJestEnvironment from "./environmentFactory.js";
 
 export default createJestEnvironment(TestEnvironment);

--- a/packages/allure-jest/src/model.ts
+++ b/packages/allure-jest/src/model.ts
@@ -1,4 +1,5 @@
 import type { JestEnvironment, JestEnvironmentConfig } from "@jest/environment";
+import type { Config as JestConfig } from "@jest/types";
 import type { RuntimeMessage } from "allure-js-commons/sdk";
 import type { Config } from "allure-js-commons/sdk/reporter";
 
@@ -14,8 +15,10 @@ export interface AllureJestEnvironment extends JestEnvironment {
   handleAllureRuntimeMessage(message: RuntimeMessage): void;
 }
 
-export interface AllureJestConfig extends JestEnvironmentConfig {
-  projectConfig: JestEnvironmentConfig["projectConfig"] & {
-    testEnvironmentOptions?: JestEnvironmentConfig["projectConfig"]["testEnvironmentOptions"] & Config;
-  };
-}
+export type AllureJestProjectConfig = JestConfig.ProjectConfig & {
+  testEnvironmentOptions?: JestConfig.ProjectConfig["testEnvironmentOptions"] & Config;
+};
+
+export type AllureJestConfig = JestEnvironmentConfig & {
+  projectConfig: AllureJestProjectConfig;
+};

--- a/packages/allure-jest/src/node.ts
+++ b/packages/allure-jest/src/node.ts
@@ -1,4 +1,4 @@
-import { TestEnvironment } from "jest-environment-node";
+import TestEnvironment from "jest-environment-node";
 import createJestEnvironment from "./environmentFactory.js";
 
 export default createJestEnvironment(TestEnvironment);

--- a/packages/allure-jest/src/utils.ts
+++ b/packages/allure-jest/src/utils.ts
@@ -45,10 +45,17 @@ export const getTestId = (path: string[]): string => path.join(" ");
  */
 export const getTestFullName = (path: string[]): string => path.join(" > ");
 
-export const shouldHookBeSkipped = (hook: Circus.Hook): boolean => {
-  const errorFirstLine = hook?.asyncError?.stack?.split("\n")?.[1]?.trim() || "";
+const jestHookPattern = /^at jestAdapter/i;
+// A slightly different reference should be used to identify jestAdapter's global hook in some older versions of Jest.
+const jestHookLegacyPattern = /jest-circus\/build\/legacy-code-todo-rewrite\/jestAdapter.js:\d+:\d+$/;
 
-  return /^at jestAdapter/i.test(errorFirstLine);
+export const shouldHookBeSkipped = (hook: Circus.Hook): boolean => {
+  // In older versions of Jest the hook's stack is direcrly in asyncError. In newer ones - in asyncError.stack.
+  const stackOrError: string | Error | undefined = hook?.asyncError;
+  const stack = typeof stackOrError === "string" ? stackOrError : stackOrError?.stack;
+  const errorFirstLine = stack?.split("\n")?.[1]?.trim() || "";
+
+  return jestHookPattern.test(errorFirstLine) || jestHookLegacyPattern.test(errorFirstLine);
 };
 
 export const last = <T>(array: T[]): T => array[array.length - 1];

--- a/yarn.lock
+++ b/yarn.lock
@@ -4110,12 +4110,15 @@ __metadata:
     typescript: "npm:^5.2.2"
     vitest: "npm:^1.6.0"
   peerDependencies:
-    jest: ">=28.0.0"
-    jest-cli: ">=28.0.0"
-    jest-environment-jsdom: ">=28.0.0"
-    jest-environment-node: ">=28.0.0"
+    jest: ">=24.8.0"
+    jest-circus: ">=24.8.0"
+    jest-cli: ">=24.8.0"
+    jest-environment-jsdom: ">=24.8.0"
+    jest-environment-node: ">=24.8.0"
   peerDependenciesMeta:
     jest:
+      optional: true
+    jest-circus:
       optional: true
     jest-cli:
       optional: true


### PR DESCRIPTION
### Context
The PR extends the range of supported Jest versions to `>=24.8.0`. Versions before 24.8.0 aren't supported because they ignore an environment's `handleTestEvent` method.

> [!NOTE]
> When using Jest lower than 27.0.0, the `testRunner: "jest-circus/runner"` must be specified in the config. That's why I've added `jest-circus` as an optional peer dependency. Starting from 27.0.0, Jest uses `jest-circus` by default without the need to install it separately.

The main motivation for the change is that older versions (especially 27) still have quite notable download counts:

<img src="https://github.com/allure-framework/allure-js/assets/17935127/8a972704-e8a9-4a40-9735-ff3b216d14e1" width="60%">

Fixes #1010