### PR TITLE
Fix Jasmine fixtures

### DIFF
--- a/packages/allure-jasmine/src/index.ts
+++ b/packages/allure-jasmine/src/index.ts
@@ -274,7 +274,7 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
         const maybePromise = reporter.#callHookAndStopFixtureOnSyncError(fixtureUuid, ctxBoundHookImpl);
 
         if (isPromise(maybePromise)) {
-          return reporter.#stopFixtureWhenPromiseIsDone(fixtureUuid, maybePromise as PromiseLike<unknown>);
+          return reporter.#stopFixtureWhenPromiseIsDone(fixtureUuid, maybePromise);
         }
 
         reporter.#stopFixture(fixtureUuid);

--- a/packages/allure-jasmine/src/index.ts
+++ b/packages/allure-jasmine/src/index.ts
@@ -2,7 +2,7 @@ import { cwd, env } from "node:process";
 import * as allure from "allure-js-commons";
 import { Stage, Status } from "allure-js-commons";
 import type { RuntimeMessage } from "allure-js-commons/sdk";
-import { isPromise } from "allure-js-commons/sdk";
+import { getMessageAndTraceFromError, getStatusFromError, isPromise } from "allure-js-commons/sdk";
 import type { Config, FixtureType } from "allure-js-commons/sdk/reporter";
 import {
   FileSystemWriter,
@@ -13,7 +13,7 @@ import {
 } from "allure-js-commons/sdk/reporter";
 import { MessageTestRuntime, setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import type { JasmineBeforeAfterFn } from "./model.js";
-import { findAnyError, findMessageAboutThrow } from "./utils.js";
+import { findAnyError, findMessageAboutThrow, last } from "./utils.js";
 
 class AllureJasmineTestRuntime extends MessageTestRuntime {
   constructor(private readonly allureJasmineReporter: AllureJasmineReporter) {
@@ -31,6 +31,7 @@ const { ALLURE_TEST_MODE } = env;
 export default class AllureJasmineReporter implements jasmine.CustomReporter {
   private readonly allureRuntime: ReporterRuntime;
   private currentAllureTestUuid?: string;
+  private currentAllureFixtureUuid?: string;
   private jasmineSuitesStack: jasmine.SuiteResult[] = [];
   private scopesStack: string[] = [];
 
@@ -50,7 +51,7 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
 
     setGlobalTestRuntime(testRuntime);
 
-    this.installHooks();
+    this.#enableAllureFixtures();
 
     // the best place to start global container for hooks and nested suites
     const scopeUuid = this.allureRuntime.startScope();
@@ -82,10 +83,11 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
   }
 
   handleAllureRuntimeMessages(message: RuntimeMessage) {
-    if (!this.currentAllureTestUuid) {
+    const rootUuid = this.currentAllureFixtureUuid ?? this.currentAllureTestUuid;
+    if (!rootUuid) {
       return;
     }
-    this.allureRuntime.applyRuntimeMessages(this.currentAllureTestUuid, [message]);
+    this.allureRuntime.applyRuntimeMessages(rootUuid, [message]);
   }
 
   jasmineStarted(): void {
@@ -115,19 +117,16 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
 
   suiteStarted(suite: jasmine.SuiteResult): void {
     this.jasmineSuitesStack.push(suite);
-    const scopeUuid = this.allureRuntime.startScope();
-    this.scopesStack.push(scopeUuid);
+    this.#startScope();
   }
 
   suiteDone(): void {
     this.jasmineSuitesStack.pop();
-    const scopeUuid = this.scopesStack.pop();
-    if (scopeUuid) {
-      this.allureRuntime.writeScope(scopeUuid);
-    }
+    this.#stopScope();
   }
 
   specStarted(spec: jasmine.SpecResult): void {
+    this.#startScope();
     this.currentAllureTestUuid = this.allureRuntime.startTest(
       {
         name: spec.description,
@@ -185,6 +184,8 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
     this.allureRuntime.stopTest(this.currentAllureTestUuid);
     this.allureRuntime.writeTest(this.currentAllureTestUuid);
     this.currentAllureTestUuid = undefined;
+
+    this.#stopScope();
   }
 
   jasmineDone(): void {
@@ -197,109 +198,162 @@ export default class AllureJasmineReporter implements jasmine.CustomReporter {
     this.scopesStack = [];
   }
 
-  private installHooks(): void {
+  #startScope = () => {
+    const scopeUuid = this.allureRuntime.startScope();
+    this.scopesStack.push(scopeUuid);
+  };
+
+  #startFixture = (name: string, type: FixtureType) => {
+    const scopeUuid = last(this.scopesStack);
+    if (scopeUuid) {
+      this.currentAllureFixtureUuid = this.allureRuntime.startFixture(scopeUuid, type, {
+        name,
+        stage: Stage.RUNNING,
+      });
+      return this.currentAllureFixtureUuid;
+    }
+  };
+
+  #stopFixture = (uuid: string, error?: Error | string) => {
+    const statusAndDetails = this.#resolveStatusWithDetails(error);
+    this.allureRuntime.updateFixture(uuid, (f) => Object.assign(f, statusAndDetails));
+    this.allureRuntime.stopFixture(uuid);
+    this.currentAllureFixtureUuid = undefined;
+  };
+
+  #stopScope = () => {
+    const scopeUuid = this.scopesStack.pop();
+    if (scopeUuid) {
+      this.allureRuntime.writeScope(scopeUuid);
+    }
+  };
+
+  #enableAllureFixtures(): void {
     const jasmineBeforeAll: JasmineBeforeAfterFn = global.beforeAll;
     const jasmineAfterAll: JasmineBeforeAfterFn = global.afterAll;
     const jasmineBeforeEach: JasmineBeforeAfterFn = global.beforeEach;
     const jasmineAfterEach: JasmineBeforeAfterFn = global.afterEach;
-    const wrapJasmineHook = (original: JasmineBeforeAfterFn, fixtureType: FixtureType, fixtureName: string) => {
-      return (action: (done: DoneFn) => void, timeout?: number): void => {
-        original((done) => {
-          const start = Date.now();
-          let ret;
 
-          if (action.length > 0) {
-            // function takes done callback
-            ret = new Promise((resolve, reject) => {
-              const t: any = resolve;
-
-              t.fail = reject;
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-              action(t);
-            });
-          } else {
-            ret = action(done);
-          }
-
-          if (isPromise(ret)) {
-            (ret as Promise<any>)
-              .then(() => {
-                done();
-
-                const scopeUuid =
-                  this.scopesStack.length > 0 ? this.scopesStack[this.scopesStack.length - 1] : undefined;
-                if (scopeUuid) {
-                  const fixtureUuid = this.allureRuntime.startFixture(scopeUuid, fixtureType, {
-                    name: fixtureName,
-                    stage: Stage.FINISHED,
-                    status: Status.PASSED,
-                    start,
-                  });
-                  if (fixtureUuid) {
-                    this.allureRuntime.stopFixture(fixtureUuid);
-                  }
-                }
-              })
-              .catch((err) => {
-                done.fail(err as Error);
-                const scopeUuid =
-                  this.scopesStack.length > 0 ? this.scopesStack[this.scopesStack.length - 1] : undefined;
-                if (scopeUuid) {
-                  const fixtureUuid = this.allureRuntime.startFixture(scopeUuid, fixtureType, {
-                    name: fixtureName,
-                    stage: Stage.FINISHED,
-                    status: Status.BROKEN,
-                    start,
-                  });
-                  if (fixtureUuid) {
-                    this.allureRuntime.stopFixture(fixtureUuid);
-                  }
-                }
-              });
-          } else {
-            try {
-              done();
-              const scopeUuid = this.scopesStack.length > 0 ? this.scopesStack[this.scopesStack.length - 1] : undefined;
-              if (scopeUuid) {
-                const fixtureUuid = this.allureRuntime.startFixture(scopeUuid, fixtureType, {
-                  name: fixtureName,
-                  stage: Stage.FINISHED,
-                  status: Status.PASSED,
-                  start,
-                });
-                if (fixtureUuid) {
-                  this.allureRuntime.stopFixture(fixtureUuid);
-                }
-              }
-            } catch (err) {
-              const { message, stack } = err as Error;
-              const scopeUuid = this.scopesStack.length > 0 ? this.scopesStack[this.scopesStack.length - 1] : undefined;
-              if (scopeUuid) {
-                const fixtureUuid = this.allureRuntime.startFixture(scopeUuid, fixtureType, {
-                  name: fixtureName,
-                  stage: Stage.FINISHED,
-                  status: Status.BROKEN,
-                  statusDetails: {
-                    message,
-                    trace: stack,
-                  },
-                  start,
-                });
-                if (fixtureUuid) {
-                  this.allureRuntime.stopFixture(fixtureUuid);
-                }
-              }
-
-              throw err;
-            }
-          }
-        }, timeout);
-      };
-    };
-
-    global.beforeAll = wrapJasmineHook(jasmineBeforeAll, "before", "beforeAll");
-    global.beforeEach = wrapJasmineHook(jasmineBeforeEach, "before", "beforeEach");
-    global.afterAll = wrapJasmineHook(jasmineAfterAll, "after", "afterAll");
-    global.afterEach = wrapJasmineHook(jasmineAfterEach, "after", "afterEach");
+    global.beforeAll = this.#injectFixtureSupportToHookFn(jasmineBeforeAll, "before", "beforeAll");
+    global.beforeEach = this.#injectFixtureSupportToHookFn(jasmineBeforeEach, "before", "beforeEach");
+    global.afterAll = this.#injectFixtureSupportToHookFn(jasmineAfterAll, "after", "afterAll");
+    global.afterEach = this.#injectFixtureSupportToHookFn(jasmineAfterEach, "after", "afterEach");
   }
+
+  #injectFixtureSupportToHookFn =
+    (jasmineHookFn: JasmineBeforeAfterFn, fixtureType: FixtureType, fixtureName: string) =>
+    (hookImpl: jasmine.ImplementationCallback, timeout?: number): void =>
+      jasmineHookFn(
+        // We use different wrappers here to keep the original length
+        hookImpl.length === 0
+          ? this.#wrapSyncOrPromiseBasedHookInAllureFixture(
+              fixtureType,
+              fixtureName,
+              hookImpl as () => void | PromiseLike<any>,
+            )
+          : this.#wrapCallbackBasedHookInAllureFixture(fixtureType, fixtureName, hookImpl),
+        timeout,
+      );
+
+  #wrapSyncOrPromiseBasedHookInAllureFixture = (
+    fixtureType: FixtureType,
+    fixtureName: string,
+    hookImpl: () => void | PromiseLike<any>,
+  ) => {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const reporter = this;
+    return function (this: unknown) {
+      // Bind hook impl to propagate UserContext
+      const ctxBoundHookImpl = hookImpl.bind(this);
+
+      const fixtureUuid = reporter.#startFixture(fixtureName, fixtureType);
+      if (!fixtureUuid) {
+        // No scope started; probably an issue in our code. Just call the hook directly
+        return ctxBoundHookImpl();
+      } else {
+        const maybePromise = reporter.#callHookAndStopFixtureOnSyncError(fixtureUuid, ctxBoundHookImpl);
+
+        if (isPromise(maybePromise)) {
+          return reporter.#stopFixtureWhenPromiseIsDone(fixtureUuid, maybePromise as PromiseLike<unknown>);
+        }
+
+        reporter.#stopFixture(fixtureUuid);
+
+        // A sync hook shouldn't return a value. But in case it does, we preserve it and let Jasmine handle it.
+        return maybePromise;
+      }
+    };
+  };
+
+  #wrapCallbackBasedHookInAllureFixture = (
+    fixtureType: FixtureType,
+    fixtureName: string,
+    hookImpl: (done: DoneFn) => void,
+  ) => {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const reporter = this;
+    return function (this: unknown, done: DoneFn) {
+      // Bind hook impl to propagate UserContext
+      const ctxBoundHookImpl = hookImpl.bind(this);
+
+      const fixtureUuid = reporter.#startFixture(fixtureName, fixtureType);
+      if (!fixtureUuid) {
+        // No scope started; probably an issue in our code. Just call the hook directly
+        return ctxBoundHookImpl(done);
+      } else {
+        const stopFixtureAndContinue = reporter.#injectStopFixtureToHookCallback(fixtureUuid, done);
+
+        // A callback-based hook shouldn't return a value. But in case it does, we preserve it and let Jasmine handle it.
+        return reporter.#callHookAndStopFixtureOnSyncError(fixtureUuid, ctxBoundHookImpl, stopFixtureAndContinue);
+      }
+    };
+  };
+
+  #callHookAndStopFixtureOnSyncError = <TArgs extends readonly any[], TResult>(
+    fixtureUuid: string,
+    fn: (...args: TArgs) => TResult,
+    ...args: TArgs
+  ) => {
+    try {
+      return fn(...args);
+    } catch (error) {
+      this.#stopFixture(fixtureUuid, error as Error | string);
+      throw error;
+    }
+  };
+
+  #stopFixtureWhenPromiseIsDone = (fixtureUuid: string, hookPromise: PromiseLike<unknown>) =>
+    hookPromise.then(
+      (value) => {
+        this.#stopFixture(fixtureUuid);
+        return value;
+      },
+      (error) => {
+        this.#stopFixture(fixtureUuid, error as Error | string);
+        throw error;
+      },
+    );
+
+  #injectStopFixtureToHookCallback = (fixtureUuid: string, done: DoneFn): DoneFn => {
+    const stopFixtureAndContinue = (error?: Error | string) => {
+      this.#stopFixture(fixtureUuid, error);
+      // @ts-ignore
+      done(error);
+    };
+    stopFixtureAndContinue.fail = (error?: Error | string) => {
+      this.#stopFixture(fixtureUuid, error ?? "done.fail was called");
+      done.fail(error);
+    };
+    return stopFixtureAndContinue;
+  };
+
+  #resolveStatusWithDetails = (error: Error | string | undefined) => {
+    if (typeof error === "undefined") {
+      return { status: Status.PASSED };
+    } else if (typeof error === "string") {
+      return { status: Status.BROKEN, statusDetails: { message: error } };
+    } else {
+      return { status: getStatusFromError(error), statusDetails: getMessageAndTraceFromError(error) };
+    }
+  };
 }

