### PR TITLE
fix(newman-reporter-allure): make Newman container name as parent suite name

### DIFF
--- a/packages/newman-reporter-allure/src/index.ts
+++ b/packages/newman-reporter-allure/src/index.ts
@@ -16,6 +16,7 @@ class AllureReporter {
   pmItemsByAllureUuid: Map<string, PmItem> = new Map();
   currentTest?: string;
   currentScope?: string;
+  rootCollectionName?: string;
 
   constructor(
     emitter: EventEmitter,
@@ -27,6 +28,7 @@ class AllureReporter {
     const { resultsDir = "./allure-results", ...restConfig } = reporterConfig;
 
     this.currentCollection = options.collection;
+    this.rootCollectionName = options.collection.name;
     this.allureConfig = reporterConfig;
     this.allureRuntime = new ReporterRuntime({
       ...restConfig,
@@ -420,15 +422,14 @@ class AllureReporter {
 
     const chain: string[] = [];
 
-    if (this.currentCollection.name && this.allureConfig.collectionAsParentSuite) {
-      chain.push(this.currentCollection.name);
-    }
-
     item.forEachParent((parent) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       chain.unshift(parent.name || parent.id);
     });
 
+    if (this.rootCollectionName) {
+      chain.unshift(this.rootCollectionName);
+    }
     return chain;
   }
 

--- a/packages/newman-reporter-allure/test/spec/simple.test.ts
+++ b/packages/newman-reporter-allure/test/spec/simple.test.ts
@@ -8,74 +8,76 @@ beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-test("complex test overview", async () => {
-  const { tests } = await runNewmanCollection({
-    info: {
-      name: "fff",
-    },
-    item: [
-      {
-        name: "ParentName",
-        item: [
-          {
-            name: "SuiteName",
-            item: [
-              {
-                name: "SubSub1",
-                item: [
-                  {
-                    name: "SubSub1",
-                    item: [
-                      {
-                        name: "testReq",
-                        event: [
-                          {
-                            listen: "test",
-                            script: {
-                              exec: [
-                                "//@allure.id=228",
-                                "//@allure.label.custom=test",
-                                'pm.test("Status code is 200", function () {',
-                                "    pm.response.to.have.status(200);",
-                                "});",
-                              ],
-                              type: "text/javascript",
-                            },
-                          },
-                        ],
-                        request: {
-                          description: "testDescription\n\nmultiline\n\n**somethingBold**",
-                          method: "GET",
-                          header: [],
-                          url: {
-                            host: ["example", "com"],
-                            path: ["test"],
-                            query: [
-                              {
-                                key: "dfgdfg",
-                                value: null,
-                              },
+const collection = {
+  info: {
+    name: "fff",
+  },
+  item: [
+    {
+      name: "ParentName",
+      item: [
+        {
+          name: "SuiteName",
+          item: [
+            {
+              name: "SubSub1",
+              item: [
+                {
+                  name: "SubSub1",
+                  item: [
+                    {
+                      name: "testReq",
+                      event: [
+                        {
+                          listen: "test",
+                          script: {
+                            exec: [
+                              "//@allure.id=228",
+                              "//@allure.label.custom=test",
+                              'pm.test("Status code is 200", function () {',
+                              "    pm.response.to.have.status(200);",
+                              "});",
                             ],
+                            type: "text/javascript",
                           },
                         },
-                        response: [],
+                      ],
+                      request: {
+                        description: "testDescription\n\nmultiline\n\n**somethingBold**",
+                        method: "GET",
+                        header: [],
+                        url: {
+                          host: ["example", "com"],
+                          path: ["test"],
+                          query: [
+                            {
+                              key: "dfgdfg",
+                              value: null,
+                            },
+                          ],
+                        },
                       },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      },
-    ],
-  });
+                      response: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+test("complex test overview", async () => {
+  const { tests } = await runNewmanCollection(collection);
 
   expect(tests).toHaveLength(1);
   expect(tests[0]).toEqual(
     expect.objectContaining({
       name: "testReq",
-      fullName: "ParentName/SuiteName/SubSub1/SubSub1#testReq",
+      fullName: "fff/ParentName/SuiteName/SubSub1/SubSub1#testReq",
       status: Status.PASSED,
       stage: Stage.FINISHED,
       description: "testDescription\n\nmultiline\n\n**somethingBold**",
@@ -83,9 +85,9 @@ test("complex test overview", async () => {
       historyId: expect.any(String),
       testCaseId: expect.any(String),
       labels: expect.arrayContaining([
-        { name: LabelName.PARENT_SUITE, value: "ParentName" },
-        { name: LabelName.SUITE, value: "SuiteName" },
-        { name: LabelName.SUB_SUITE, value: "SubSub1 > SubSub1" },
+        { name: LabelName.PARENT_SUITE, value: "fff" },
+        { name: LabelName.SUITE, value: "ParentName" },
+        { name: LabelName.SUB_SUITE, value: "SuiteName > SubSub1 > SubSub1" },
         { name: LabelName.ALLURE_ID, value: "228" },
         { name: "custom", value: "test" },
       ]),


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
This changes provides fixes for #935, #792 where option `--reporter-allure-collection-as-parent-suite` did not work as expected.
- The options `--reporter-allure-collection-as-parent-suite` has been removed.
- Collection Container name will be as Parent Suite name by default.
- Test have been updated to reflect the new default nested structure.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
