### PR TITLE
fix(newman-reporter-allure): Update README.md - change flag export to reportDir (fixes #992)

### DIFF
--- a/packages/newman-reporter-allure/README.md
+++ b/packages/newman-reporter-allure/README.md
@@ -24,7 +24,7 @@ To generate Allure results, specify `allure` in Newman's `-r` or `--reporters` o
 
 ```console
 $ newman run <Collection> -e <Environment> -r allure
-$ newman run <Collection> -e <Environment> -r allure --reporter-allure-export <allure-results-out-dir>
+$ newman run <Collection> -e <Environment> -r allure --reporter-allure-resultsDir <allure-results-out-dir>
 ```
 
 Use the option `--reporter-allure-collection-as-parent-suite` to use the collection name as the parent suite title under the _Suites_ view. This helps when you run multiple collections and want to aggregate them in a single report.


### PR DESCRIPTION
### Context
https://github.com/allure-framework/allure-js/issues/992

The better solution would've been to allow both for backwards compatibility
Old: --reporter-allure-export
New: --reporter-allure-reportDir

### Checklist
- [x] Sign Allure CLA

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