--- a/packages/allure-jasmine/src/model.ts
+++ b/packages/allure-jasmine/src/model.ts
@@ -1,1 +1,1 @@
-export type JasmineBeforeAfterFn = (action: (done: DoneFn) => void, timeout?: number) => void;
+export type JasmineBeforeAfterFn = typeof beforeEach;

--- a/packages/allure-jasmine/src/utils.ts
+++ b/packages/allure-jasmine/src/utils.ts
@@ -12,3 +12,5 @@ export const findAnyError = (expectations?: FailedExpectation[]): FailedExpectat
 export const findMessageAboutThrow = (expectations?: FailedExpectation[]) => {
   return expectations?.find((e) => e.matcherName === "");
 };
+
+export const last = <T>(arr: readonly T[]) => (arr.length ? arr[arr.length - 1] : undefined);

--- a/packages/allure-jasmine/test/spec/hooks.test.ts
+++ b/packages/allure-jasmine/test/spec/hooks.test.ts
@@ -1,80 +1,45 @@
-import { expect, it } from "vitest";
+/* eslint max-lines: 0 */
+import { describe, expect, it } from "vitest";
 import { Stage, Status } from "allure-js-commons";
 import { runJasmineInlineTest } from "../utils.js";
 
-it("handles jasmine hooks in flat structure", async () => {
+it("should support all types of hooks", async () => {
   const { tests, groups } = await runJasmineInlineTest({
-    "spec/test/sample1.spec.js": `
+    "spec/test/sample.spec.js": `
+      beforeAll(() => {});
       afterAll(() => {});
-
+      beforeEach(() => {});
       afterEach(() => {});
 
-      it("should pass", () => {
-        expect(true).toBe(true);
-      });
-    `,
-    "spec/test/sample2.spec.js": `
-      beforeAll(() => {});
-
-      beforeEach(() => {});
-
-      it("should fail", () => {
-        expect(true).toBe(false);
-      });
+      it("foo", () => {});
     `,
   });
 
-  expect(tests).toHaveLength(2);
-  expect(tests).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: "should pass",
-        status: Status.PASSED,
-        stage: Stage.FINISHED,
-      }),
-      expect.objectContaining({
-        name: "should fail",
-        status: Status.FAILED,
-        stage: Stage.FINISHED,
-      }),
-    ]),
-  );
-  expect(groups).toHaveLength(6);
+  const [{ uuid }] = tests;
+  expect(groups).toHaveLength(4);
   expect(groups).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         name: "beforeAll",
-        children: [tests[0].uuid, tests[1].uuid],
+        children: [uuid],
         befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
         afters: [],
       }),
       expect.objectContaining({
         name: "beforeEach",
-        children: [tests[0].uuid, tests[1].uuid],
+        children: [uuid],
         befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
         afters: [],
       }),
       expect.objectContaining({
         name: "afterEach",
-        children: [tests[0].uuid, tests[1].uuid],
-        befores: [],
-        afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
-      }),
-      expect.objectContaining({
-        name: "beforeEach",
-        children: [tests[0].uuid, tests[1].uuid],
-        befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
-        afters: [],
-      }),
-      expect.objectContaining({
-        name: "afterEach",
-        children: [tests[0].uuid, tests[1].uuid],
+        children: [uuid],
         befores: [],
         afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
       }),
       expect.objectContaining({
         name: "afterAll",
-        children: [tests[0].uuid, tests[1].uuid],
+        children: [uuid],
         befores: [],
         afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
       }),
@@ -82,105 +47,1057 @@ it("handles jasmine hooks in flat structure", async () => {
   );
 });
 
-it("handles jasmine hooks in nested structure", async () => {
+it("should report root hooks for a test in another file", async () => {
   const { tests, groups } = await runJasmineInlineTest({
-    "spec/test/sample1.spec.js": `
-      describe("nested 1", () => {
-        beforeAll(() => {});
-
-        afterAll(() => {});
-
-        beforeEach(() => {});
-
-        afterEach(() => {});
-
-        it("should pass 1", () => {
-          expect(true).toBe(true);
-        });
-      })
+    "spec/test/hooks.spec.js": `
+      beforeAll(() => {});
+      afterAll(() => {});
+      beforeEach(() => {});
+      afterEach(() => {});
     `,
-    "spec/test/sample2.spec.js": `
-      describe("nested 2", () => {
-        beforeAll(() => {});
-
-        afterAll(() => {});
-
-        beforeEach(() => {});
-
-        afterEach(() => {});
-
-        it("should pass 2", () => {
-          expect(true).toBe(true);
-        });
-      })
+    "spec/test/test.spec.js": `
+      it("foo", () => {});
     `,
   });
 
-  expect(tests).toHaveLength(2);
-  expect(tests).toEqual(
-    expect.arrayContaining([
-      expect.objectContaining({
-        name: "should pass 1",
-        status: Status.PASSED,
-        stage: Stage.FINISHED,
-      }),
-      expect.objectContaining({
-        name: "should pass 2",
-        status: Status.PASSED,
-        stage: Stage.FINISHED,
-      }),
-    ]),
-  );
-  expect(groups).toHaveLength(8);
+  const [{ uuid }] = tests;
+  expect(groups).toHaveLength(4);
   expect(groups).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
         name: "beforeAll",
-        children: [tests[0].uuid],
+        children: [uuid],
         befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
         afters: [],
       }),
       expect.objectContaining({
         name: "beforeEach",
-        children: [tests[0].uuid],
+        children: [uuid],
         befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
         afters: [],
       }),
       expect.objectContaining({
         name: "afterEach",
-        children: [tests[0].uuid],
+        children: [uuid],
         befores: [],
         afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
       }),
       expect.objectContaining({
         name: "afterAll",
-        children: [tests[0].uuid],
+        children: [uuid],
         befores: [],
         afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
       }),
+    ]),
+  );
+});
+
+it("should report non-root hooks", async () => {
+  const { tests, groups } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      describe("foo", () => {
+        beforeAll(() => {});
+        afterAll(() => {});
+        beforeEach(() => {});
+        afterEach(() => {});
+
+        it("bar", () => {});
+      })
+    `,
+  });
+
+  const [{ uuid }] = tests;
+  expect(groups).toHaveLength(4);
+  expect(groups).toEqual(
+    expect.arrayContaining([
       expect.objectContaining({
         name: "beforeAll",
-        children: [tests[1].uuid],
+        children: [uuid],
         befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
         afters: [],
       }),
       expect.objectContaining({
         name: "beforeEach",
-        children: [tests[1].uuid],
+        children: [uuid],
         befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
         afters: [],
       }),
       expect.objectContaining({
         name: "afterEach",
-        children: [tests[1].uuid],
+        children: [uuid],
         befores: [],
         afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
       }),
       expect.objectContaining({
         name: "afterAll",
-        children: [tests[1].uuid],
+        children: [uuid],
         befores: [],
         afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
+      }),
+    ]),
+  );
+});
+
+it("should report one beforeEach/afterEach fixture per test", async () => {
+  const { tests, groups } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      beforeEach(() => {});
+      afterEach(() => {});
+
+      it("foo", () => {});
+      it("bar", () => {});
+    `,
+  });
+
+  const [{ uuid: fooUuid }, { uuid: barUuid }] = tests;
+
+  expect(groups).toHaveLength(4);
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "beforeEach",
+        children: [fooUuid],
+        befores: [
+          expect.objectContaining({
+            name: "beforeEach",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          }),
+        ],
+        afters: [],
+      }),
+      expect.objectContaining({
+        name: "afterEach",
+        children: [fooUuid],
+        befores: [],
+        afters: [
+          expect.objectContaining({
+            name: "afterEach",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        name: "beforeEach",
+        children: [barUuid],
+        befores: [
+          expect.objectContaining({
+            name: "beforeEach",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          }),
+        ],
+        afters: [],
+      }),
+      expect.objectContaining({
+        name: "afterEach",
+        children: [barUuid],
+        befores: [],
+        afters: [
+          expect.objectContaining({
+            name: "afterEach",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+          }),
+        ],
+      }),
+    ]),
+  );
+});
+
+it("should report hooks for a test in a sub-suite", async () => {
+  const { tests, groups } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      beforeAll(() => {});
+      afterAll(() => {});
+      beforeEach(() => {});
+      afterEach(() => {});
+
+      describe("foo", () => {
+        it("bar", () => {});
+      });
+    `,
+  });
+
+  const [{ uuid }] = tests;
+  expect(groups).toHaveLength(4);
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "beforeAll",
+        children: [uuid],
+        befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
+        afters: [],
+      }),
+      expect.objectContaining({
+        name: "beforeEach",
+        children: [uuid],
+        befores: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
+        afters: [],
+      }),
+      expect.objectContaining({
+        name: "afterEach",
+        children: [uuid],
+        befores: [],
+        afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
+      }),
+      expect.objectContaining({
+        name: "afterAll",
+        children: [uuid],
+        befores: [],
+        afters: [expect.objectContaining({ status: Status.PASSED, stage: Stage.FINISHED })],
+      }),
+    ]),
+  );
+});
+
+it("should not report hooks for a test in a parent-suite", async () => {
+  const { tests, groups } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      describe("foo", () => {
+        beforeAll(() => {});
+        afterAll(() => {});
+        beforeEach(() => {});
+        afterEach(() => {});
+
+        it("bar", () => {});
+      });
+
+      it("baz", () => {});
+    `,
+  });
+
+  const bazUuid = tests.find((t) => t.name === "baz")?.uuid;
+  expect(groups).not.toContainEqual(
+    expect.objectContaining({
+      children: expect.arrayContaining([bazUuid]),
+    }),
+  );
+});
+
+describe("timings", () => {
+  it("should be consistent for sync hooks", async () => {
+    const { tests, groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        const delay = () => {
+          for (const now = Date.now(); now === Date.now();)
+            ;
+        };
+        beforeAll(delay);
+        afterAll(delay);
+        beforeEach(delay);
+        afterEach(delay);
+
+        it("bar", delay);
+      `,
+    });
+
+    const [{ start: testStart, stop: testStop }] = tests;
+    const {
+      befores: [{ start: beforeAllStart, stop: beforeAllStop }],
+    } = groups.find((g) => g.name === "beforeAll")!;
+    const {
+      befores: [{ start: beforeEachStart, stop: beforeEachStop }],
+    } = groups.find((g) => g.name === "beforeEach")!;
+    const {
+      afters: [{ start: afterAllStart, stop: afterAllStop }],
+    } = groups.find((g) => g.name === "afterAll")!;
+    const {
+      afters: [{ start: afterEachStart, stop: afterEachStop }],
+    } = groups.find((g) => g.name === "afterEach")!;
+    const timiline = [
+      beforeAllStart,
+      beforeAllStop,
+      testStart, // Jasmine calls beforeEach and afterEach between specStarted and specDone.
+      beforeEachStart,
+      beforeEachStop,
+      afterEachStart,
+      afterEachStop,
+      testStop,
+      afterAllStart,
+      afterAllStop,
+    ];
+    expect([...timiline].sort()).toEqual(timiline);
+  });
+
+  it("should be consistent for async hooks", async () => {
+    const { tests, groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        const wait = async () => await new Promise((r) => setTimeout(r, 1));
+        beforeAll(wait);
+        afterAll(wait);
+        beforeEach(wait);
+        afterEach(wait);
+
+        it("bar", wait);
+      `,
+    });
+
+    const [{ start: testStart, stop: testStop }] = tests;
+    const {
+      befores: [{ start: beforeAllStart, stop: beforeAllStop }],
+    } = groups.find((g) => g.name === "beforeAll")!;
+    const {
+      befores: [{ start: beforeEachStart, stop: beforeEachStop }],
+    } = groups.find((g) => g.name === "beforeEach")!;
+    const {
+      afters: [{ start: afterAllStart, stop: afterAllStop }],
+    } = groups.find((g) => g.name === "afterAll")!;
+    const {
+      afters: [{ start: afterEachStart, stop: afterEachStop }],
+    } = groups.find((g) => g.name === "afterEach")!;
+    const timiline = [
+      beforeAllStart,
+      beforeAllStop,
+      testStart,
+      beforeEachStart,
+      beforeEachStop,
+      afterEachStart,
+      afterEachStop,
+      testStop,
+      afterAllStart,
+      afterAllStop,
+    ];
+    expect([...timiline].sort()).toEqual(timiline);
+  });
+
+  it("should be consistent for hooks with callbacks", async () => {
+    const { tests, groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        const wait = (done) => setTimeout(done, 1);
+        beforeAll(wait);
+        afterAll(wait);
+        beforeEach(wait);
+        afterEach(wait);
+
+        it("bar", wait);
+      `,
+    });
+
+    const [{ start: testStart, stop: testStop }] = tests;
+    const {
+      befores: [{ start: beforeAllStart, stop: beforeAllStop }],
+    } = groups.find((g) => g.name === "beforeAll")!;
+    const {
+      befores: [{ start: beforeEachStart, stop: beforeEachStop }],
+    } = groups.find((g) => g.name === "beforeEach")!;
+    const {
+      afters: [{ start: afterAllStart, stop: afterAllStop }],
+    } = groups.find((g) => g.name === "afterAll")!;
+    const {
+      afters: [{ start: afterEachStart, stop: afterEachStop }],
+    } = groups.find((g) => g.name === "afterEach")!;
+    const timiline = [
+      beforeAllStart,
+      beforeAllStop,
+      testStart,
+      beforeEachStart,
+      beforeEachStop,
+      afterEachStart,
+      afterEachStop,
+      testStop,
+      afterAllStart,
+      afterAllStop,
+    ];
+    expect([...timiline].sort()).toEqual(timiline);
+  });
+});
+
+describe("hook failures", () => {
+  it("reports failed sync hook", async () => {
+    const { tests, groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        beforeAll(() => {
+          throw new Error("foo");
+        });
+
+        it("bar", () => {});
+      `,
+    });
+
+    expect(tests, "has broken test").toEqual([
+      expect.objectContaining({
+        name: "bar",
+        status: Status.BROKEN,
+        statusDetails: expect.objectContaining({
+          message: expect.stringContaining("Not run because a beforeAll function failed"),
+          trace: expect.anything(),
+        }),
+      }),
+    ]);
+    expect(groups, "has broken fixture").toEqual([
+      expect.objectContaining({
+        befores: [
+          expect.objectContaining({
+            name: "beforeAll",
+            status: Status.BROKEN,
+            statusDetails: expect.objectContaining({
+              message: expect.stringContaining("foo"),
+              trace: expect.stringContaining("sample.spec.js"),
+            }),
+          }),
+        ],
+        children: [tests[0].uuid],
+      }),
+    ]);
+  });
+
+  it("reports failed async hook", async () => {
+    const { tests, groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        beforeAll(async () => {
+          throw new Error("foo");
+        });
+
+        it("bar", () => {});
+      `,
+    });
+
+    expect(tests, "has broken test").toEqual([
+      expect.objectContaining({
+        name: "bar",
+        status: Status.BROKEN,
+        statusDetails: expect.objectContaining({
+          message: expect.stringContaining("Not run because a beforeAll function failed"),
+          trace: expect.anything(),
+        }),
+      }),
+    ]);
+    expect(groups, "has broken fixture").toEqual([
+      expect.objectContaining({
+        befores: [
+          expect.objectContaining({
+            name: "beforeAll",
+            status: Status.BROKEN,
+            statusDetails: expect.objectContaining({
+              message: expect.stringContaining("foo"),
+              trace: expect.stringContaining("sample.spec.js"),
+            }),
+          }),
+        ],
+        children: [tests[0].uuid],
+      }),
+    ]);
+  });
+
+  describe("callback hooks", () => {
+    it("should report an unhandled exception", async () => {
+      const { tests, groups } = await runJasmineInlineTest({
+        "spec/test/sample.spec.js": `
+          beforeAll((done) => {
+            throw new Error("foo");
+          });
+
+          it("bar", () => {});
+        `,
+      });
+
+      expect(tests, "has broken test").toEqual([
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          statusDetails: expect.objectContaining({
+            message: expect.stringContaining("Not run because a beforeAll function failed"),
+            trace: expect.anything(),
+          }),
+        }),
+      ]);
+      expect(groups, "has broken fixture").toEqual([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: expect.stringContaining("foo"),
+                trace: expect.stringContaining("sample.spec.js"),
+              }),
+            }),
+          ],
+          children: [tests[0].uuid],
+        }),
+      ]);
+    });
+
+    it("should report error when done.fail is called with Error", async () => {
+      const { tests, groups } = await runJasmineInlineTest({
+        "spec/test/sample.spec.js": `
+          beforeAll((done) => {
+            done.fail(new Error("foo"));
+          });
+
+          it("bar", () => {});
+        `,
+      });
+
+      expect(tests, "has broken test").toEqual([
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          statusDetails: expect.objectContaining({
+            message: expect.stringContaining("Not run because a beforeAll function failed"),
+            trace: expect.anything(),
+          }),
+        }),
+      ]);
+      expect(groups, "has broken fixture").toEqual([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: expect.stringContaining("foo"),
+                trace: expect.stringContaining("sample.spec.js"),
+              }),
+            }),
+          ],
+          children: [tests[0].uuid],
+        }),
+      ]);
+    });
+
+    it("should report error when done.fail is called with string", async () => {
+      const { tests, groups } = await runJasmineInlineTest({
+        "spec/test/sample.spec.js": `
+          beforeAll((done) => {
+            done.fail("foo");
+          });
+
+          it("bar", () => {});
+        `,
+      });
+
+      expect(tests, "has broken test").toEqual([
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          statusDetails: {
+            message: expect.stringContaining("Not run because a beforeAll function failed"),
+            trace: expect.anything(),
+          },
+        }),
+      ]);
+      expect(groups, "has broken fixture").toEqual([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              status: Status.BROKEN,
+              statusDetails: {
+                message: "foo",
+              },
+            }),
+          ],
+          children: [tests[0].uuid],
+        }),
+      ]);
+    });
+
+    it("should report error when done.fail is called with no args", async () => {
+      const { tests, groups } = await runJasmineInlineTest({
+        "spec/test/sample.spec.js": `
+          beforeAll((done) => {
+            done.fail();
+          });
+
+          it("bar", () => {});
+        `,
+      });
+
+      expect(tests, "has broken test").toEqual([
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          statusDetails: {
+            message: expect.stringContaining("Not run because a beforeAll function failed"),
+            trace: expect.anything(),
+          },
+        }),
+      ]);
+      expect(groups, "has broken fixture").toEqual([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              status: Status.BROKEN,
+              statusDetails: {
+                message: "done.fail was called",
+              },
+            }),
+          ],
+          children: [tests[0].uuid],
+        }),
+      ]);
+    });
+
+    it("should report done with Error", async () => {
+      const { tests, groups } = await runJasmineInlineTest({
+        "spec/test/sample.spec.js": `
+          beforeAll((done) => {
+            done(new Error("foo"));
+          });
+
+          it("bar", () => {});
+        `,
+      });
+
+      expect(tests, "has broken test").toEqual([
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          statusDetails: {
+            message: expect.stringContaining("Not run because a beforeAll function failed"),
+            trace: expect.anything(),
+          },
+        }),
+      ]);
+      expect(groups, "has broken fixture").toEqual([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: expect.stringContaining("foo"),
+                trace: expect.stringContaining("sample.spec.js"),
+              }),
+            }),
+          ],
+          children: [tests[0].uuid],
+        }),
+      ]);
+    });
+
+    it("should report done with string", async () => {
+      const { tests, groups } = await runJasmineInlineTest({
+        "spec/test/sample.spec.js": `
+          beforeAll((done) => {
+            done("foo");
+          });
+
+          it("bar", () => {});
+        `,
+      });
+
+      expect(tests, "has broken test").toEqual([
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          statusDetails: {
+            message: expect.stringContaining("Not run because a beforeAll function failed"),
+            trace: expect.anything(),
+          },
+        }),
+      ]);
+      expect(groups, "has broken fixture").toEqual([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              status: Status.BROKEN,
+              statusDetails: {
+                message: "foo",
+              },
+            }),
+          ],
+          children: [tests[0].uuid],
+        }),
+      ]);
+    });
+  });
+});
+
+it("should keep the context", async () => {
+  const {
+    tests: [test],
+    groups,
+  } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      beforeAll(function () {
+        this.state = ["beforeAll"];
+      });
+      beforeEach(function () {
+        this.state.push("beforeEach");
+      });
+      afterEach(function () {
+        this.state.push("afterEach");
+      });
+      afterAll(function () {
+        this.state.push("afterAll");
+        expect(this.state).toEqual([
+          "beforeAll",
+          "beforeEach",
+          "it",
+          "afterEach",
+          "afterAll",
+        ]);
+      });
+
+      it("foo", function () {
+        this.state.push("it");
+      });
+    `,
+  });
+
+  expect(test).toMatchObject({ status: Status.PASSED });
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        befores: [expect.objectContaining({ name: "beforeAll", status: Status.PASSED })],
+      }),
+      expect.objectContaining({
+        befores: [expect.objectContaining({ name: "beforeEach", status: Status.PASSED })],
+      }),
+      expect.objectContaining({
+        afters: [expect.objectContaining({ name: "afterAll", status: Status.PASSED })],
+      }),
+      expect.objectContaining({
+        afters: [expect.objectContaining({ name: "afterEach", status: Status.PASSED })],
+      }),
+    ]),
+  );
+});
+
+describe("hook steps", () => {
+  it("supports steps in async hooks", async () => {
+    const { groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        const { step } = require("allure-js-commons");
+
+        const wait = async () => await new Promise((r) => setTimeout(r, 1));
+        beforeAll(async () => {
+          await step("step in beforeAll", wait);
+        });
+        afterAll(async () => {
+          await step("step in afterAll", wait);
+        });
+        beforeEach(async () => {
+          await step("step in beforeEach", wait);
+        });
+        afterEach(async () => {
+          await step("step in afterEach", wait);
+        });
+
+        it("foo", wait);
+      `,
+    });
+
+    expect(groups).toHaveLength(4);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              steps: [
+                expect.objectContaining({
+                  name: "step in beforeAll",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          name: "afterAll",
+          afters: [
+            expect.objectContaining({
+              steps: [
+                expect.objectContaining({
+                  name: "step in afterAll",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeEach",
+              steps: [
+                expect.objectContaining({
+                  name: "step in beforeEach",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          name: "afterEach",
+          afters: [
+            expect.objectContaining({
+              steps: [
+                expect.objectContaining({
+                  name: "step in afterEach",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("supports steps in hooks with callbacks", async () => {
+    const { groups } = await runJasmineInlineTest({
+      "spec/test/sample.spec.js": `
+        const { step } = require("allure-js-commons");
+
+        beforeAll((done) => {
+          step("step in beforeAll", () => {}).finally(done);
+        });
+        afterAll((done) => {
+          step("step in afterAll", () => {}).finally(done);
+        });
+        beforeEach((done) => {
+          step("step in beforeEach", () => {}).finally(done);
+        });
+        afterEach((done) => {
+          step("step in afterEach", () => {}).finally(done);
+        });
+
+        it("foo", () => {});
+      `,
+    });
+
+    expect(groups).toHaveLength(4);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeAll",
+              steps: [
+                expect.objectContaining({
+                  name: "step in beforeAll",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          name: "afterAll",
+          afters: [
+            expect.objectContaining({
+              steps: [
+                expect.objectContaining({
+                  name: "step in afterAll",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          befores: [
+            expect.objectContaining({
+              name: "beforeEach",
+              steps: [
+                expect.objectContaining({
+                  name: "step in beforeEach",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          name: "afterEach",
+          afters: [
+            expect.objectContaining({
+              steps: [
+                expect.objectContaining({
+                  name: "step in afterEach",
+                  status: Status.PASSED,
+                  stage: Stage.FINISHED,
+                }),
+              ],
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+});
+
+it("should support attachments in hooks", async () => {
+  const { groups, attachments } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { attachment } = require("allure-js-commons");
+
+      beforeAll(async () => {
+        await attachment("foo", "beforeAll", "text/plain");
+      });
+      afterAll(async () => {
+        await attachment("bar", "afterAll", "text/plain");
+      });
+      beforeEach(async () => {
+        await attachment("baz", "beforeEach", "text/plain");
+      });
+      afterEach(async () => {
+        await attachment("qux", "afterEach", "text/plain");
+      });
+
+      it("quz", () => {});
+    `,
+  });
+
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        befores: [
+          expect.objectContaining({
+            name: "beforeAll",
+            steps: [
+              expect.objectContaining({
+                name: "foo",
+                attachments: [expect.objectContaining({ name: "foo", type: "text/plain" })],
+              }),
+            ],
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        afters: [
+          expect.objectContaining({
+            name: "afterAll",
+            steps: [
+              expect.objectContaining({
+                name: "bar",
+                attachments: [expect.objectContaining({ name: "bar", type: "text/plain" })],
+              }),
+            ],
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        befores: [
+          expect.objectContaining({
+            name: "beforeEach",
+            steps: [
+              expect.objectContaining({
+                name: "baz",
+                attachments: [expect.objectContaining({ name: "baz", type: "text/plain" })],
+              }),
+            ],
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        afters: [
+          expect.objectContaining({
+            name: "afterEach",
+            steps: [
+              expect.objectContaining({
+                name: "qux",
+                attachments: [expect.objectContaining({ name: "qux", type: "text/plain" })],
+              }),
+            ],
+          }),
+        ],
+      }),
+    ]),
+  );
+
+  const {
+    befores: [
+      {
+        steps: [
+          {
+            attachments: [{ source: beforeAllAttachment }],
+          },
+        ],
+      },
+    ],
+  } = groups.find((g) => g.name === "beforeAll")!;
+  const {
+    afters: [
+      {
+        steps: [
+          {
+            attachments: [{ source: afterAllAttachment }],
+          },
+        ],
+      },
+    ],
+  } = groups.find((g) => g.name === "afterAll")!;
+  const {
+    befores: [
+      {
+        steps: [
+          {
+            attachments: [{ source: beforeEachAttachment }],
+          },
+        ],
+      },
+    ],
+  } = groups.find((g) => g.name === "beforeEach")!;
+  const {
+    afters: [
+      {
+        steps: [
+          {
+            attachments: [{ source: afterEachAttachment }],
+          },
+        ],
+      },
+    ],
+  } = groups.find((g) => g.name === "afterEach")!;
+
+  expect(Buffer.from(attachments[beforeAllAttachment] as string, "base64").toString("utf8")).toEqual("beforeAll");
+  expect(Buffer.from(attachments[afterAllAttachment] as string, "base64").toString("utf8")).toEqual("afterAll");
+  expect(Buffer.from(attachments[beforeEachAttachment] as string, "base64").toString("utf8")).toEqual("beforeEach");
+  expect(Buffer.from(attachments[afterEachAttachment] as string, "base64").toString("utf8")).toEqual("afterEach");
+});
+
+it("should support hook renaming", async () => {
+  const { groups } = await runJasmineInlineTest({
+    "spec/test/sample.spec.js": `
+      const { displayName } = require("allure-js-commons");
+
+      beforeAll(async () => {
+        await displayName("foo");
+      });
+      afterAll(async () => {
+        await displayName("bar");
+      });
+      beforeEach(async () => {
+        await displayName("baz");
+      });
+      afterEach(async () => {
+        await displayName("qux");
+      });
+
+      it("quz", () => {});
+    `,
+  });
+
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        befores: [expect.objectContaining({ name: "foo" })],
+      }),
+      expect.objectContaining({
+        afters: [expect.objectContaining({ name: "bar" })],
+      }),
+      expect.objectContaining({
+        befores: [expect.objectContaining({ name: "baz" })],
+      }),
+      expect.objectContaining({
+        afters: [expect.objectContaining({ name: "qux" })],
       }),
     ]),
   );

--- a/packages/allure-js-commons/src/facade.ts
+++ b/packages/allure-js-commons/src/facade.ts
@@ -18,10 +18,10 @@ const callRuntimeMethod = <
 
   if (!isPromise(runtime)) {
     // @ts-ignore
-    return (runtime as TestRuntime)[method](...args);
+    return runtime[method](...args);
   }
 
-  return (runtime as Promise<TestRuntime>).then((testRuntime) => {
+  return runtime.then((testRuntime) => {
     // @ts-ignore
     return testRuntime[method](...args);
   }) as R;

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -133,5 +133,5 @@ export const getUnfinishedStepsMessages = (messages: RuntimeMessage[]) => {
   return grouppedStepsMessage.filter((step) => step.length === 1);
 };
 
-export const isPromise = (obj: any): boolean =>
+export const isPromise = <T = any>(obj: any): obj is PromiseLike<T> =>
   !!obj && (typeof obj === "object" || typeof obj === "function") && typeof obj.then === "function";

--- a/packages/allure-mocha/src/legacy.ts
+++ b/packages/allure-mocha/src/legacy.ts
@@ -164,16 +164,16 @@ class LegacyAllureApi {
         parameter: this.addStepParameter,
       });
       if (isPromise(result)) {
-        const promise = result as Promise<any>;
-        return promise
-          .then((v) => {
+        return result.then(
+          (v) => {
             this.stopStepSuccess();
             return v;
-          })
-          .catch((e) => {
+          },
+          (e) => {
             this.stopStepWithError(e);
             throw e;
-          }) as T;
+          },
+        ) as T;
       }
       this.stopStepSuccess();
       return result;


### PR DESCRIPTION
### Context
The following issues with fixtures in Jasmine are fixed:

1. Async hooks are interleaved with each other and with test functions (the sequencing issue).
2. beforeEach/afterEach hooks affect all tests in the suite instead of only one test (the scoping issue).
3. Some errors in hooks are not reported properly.
4. User context doesn't flow into a hook implementation properly.
5. Unable to use Allure steps in a hook implementation.
6. Unable to use Allure attachments in a hook implementation.
7. Unable to rename an Allure fixture.

### Extra changes

  - `isPromise` now is a `PromiseLike<T = any>` type guard.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
