### PR TITLE
fix(allure-cypress): missing tests and fixtures when an error occurs in a hook

### DIFF
--- a/packages/allure-cypress/src/index.ts
+++ b/packages/allure-cypress/src/index.ts
@@ -2,7 +2,10 @@ import { getMessageAndTraceFromError, getStatusFromError } from "allure-js-commo
 import { ALLURE_REPORT_SYSTEM_HOOK } from "./model.js";
 import type { CypressCommand, CypressHook, CypressTest } from "./model.js";
 import {
+  completeHookErrorReporting,
+  completeSpecIfNoAfterHooksRemain,
   enableScopeLevelAfterHookReporting,
+  flushRuntimeMessages,
   initTestRuntime,
   reportCommandEnd,
   reportCommandStart,
@@ -18,12 +21,9 @@ import {
   reportTestSkip,
   reportTestStart,
   reportUnfinishedSteps,
-  completeHookErrorReporting,
-  flushRuntimeMessages,
-  completeSpecIfNoAfterHooksRemain,
 } from "./runtime.js";
 import { isAllureInitialized, setAllureInitialized } from "./state.js";
-import { applyTestPlan, isTestReported, shouldCommandBeSkipped, isAllureHook } from "./utils.js";
+import { applyTestPlan, isAllureHook, isTestReported, shouldCommandBeSkipped } from "./utils.js";
 
 const {
   EVENT_RUN_BEGIN,

--- a/packages/allure-cypress/src/index.ts
+++ b/packages/allure-cypress/src/index.ts
@@ -1,10 +1,8 @@
 import { getMessageAndTraceFromError, getStatusFromError } from "allure-js-commons/sdk";
-import type { CypressCommand, CypressHook, CypressTest } from "./model.js";
 import { ALLURE_REPORT_SYSTEM_HOOK } from "./model.js";
+import type { CypressCommand, CypressHook, CypressTest } from "./model.js";
 import {
   enableScopeLevelAfterHookReporting,
-  flushFinalRuntimeMessages,
-  flushRuntimeMessages,
   initTestRuntime,
   reportCommandEnd,
   reportCommandStart,
@@ -20,9 +18,12 @@ import {
   reportTestSkip,
   reportTestStart,
   reportUnfinishedSteps,
+  completeHookErrorReporting,
+  flushRuntimeMessages,
+  completeSpecIfNoAfterHooksRemain,
 } from "./runtime.js";
 import { isAllureInitialized, setAllureInitialized } from "./state.js";
-import { applyTestPlan, isTestReported, shouldCommandBeSkipped } from "./utils.js";
+import { applyTestPlan, isTestReported, shouldCommandBeSkipped, isAllureHook } from "./utils.js";
 
 const {
   EVENT_RUN_BEGIN,
@@ -35,7 +36,6 @@ const {
   EVENT_TEST_FAIL,
   EVENT_TEST_PENDING,
   EVENT_TEST_END,
-  EVENT_RUN_END,
 } = Mocha.Runner.constants;
 
 const initializeAllure = () => {
@@ -53,7 +53,7 @@ const initializeAllure = () => {
       reportRunStart();
     })
     .on(EVENT_SUITE_BEGIN, (suite: Mocha.Suite) => {
-      if (!suite.parent) {
+      if (suite.root) {
         applyTestPlan(Cypress.spec, suite);
       }
       reportSuiteStart(suite);
@@ -62,14 +62,14 @@ const initializeAllure = () => {
       reportSuiteEnd(suite);
     })
     .on(EVENT_HOOK_BEGIN, (hook: CypressHook) => {
-      if (hook.title.includes(ALLURE_REPORT_SYSTEM_HOOK)) {
+      if (isAllureHook(hook)) {
         return;
       }
 
       reportHookStart(hook);
     })
     .on(EVENT_HOOK_END, (hook: CypressHook) => {
-      if (hook.title.includes(ALLURE_REPORT_SYSTEM_HOOK)) {
+      if (isAllureHook(hook)) {
         return;
       }
 
@@ -85,22 +85,34 @@ const initializeAllure = () => {
     .on(EVENT_TEST_PASS, () => {
       reportTestPass();
     })
-    .on(EVENT_TEST_FAIL, (_: CypressTest, err: Error) => {
+    .on(EVENT_TEST_FAIL, (testOrHook: CypressTest | CypressHook, err: Error) => {
+      const isHook = "hookName" in testOrHook;
+      if (isHook && testOrHook.parent!.root && testOrHook.hookName === "after all") {
+        // Errors in spec-level 'after all' hooks are handled by Allure wrappers.
+        return;
+      }
+      const isAllureHookFailure = isHook && isAllureHook(testOrHook);
+
+      if (isAllureHookFailure) {
+        // Normally, Allure hooks are skipped from the report.
+        // In case of errors, it will be helpful to see them.
+        reportHookStart(testOrHook, Date.now() - (testOrHook.duration ?? 0));
+      }
+
+      // This will mark the fixture and the test (if any) as failed/broken.
       reportTestOrHookFail(err);
+
+      if (isHook) {
+        // This will end the fixture and test (if any) and will report the remaining
+        // tests in the hook's suite (the ones that will be skipped by Cypress/Mocha).
+        completeHookErrorReporting(testOrHook, err);
+      }
     })
     .on(EVENT_TEST_PENDING, (test: CypressTest) => {
       reportTestSkip(test);
     })
     .on(EVENT_TEST_END, (test: CypressTest) => {
       reportTestEnd(test);
-    })
-    .on(EVENT_RUN_END, () => {
-      // after:spec isn't called in interactive mode by default.
-      // We're using the 'end' event instead to report the remaining messages
-      // (the root 'suite end', mainly).
-      if (Cypress.config("isInteractive")) {
-        flushFinalRuntimeMessages();
-      }
     });
 
   Cypress.Screenshot.defaults({
@@ -132,11 +144,11 @@ const initializeAllure = () => {
     reportCommandEnd();
   });
 
-  afterEach(ALLURE_REPORT_SYSTEM_HOOK, () => {
+  afterEach(ALLURE_REPORT_SYSTEM_HOOK, flushRuntimeMessages);
+
+  after(ALLURE_REPORT_SYSTEM_HOOK, function (this: Mocha.Context) {
     flushRuntimeMessages();
-  });
-  after(ALLURE_REPORT_SYSTEM_HOOK, () => {
-    flushRuntimeMessages();
+    completeSpecIfNoAfterHooksRemain(this);
   });
 
   enableScopeLevelAfterHookReporting();

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -86,7 +86,9 @@ export type CypressFailMessage = {
 
 export type CypressTestSkipMessage = {
   type: "cypress_test_skip";
-  data: object;
+  data: {
+    statusDetails?: StatusDetails;
+  };
 };
 
 export type CypressTestPassMessage = {
@@ -94,12 +96,9 @@ export type CypressTestPassMessage = {
   data: object;
 };
 
-export type CypressTestStatusMessage = {
-  type: "cypress_test_status";
-  data: {
-    status: Status;
-    statusDetails?: StatusDetails;
-  };
+export type CypressSkippedTestMessage = {
+  type: "cypress_skipped_test";
+  data: CypressTestStartMessage["data"] & CypressFailMessage["data"] & CypressTestEndMessage["data"];
 };
 
 export type CypressTestEndMessage = {
@@ -141,7 +140,7 @@ export type CypressMessage =
   | CypressTestPassMessage
   | CypressFailMessage
   | CypressTestSkipMessage
-  | CypressTestStatusMessage
+  | CypressSkippedTestMessage
   | CypressTestEndMessage;
 
 export type SpecContext = {

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -12,16 +12,12 @@ export type AllureCypressConfig = ReporterConfig & {
 
 export type CypressTest = Mocha.Test & {
   wallClockStartedAt?: Date;
-  hookName?: string;
-  id: string;
 };
 
 export type CypressHook = Mocha.Hook & {
   id: string;
   hookId: string;
-  parent: Mocha.Suite & {
-    id: string;
-  };
+  hookName: string;
 };
 
 export type CypressCommand = {
@@ -98,6 +94,14 @@ export type CypressTestPassMessage = {
   data: object;
 };
 
+export type CypressTestStatusMessage = {
+  type: "cypress_test_status";
+  data: {
+    status: Status;
+    statusDetails?: StatusDetails;
+  };
+};
+
 export type CypressTestEndMessage = {
   type: "cypress_test_end";
   data: {
@@ -137,6 +141,7 @@ export type CypressMessage =
   | CypressTestPassMessage
   | CypressFailMessage
   | CypressTestSkipMessage
+  | CypressTestStatusMessage
   | CypressTestEndMessage;
 
 export type SpecContext = {
@@ -156,6 +161,7 @@ export type AllureSpecState = {
   initialized: boolean;
   testPlan: TestPlanV1 | null | undefined;
   messages: CypressMessage[];
+  currentTest?: CypressTest;
 };
 
 export type HookPosition = "before" | "after";
@@ -174,3 +180,5 @@ export type CypressSuiteFunction = (
   configOrFn?: Cypress.SuiteConfigOverrides | ((this: Mocha.Suite) => void),
   fn?: (this: Mocha.Suite) => void,
 ) => Mocha.Suite;
+
+export type HookImplementation = Mocha.Func | Mocha.AsyncFunc | ((this: Mocha.Context) => void);

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -183,6 +183,7 @@ export type AllureSpecState = {
 export type AllureCypressTaskArgs = {
   absolutePath: string;
   messages: readonly CypressMessage[];
+  isInteractive: boolean;
 };
 
 export type CypressSuiteFunction = (

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -10,14 +10,21 @@ export type AllureCypressConfig = ReporterConfig & {
   videoOnFailOnly?: boolean;
 };
 
+export type CypressSuite = Mocha.Suite & {
+  parent: CypressSuite | undefined;
+  tests: CypressTest[];
+  suites: CypressSuite[];
+};
+
 export type CypressTest = Mocha.Test & {
   wallClockStartedAt?: Date;
+  parent: CypressSuite | undefined;
 };
 
 export type CypressHook = Mocha.Hook & {
-  id: string;
   hookId: string;
   hookName: string;
+  parent: CypressSuite | undefined;
 };
 
 export type CypressCommand = {
@@ -180,4 +187,5 @@ export type CypressSuiteFunction = (
   fn?: (this: Mocha.Suite) => void,
 ) => Mocha.Suite;
 
-export type HookImplementation = Mocha.Func | Mocha.AsyncFunc | ((this: Mocha.Context) => void);
+export type DirectHookImplementation = Mocha.AsyncFunc | ((this: Mocha.Context) => void);
+export type HookImplementation = Mocha.Func | DirectHookImplementation;

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -62,6 +62,8 @@ export type CypressHookStartMessage = {
   type: "cypress_hook_start";
   data: {
     name: string;
+    scopeType: "each" | "all";
+    position: "before" | "after";
     start: number;
   };
 };
@@ -169,12 +171,6 @@ export type AllureSpecState = {
   messages: CypressMessage[];
   currentTest?: CypressTest;
 };
-
-export type HookPosition = "before" | "after";
-
-export type HookScopeType = "all" | "each";
-
-export type HookType = [position: HookPosition, scopeType: HookScopeType];
 
 export type AllureCypressTaskArgs = {
   absolutePath: string;

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -11,6 +11,7 @@ export type AllureCypressConfig = ReporterConfig & {
 };
 
 export type CypressSuite = Mocha.Suite & {
+  id: string;
   parent: CypressSuite | undefined;
   tests: CypressTest[];
   suites: CypressSuite[];
@@ -44,6 +45,7 @@ export type CupressRunStart = {
 export type CypressSuiteStartMessage = {
   type: "cypress_suite_start";
   data: {
+    id: string;
     name: string;
     root: boolean;
     start: number;
@@ -107,7 +109,11 @@ export type CypressTestPassMessage = {
 
 export type CypressSkippedTestMessage = {
   type: "cypress_skipped_test";
-  data: CypressTestStartMessage["data"] & CypressFailMessage["data"] & CypressTestEndMessage["data"];
+  data: CypressTestStartMessage["data"] &
+    CypressFailMessage["data"] &
+    CypressTestEndMessage["data"] & {
+      suites: string[];
+    };
 };
 
 export type CypressTestEndMessage = {
@@ -159,6 +165,8 @@ export type SpecContext = {
   fixture: string | undefined;
   commandSteps: string[];
   videoScope: string;
+  suiteIdToScope: Map<string, string>;
+  suiteScopeToId: Map<string, string>;
   suiteScopes: string[];
   testScope: string | undefined;
   suiteNames: string[];

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -57,7 +57,11 @@ export class AllureCypress {
       },
       reportFinalAllureCypressSpecMessages: (args: AllureCypressTaskArgs) => {
         this.#applyAllureCypressMessages(args);
-        this.endSpec(args.absolutePath);
+        if (args.isInteractive) {
+          // In non-interactive mode the spec is ended via the 'after:spec' event instead
+          // to get the spec's video.
+          this.endSpec(args.absolutePath);
+        }
         return null;
       },
     });
@@ -76,7 +80,7 @@ export class AllureCypress {
    * you need to define your own handler or combine Allure Cypress with other
    * plugins. More info [here](https://github.com/allure-framework/allure-js/blob/main/packages/allure-cypress/README.md#setupnodeevents-limitations).
    * @param spec The first argument of the `after:spec` event.
-   * @param results The second argument of the `after:spec` event.
+   * @param results The second argument of the `after:spec` event. It's `undefined` in interactive mode.
    * @example
    * ```javascript
    * import { defineConfig } from "cypress";
@@ -94,15 +98,15 @@ export class AllureCypress {
    * });
    * ```
    */
-  onAfterSpec = (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
-    this.endSpec(spec.absolute, results.video ?? undefined);
+  onAfterSpec = (spec: Cypress.Spec, results: CypressCommandLine.RunResult | undefined) => {
+    this.endSpec(spec.absolute, results?.video ?? undefined);
   };
 
   /**
    * Forward the `after:run` event into Allure Cypress using this function if
    * you need to define your own handler or combine Allure Cypress with other
    * plugins. More info [here](https://github.com/allure-framework/allure-js/blob/main/packages/allure-cypress/README.md#setupnodeevents-limitations).
-   * @param results The argument of the `after:run` event.
+   * @param results The argument of the `after:run` event. It's `undefined` in interactive mode.
    * @example
    * ```javascript
    * import { defineConfig } from "cypress";
@@ -120,8 +124,10 @@ export class AllureCypress {
    * });
    * ```
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  onAfterRun = (results: CypressCommandLine.CypressFailedRunResult | CypressCommandLine.CypressRunResult) => {
+  onAfterRun = (
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    results: CypressCommandLine.CypressFailedRunResult | CypressCommandLine.CypressRunResult | undefined,
+  ) => {
     this.endRun();
   };
 

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -32,7 +32,7 @@ import type {
   CypressTestStartMessage,
   SpecContext,
 } from "./model.js";
-import { getHookType, last } from "./utils.js";
+import { last } from "./utils.js";
 
 export class AllureCypress {
   allureRuntime: ReporterRuntime;
@@ -231,23 +231,20 @@ export class AllureCypress {
     }
   };
 
-  #startHook = (context: SpecContext, { data: { name, start } }: CypressHookStartMessage) => {
-    const [hookPosition, hookScopeType] = getHookType(name);
-    if (hookPosition) {
-      const isEach = hookScopeType === "each";
-      const isAfterEach = hookPosition === "after" && isEach;
-      if (!isAfterEach) {
-        this.#emitPreviousTestScope(context);
-      }
+  #startHook = (context: SpecContext, { data: { name, scopeType, position, start } }: CypressHookStartMessage) => {
+    const isEach = scopeType === "each";
+    const isAfterEach = position === "after" && isEach;
+    if (!isAfterEach) {
+      this.#emitPreviousTestScope(context);
+    }
 
-      const scope = isEach ? context.testScope : last(context.suiteScopes);
-      if (scope) {
-        context.fixture = this.allureRuntime.startFixture(scope, hookPosition, {
-          name,
-          start,
-          status: undefined,
-        });
-      }
+    const scope = isEach ? context.testScope : last(context.suiteScopes);
+    if (scope) {
+      context.fixture = this.allureRuntime.startFixture(scope, position, {
+        name,
+        start,
+        status: undefined,
+      });
     }
   };
 

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -75,6 +75,7 @@ export class AllureCypress {
    * @param spec The first argument of the `after:spec` event.
    * @param results The second argument of the `after:spec` event.
    * @example
+   * ```javascript
    * import { defineConfig } from "cypress";
    * import { allureCypress } from "allure-cypress/reporter";
    *
@@ -88,6 +89,7 @@ export class AllureCypress {
    *   }
    *   // ...
    * });
+   * ```
    */
   onAfterSpec = (spec: Cypress.Spec, results: CypressCommandLine.RunResult) => {
     this.endSpec(spec.absolute, results.video ?? undefined);
@@ -99,6 +101,7 @@ export class AllureCypress {
    * plugins. More info [here](https://github.com/allure-framework/allure-js/blob/main/packages/allure-cypress/README.md#setupnodeevents-limitations).
    * @param results The argument of the `after:run` event.
    * @example
+   * ```javascript
    * import { defineConfig } from "cypress";
    * import { allureCypress } from "allure-cypress/reporter";
    *
@@ -112,6 +115,7 @@ export class AllureCypress {
    *   }
    *   // ...
    * });
+   * ```
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   onAfterRun = (results: CypressCommandLine.CypressFailedRunResult | CypressCommandLine.CypressRunResult) => {
@@ -458,6 +462,7 @@ export const enableTestPlan = (config: Cypress.PluginConfigOptions) => {
  * @param cypressConfig The Cypress configuration (the second argument of `setupNodeEvents`). If provided, the selective run feature will be enabled.
  * @param allureConfig An Allure configuration object (optional).
  * @example
+ * ```javascript
  * import { defineConfig } from "cypress";
  * import { allureCypress } from "allure-cypress/reporter";
  *
@@ -470,6 +475,7 @@ export const enableTestPlan = (config: Cypress.PluginConfigOptions) => {
  *     // ...
  *   }
  * });
+ * ```
  */
 export const allureCypress = (
   on: Cypress.PluginEvents,

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -445,7 +445,7 @@ export class AllureCypress {
 
   #initializeSpecContext = (absolutePath: string) => {
     const specPathElements = path.relative(process.cwd(), absolutePath).split(path.sep);
-    const context = {
+    const context: SpecContext = {
       specPath: specPathElements.join("/"),
       package: specPathElements.join("."),
       test: undefined,

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -429,10 +429,9 @@ export const reportTestEnd = (test: CypressTest) => {
 };
 
 export const completeHookErrorReporting = (hook: CypressHook, err: Error) => {
-  const hookName = hook.hookName;
-  const isEachHook = hookName.includes("each");
+  const isEachHook = hook.hookName.includes("each");
   const suite = hook.parent!;
-  const testFailData = getStatusDataOfTestSkippedByHookError(hookName, isEachHook, err, suite);
+  const testFailData = getStatusDataOfTestSkippedByHookError(hook.title, isEachHook, err, suite);
 
   // Cypress doens't emit 'hook end' if the hook has failed.
   reportHookEnd(hook);
@@ -519,7 +518,7 @@ const reportTestsSkippedByHookError = (test: CypressTest, testFailData: CypressF
 };
 
 const getStatusDataOfTestSkippedByHookError = (
-  hookName: string,
+  hookTitle: string,
   isEachHook: boolean,
   err: Error,
   suite: CypressSuite,
@@ -529,15 +528,15 @@ const getStatusDataOfTestSkippedByHookError = (
   return {
     status,
     statusDetails: {
-      message: isEachHook ? getSkipReason(hookName, suite) : message,
+      message: isEachHook ? getSkipReason(hookTitle, suite) : message,
       trace,
     },
   };
 };
 
-const getSkipReason = (hookName: string, suite: Mocha.Suite) => {
-  const suiteName = suite.title ? suite.title : "root";
-  return `'${hookName}' of suite '${suiteName}' failed for one of the previous tests`;
+const getSkipReason = (hookTitle: string, suite: CypressSuite) => {
+  const suiteName = suite.title ? `'${suite.title}'` : "root";
+  return `'${hookTitle}' defined in the ${suiteName} suite has failed`;
 };
 
 const forwardDescribeCall = (target: CypressSuiteFunction, ...args: Parameters<CypressSuiteFunction>) => {

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -279,15 +279,11 @@ export const reportHookEnd = (hook: Mocha.Hook) => {
   });
 };
 
-export const reportTestStart = (test: CypressTest, flag?: string) => {
-  const x = getNamesAndLabels(Cypress.spec, test);
-  if (flag) {
-    x.labels.push({ name: "reported", value: flag });
-  }
+export const reportTestStart = (test: CypressTest) => {
   enqueueRuntimeMessage({
     type: "cypress_test_start",
     data: {
-      ...x,
+      ...getNamesAndLabels(Cypress.spec, test),
       start: test.wallClockStartedAt?.getTime() || Date.now(),
     },
   });

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -289,6 +289,8 @@ export const reportHookStart = (hook: CypressHook, start?: number) => {
     type: "cypress_hook_start",
     data: {
       name: hook.title,
+      scopeType: hook.hookName.includes("each") ? "each" : "all",
+      position: hook.hookName.includes("before") ? "before" : "after",
       start: start ?? Date.now(),
     },
   });

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -10,6 +10,7 @@ import type { RuntimeMessage } from "allure-js-commons/sdk";
 import { getGlobalTestRuntime, setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import type { TestRuntime } from "allure-js-commons/sdk/runtime";
 import type {
+  AllureCypressTaskArgs,
   CypressCommand,
   CypressCommandEndMessage,
   CypressFailMessage,
@@ -235,7 +236,12 @@ export class AllureCypressTestRuntime implements TestRuntime {
   flushAllureMessagesToTaskAsync = (taskName: string): Cypress.Chainable<unknown> | undefined => {
     const messages = this.#dequeueAllMessages();
     if (messages.length) {
-      return cy.task(taskName, { absolutePath: Cypress.spec.absolute, messages }, { log: false });
+      const args: AllureCypressTaskArgs = {
+        absolutePath: Cypress.spec.absolute,
+        messages,
+        isInteractive: Cypress.config("isInteractive"),
+      };
+      return cy.task(taskName, args, { log: false });
     }
   };
 

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -31,6 +31,7 @@ import {
   setRuntimeMessages,
 } from "./state.js";
 import {
+  getSuites,
   getTestSkipData,
   getTestStartData,
   getTestStopData,
@@ -267,6 +268,7 @@ export const reportSuiteStart = (suite: CypressSuite) => {
   enqueueRuntimeMessage({
     type: "cypress_suite_start",
     data: {
+      id: suite.id,
       name: suite.title,
       root: suite.root,
       start: Date.now(),
@@ -510,6 +512,7 @@ const reportTestsSkippedByHookError = (test: CypressTest, testFailData: CypressF
       ...getTestStartData(test),
       ...testFailData,
       ...getTestStopData(test),
+      suites: getSuites(test).map((s) => s.id),
     },
   });
   markTestAsReported(test);
@@ -519,7 +522,7 @@ const getStatusDataOfTestSkippedByHookError = (
   hookName: string,
   isEachHook: boolean,
   err: Error,
-  suite: Mocha.Suite,
+  suite: CypressSuite,
 ) => {
   const status = isEachHook ? Status.SKIPPED : getStatusFromError(err);
   const { message, trace } = getMessageAndTraceFromError(err);

--- a/packages/allure-cypress/src/state.ts
+++ b/packages/allure-cypress/src/state.ts
@@ -1,4 +1,4 @@
-import type { AllureSpecState, CypressMessage } from "./model.js";
+import type { AllureSpecState, CypressMessage, CypressTest } from "./model.js";
 
 export const getAllureState = () => {
   let state = Cypress.env("allure") as AllureSpecState;
@@ -7,6 +7,7 @@ export const getAllureState = () => {
       initialized: false,
       messages: [],
       testPlan: undefined,
+      currentTest: undefined,
     };
     Cypress.env("allure", state);
   }
@@ -30,3 +31,13 @@ export const enqueueRuntimeMessage = (message: CypressMessage) => {
 };
 
 export const getAllureTestPlan = () => getAllureState().testPlan;
+
+export const getCurrentTest = () => getAllureState().currentTest;
+
+export const setCurrentTest = (test: CypressTest) => {
+  getAllureState().currentTest = test;
+};
+
+export const dropCurrentTest = () => {
+  getAllureState().currentTest = undefined;
+};

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -2,7 +2,7 @@ import { LabelName, Status } from "allure-js-commons";
 import { extractMetadataFromString, getMessageAndTraceFromError, getStatusFromError } from "allure-js-commons/sdk";
 import type { TestPlanV1 } from "allure-js-commons/sdk";
 import { ALLURE_REPORT_STEP_COMMAND, ALLURE_REPORT_SYSTEM_HOOK } from "./model.js";
-import type { CypressCommand, CypressHook, CypressSuite, CypressTest, HookPosition, HookScopeType, HookType } from "./model.js";
+import type { CypressCommand, CypressHook, CypressSuite, CypressTest } from "./model.js";
 import { getAllureTestPlan } from "./state.js";
 
 export const uint8ArrayToBase64 = (data: unknown) => {
@@ -115,16 +115,6 @@ export const markTestAsReported = (test: CypressTest) => {
 };
 
 export const isTestReported = (test: CypressTest) => (test as any)[testReportedKey] === true;
-
-const hookTypeRegexp = /^"(before|after) (all|each)"/;
-
-export const getHookType = (name: string): HookType | [] => {
-  const match = hookTypeRegexp.exec(name);
-  if (match) {
-    return [match[1] as HookPosition, match[2] as HookScopeType];
-  }
-  return [];
-};
 
 export const iterateSuites = function* (parent: CypressSuite) {
   const suiteQueue: CypressSuite[] = [];

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -17,20 +17,19 @@ export const uint8ArrayToBase64 = (data: unknown) => {
   return btoa(String.fromCharCode.apply(null, data as number[]));
 };
 
-export const getSuitePath = (test: CypressTest): string[] => {
-  const path: string[] = [];
-  let currentSuite: CypressSuite | undefined = test.parent;
-
-  while (currentSuite) {
-    if (currentSuite.title) {
-      path.unshift(currentSuite.title);
-    }
-
-    currentSuite = currentSuite.parent;
+export const getSuites = (test: CypressTest) => {
+  const suites: CypressSuite[] = [];
+  for (let s: CypressSuite | undefined = test.parent; s; s = s.parent) {
+    suites.push(s);
   }
-
-  return path;
+  suites.reverse();
+  return suites;
 };
+
+export const getSuitePath = (test: CypressTest): string[] =>
+  getSuites(test)
+    .filter((s) => s.title)
+    .map((s) => s.title);
 
 export const shouldCommandBeSkipped = (command: CypressCommand) => {
   if (last(command.attributes.args)?.log === false) {

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -117,10 +117,15 @@ export const markTestAsReported = (test: CypressTest) => {
 export const isTestReported = (test: CypressTest) => (test as any)[testReportedKey] === true;
 
 export const iterateSuites = function* (parent: CypressSuite) {
-  const suiteQueue: CypressSuite[] = [];
-  for (let s: CypressSuite | undefined = parent; s; s = suiteQueue.shift()) {
+  const suiteStack: CypressSuite[] = [];
+  for (let s: CypressSuite | undefined = parent; s; s = suiteStack.pop()) {
     yield s;
-    suiteQueue.push(...s.suites);
+
+    // Pushing in reverse allows us to maintain depth-first pre-order traversal -
+    // the same order as used by Mocha & Cypress.
+    for (let i = s.suites.length - 1; i >= 0; i--) {
+      suiteStack.push(s.suites[i]);
+    }
   }
 };
 

--- a/packages/allure-cypress/test/spec/hooks.test.ts
+++ b/packages/allure-cypress/test/spec/hooks.test.ts
@@ -349,3 +349,23 @@ it("reports manually skipped tests in hooks", async () => {
   expect(tests[0].status).toBe(Status.SKIPPED);
   expect(tests[0].stage).toBe(Stage.FINISHED);
 });
+
+
+it("should report an error in a beforeEach hook", async () => {
+  await issue("1072");
+  const { tests } = await runCypressInlineTest({
+    "cypress/e2e/sample.cy.js": () => `
+      describe("suite", () => {
+        beforeEach(() => {
+          throw new Error();
+        });
+
+        it("foo", () => {});
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].status).toBe(Status.BROKEN);
+  expect(tests[0].stage).toBe(Stage.FINISHED);
+});

--- a/packages/allure-cypress/test/spec/hooks.test.ts
+++ b/packages/allure-cypress/test/spec/hooks.test.ts
@@ -1,3 +1,5 @@
+/* eslint max-lines: off */
+import { describe } from "node:test";
 import { expect, it } from "vitest";
 import { Stage, Status, issue } from "allure-js-commons";
 import { runCypressInlineTest } from "../utils.js";
@@ -350,60 +352,877 @@ it("reports manually skipped tests in hooks", async () => {
   expect(tests[0].stage).toBe(Stage.FINISHED);
 });
 
+describe("hook errors", () => {
+  it("should report a failed spec-level beforeEach", async () => {
+    await issue("1072");
+    const { tests, groups } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": () => `
+        beforeEach(function () {
+          if (this.currentTest.title === "baz") {
+            throw new Error("Lorem Ipsum");
+          }
+        });
+        after("spec-level", () => {});
 
-it("should report an error in a beforeEach hook", async () => {
-  await issue("1072");
-  const { tests } = await runCypressInlineTest({
-    "cypress/e2e/sample.cy.js": () => `
-      beforeEach(function () {
-        if (this.currentTest.title === "bar") {
+        it("foo", () => {}); // should pass and get beforeEach and after("spec-level")
+        describe("suite 1", () => {
+          after("suite 1", () => {});
+          it("bar", () => {}); // should pass and get beforeEach, after("suite 1"), and after("spec-level")
+          it("baz", () => {}); // should break and get beforeEach, after("suite 1"), and after("spec-level")
+          it("qux", () => {}); // should skip and get after("suite 1") and after("spec-level")
+        });
+        describe("suite 2", () => {
+          after("suite 2", () => {}); // shouldn't be executed at all
+          it("quux", () => {}); // should skip and get after("spec-level")
+        });
+      `,
+    });
+
+    expect(tests).toHaveLength(5);
+    expect(tests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "foo",
+          status: Status.PASSED,
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "bar",
+          status: Status.PASSED,
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "baz",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum",
+          }),
+        }),
+        expect.objectContaining({
+          name: "qux",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: String.raw`'"before each" hook for "baz"' defined in the root suite has failed`,
+          }),
+        }),
+        expect.objectContaining({
+          name: "quux",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: String.raw`'"before each" hook for "baz"' defined in the root suite has failed`,
+          }),
+        }),
+      ]),
+    );
+    const fooUuid = tests.find((t) => t.name === "foo")!.uuid;
+    const barUuid = tests.find((t) => t.name === "bar")!.uuid;
+    const bazUuid = tests.find((t) => t.name === "baz")!.uuid;
+    const quxUuid = tests.find((t) => t.name === "qux")!.uuid;
+    const quuxUuid = tests.find((t) => t.name === "quux")!.uuid;
+    expect(groups).toHaveLength(5);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          children: [fooUuid],
+          befores: [
+            expect.objectContaining({
+              name: String.raw`"before each" hook`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [barUuid],
+          befores: [
+            expect.objectContaining({
+              name: String.raw`"before each" hook`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [bazUuid],
+          befores: [
+            expect.objectContaining({
+              name: String.raw`"before each" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [barUuid, bazUuid, quxUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook: suite 1`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooUuid, barUuid, bazUuid, quxUuid, quuxUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("should report a failed spec-level afterEach", async () => {
+    await issue("1072");
+    const { tests, groups } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": () => `
+        afterEach(function () {
+          if (this.currentTest.title === "baz") {
+            throw new Error("Lorem Ipsum");
+          }
+        });
+        after("spec-level", () => {});
+
+        it("foo", () => {}); // should pass and get afterEach and after("spec-level")
+        describe("suite 1", () => {
+          after("suite 1", () => {});
+          it("bar", () => {}); // should pass and get afterEach, after("suite 1"), and after("spec-level")
+          it("baz", () => {}); // should pass and get afterEach, after("suite 1"), and after("spec-level")
+          it("qux", () => {}); // should skip and get after("suite 1") and after("spec-level")
+        });
+        describe("suite 2", () => {
+          after("suite 2", () => {}); // shouldn't be executed at all
+          it("quux", () => {}); // should skip and get after("spec-level")
+        });
+      `,
+    });
+
+    expect(tests).toHaveLength(5);
+    expect(tests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "foo",
+          status: Status.PASSED,
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "bar",
+          status: Status.PASSED,
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "baz",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "qux",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: String.raw`'"after each" hook for "baz"' defined in the root suite has failed`,
+          }),
+        }),
+        expect.objectContaining({
+          name: "quux",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: String.raw`'"after each" hook for "baz"' defined in the root suite has failed`,
+          }),
+        }),
+      ]),
+    );
+    const fooUuid = tests.find((t) => t.name === "foo")!.uuid;
+    const barUuid = tests.find((t) => t.name === "bar")!.uuid;
+    const bazUuid = tests.find((t) => t.name === "baz")!.uuid;
+    const quxUuid = tests.find((t) => t.name === "qux")!.uuid;
+    const quuxUuid = tests.find((t) => t.name === "quux")!.uuid;
+    expect(groups).toHaveLength(5);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          children: [fooUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [barUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [bazUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [barUuid, bazUuid, quxUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook: suite 1`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooUuid, barUuid, bazUuid, quxUuid, quuxUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("should report a failed spec-level before", async () => {
+    await issue("1072");
+    const { tests, groups } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": () => `
+        before(function () {
           throw new Error("Lorem Ipsum");
-        }
-      });
+        });
+        after(() => {
+          throw new Error("Ipsum Lorem"); // doesn't overwrite the error in 'before all'
+        });
 
-      it("foo", () => {});
-      it("bar", () => {});
-      it("baz", () => {});
-      describe("suite", () => {
-        it("qux", () => {});
-      });
+        it("foo", () => {});
+        describe("suite 1", () => {
+          it("bar", () => {});
+        });
+        describe("suite 2", () => {
+          it("baz", () => {});
+        });
+      `,
+    });
+
+    expect(tests).toHaveLength(3);
+    expect(tests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "foo",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum",
+          }),
+        }),
+        expect.objectContaining({
+          name: "bar",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum",
+          }),
+        }),
+        expect.objectContaining({
+          name: "baz",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum",
+          }),
+        }),
+      ]),
+    );
+    const fooUuid = tests.find((t) => t.name === "foo")!.uuid;
+    const barUuid = tests.find((t) => t.name === "bar")!.uuid;
+    const bazUuid = tests.find((t) => t.name === "baz")!.uuid;
+    expect(groups).toHaveLength(2);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          children: [fooUuid, barUuid, bazUuid],
+          befores: [
+            expect.objectContaining({
+              name: String.raw`"before all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooUuid, barUuid, bazUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Ipsum Lorem",
+              }),
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("should report a failed spec-level after", async () => {
+    await issue("1072");
+    const { tests, groups } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": () => `
+        after(function () {
+          throw new Error("Lorem Ipsum");
+        });
+
+        it("foo", () => {});
+        describe("suite 1", () => {
+          it("bar", () => {});
+        });
+        describe("suite 2", () => {
+          it("baz", () => {});
+        });
+      `,
+    });
+
+    expect(tests).toHaveLength(3);
+    expect(tests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "foo",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "bar",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "baz",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+      ]),
+    );
+    const fooUuid = tests.find((t) => t.name === "foo")!.uuid;
+    const barUuid = tests.find((t) => t.name === "bar")!.uuid;
+    const bazUuid = tests.find((t) => t.name === "baz")!.uuid;
+    expect(groups).toHaveLength(1);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          children: [fooUuid, barUuid, bazUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum",
+              }),
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("should report failed nested hooks", async () => {
+    await issue("1072");
+    const { tests, groups } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": () => `
+        afterEach("spec-level", () => {});
+        after("spec-level", () => {});
+
+        describe("before", () => {
+          before(() => {
+            throw new Error("Lorem Ipsum before");
+          });
+          it("foo before", () => {});
+          describe("before 1", () => {
+            it("bar before", () => {});
+          });
+          describe("before 2", () => {
+            it("baz before", () => {});
+          });
+        });
+
+        describe("after", () => {
+          after(() => {
+            throw new Error("Lorem Ipsum after");
+          });
+          it("foo after", () => {});
+          describe("after 1", () => {
+            it("bar after", () => {});
+          });
+          describe("after 2", () => {
+            it("baz after", () => {});
+          });
+        });
+
+        describe("beforeEach", () => {
+          beforeEach(() => {
+            throw new Error("Lorem Ipsum beforeEach");
+          });
+          it("foo beforeEach", () => {});
+          it("bar beforeEach", () => {});
+          describe("beforeEach 1", () => {
+            it("baz beforeEach", () => {});
+          });
+          describe("beforeEach 2", () => {
+            it("qux beforeEach", () => {});
+          });
+        });
+
+        describe("afterEach", () => {
+          afterEach(() => {
+            throw new Error("Lorem Ipsum afterEach");
+          });
+          it("foo afterEach", () => {});
+          it("bar afterEach", () => {});
+          describe("afterEach 1", () => {
+            it("baz afterEach", () => {});
+          });
+          describe("afterEach 2", () => {
+            it("qux afterEach", () => {});
+          });
+        });
+      `,
+    });
+
+    expect(tests).toHaveLength(14);
+    expect(tests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "foo before",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum before",
+          }),
+        }),
+        expect.objectContaining({
+          name: "bar before",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum before",
+          }),
+        }),
+        expect.objectContaining({
+          name: "baz before",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum before",
+          }),
+        }),
+        expect.objectContaining({
+          name: "foo after",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "bar after",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "baz after",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "foo beforeEach",
+          status: Status.BROKEN,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "Lorem Ipsum beforeEach",
+          }),
+        }),
+        expect.objectContaining({
+          name: "bar beforeEach",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "'\"before each\" hook for \"foo beforeEach\"' defined in the 'beforeEach' suite has failed",
+          }),
+        }),
+        expect.objectContaining({
+          name: "baz beforeEach",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "'\"before each\" hook for \"foo beforeEach\"' defined in the 'beforeEach' suite has failed",
+          }),
+        }),
+        expect.objectContaining({
+          name: "qux beforeEach",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "'\"before each\" hook for \"foo beforeEach\"' defined in the 'beforeEach' suite has failed",
+          }),
+        }),
+        expect.objectContaining({
+          name: "foo afterEach",
+          status: Status.PASSED, // after/afterEach don't affect the test's status
+          stage: Stage.FINISHED,
+        }),
+        expect.objectContaining({
+          name: "bar afterEach",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "'\"after each\" hook for \"foo afterEach\"' defined in the 'afterEach' suite has failed",
+          }),
+        }),
+        expect.objectContaining({
+          name: "baz afterEach",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "'\"after each\" hook for \"foo afterEach\"' defined in the 'afterEach' suite has failed",
+          }),
+        }),
+        expect.objectContaining({
+          name: "qux afterEach",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "'\"after each\" hook for \"foo afterEach\"' defined in the 'afterEach' suite has failed",
+          }),
+        }),
+      ]),
+    );
+
+    const fooBeforeUuid = tests.find((t) => t.name === "foo before")!.uuid;
+    const barBeforeUuid = tests.find((t) => t.name === "bar before")!.uuid;
+    const bazBeforeUuid = tests.find((t) => t.name === "baz before")!.uuid;
+    const fooAfterUuid = tests.find((t) => t.name === "foo after")!.uuid;
+    const barAfterUuid = tests.find((t) => t.name === "bar after")!.uuid;
+    const bazAfterUuid = tests.find((t) => t.name === "baz after")!.uuid;
+    const fooBeforeEachUuid = tests.find((t) => t.name === "foo beforeEach")!.uuid;
+    const barBeforeEachUuid = tests.find((t) => t.name === "bar beforeEach")!.uuid;
+    const bazBeforeEachUuid = tests.find((t) => t.name === "baz beforeEach")!.uuid;
+    const quxBeforeEachUuid = tests.find((t) => t.name === "qux beforeEach")!.uuid;
+    const fooAfterEachUuid = tests.find((t) => t.name === "foo afterEach")!.uuid;
+    const barAfterEachUuid = tests.find((t) => t.name === "bar afterEach")!.uuid;
+    const bazAfterEachUuid = tests.find((t) => t.name === "baz afterEach")!.uuid;
+    const quxAfterEachUuid = tests.find((t) => t.name === "qux afterEach")!.uuid;
+
+    expect(groups).toHaveLength(10);
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          children: [fooBeforeUuid, barBeforeUuid, bazBeforeUuid],
+          befores: [
+            expect.objectContaining({
+              name: String.raw`"before all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum before",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooAfterUuid, barAfterUuid, bazAfterUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum after",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooBeforeEachUuid],
+          befores: [
+            expect.objectContaining({
+              name: String.raw`"before each" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum beforeEach",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooAfterEachUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum afterEach",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooAfterUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [barAfterUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [bazAfterUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooBeforeEachUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [fooAfterEachUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after each" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [
+            fooBeforeUuid,
+            barBeforeUuid,
+            bazBeforeUuid,
+            fooAfterUuid,
+            barAfterUuid,
+            bazAfterUuid,
+            fooBeforeEachUuid,
+            barBeforeEachUuid,
+            bazBeforeEachUuid,
+            quxBeforeEachUuid,
+            fooAfterEachUuid,
+            barAfterEachUuid,
+            bazAfterEachUuid,
+            quxAfterEachUuid,
+          ],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook: spec-level`,
+              status: Status.PASSED,
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+
+  it("should report the spec on spec-level after failures", async () => {
+    const { tests, groups } = await runCypressInlineTest({
+      "cypress/e2e/promise.cy.js": () => `
+        after(() => new Cypress.Promise((_, reject) => setTimeout(() => reject(new Error("Lorem Ipsum promise")), 0)));
+        it("foo", () => {});
+      `,
+      "cypress/e2e/sync.cy.js": () => `
+        after(() => {
+          throw new Error("Lorem Ipsum sync");
+        });
+        it("bar", () => {});
+      `,
+      "cypress/e2e/callback.cy.js": () => `
+        after((done) => setTimeout(() => done(new Error("Lorem Ipsum callback")), 0));
+        it("baz", () => {});
+      `,
+    });
+
+    expect(tests).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "foo",
+          status: Status.PASSED,
+        }),
+        expect.objectContaining({
+          name: "bar",
+          status: Status.PASSED,
+        }),
+        expect.objectContaining({
+          name: "baz",
+          status: Status.PASSED,
+        }),
+      ]),
+    );
+    const fooUuid = tests.find((t) => t.name === "foo")!.uuid;
+    const barUuid = tests.find((t) => t.name === "bar")!.uuid;
+    const bazUuid = tests.find((t) => t.name === "baz")!.uuid;
+    expect(groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          children: [fooUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum promise",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [barUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum sync",
+              }),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          children: [bazUuid],
+          afters: [
+            expect.objectContaining({
+              name: String.raw`"after all" hook`,
+              status: Status.BROKEN,
+              statusDetails: expect.objectContaining({
+                message: "Lorem Ipsum callback",
+              }),
+            }),
+          ],
+        }),
+      ]),
+    );
+  });
+});
+
+it("should complete the spec from the last after hook", async () => {
+  const { tests, groups } = await runCypressInlineTest({
+    "cypress/e2e/promise.cy.js": () => `
+      after("foo promise", () => new Cypress.Promise((resolve) => setTimeout(resolve, 0)));
+      after("bar promise", () => new Cypress.Promise((resolve) => setTimeout(resolve, 0)));
+      it("baz promise", () => {});
+    `,
+    "cypress/e2e/sync.cy.js": () => `
+      after("foo sync", () => {});
+      after("bar sync", () => {});
+      it("baz sync", () => {});
+    `,
+    "cypress/e2e/callback.cy.js": () => `
+      after("foo callback", (done) => setTimeout(done, 0));
+      after("bar callback", (done) => setTimeout(done, 0));
+      it("baz callback", () => {});
     `,
   });
 
-  expect(tests).toHaveLength(3);
   expect(tests).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
-        name: "foo",
+        name: "baz promise",
         status: Status.PASSED,
-        stage: Stage.FINISHED,
-        statusDetails: expect.objectContaining({
-          message: ""
-        }),
       }),
       expect.objectContaining({
-        name: "bar",
-        status: Status.BROKEN,
-        stage: Stage.FINISHED,
-        statusDetails: expect.objectContaining({
-          message: expect.stringContaining("Lorem Ipsum"),
-        }),
+        name: "baz sync",
+        status: Status.PASSED,
       }),
       expect.objectContaining({
-        name: "baz",
-        status: Status.SKIPPED,
-        stage: Stage.FINISHED,
-        statusDetails: expect.objectContaining({
-          message: expect.stringContaining("Lorem Ipsum"),
-        }),
+        name: "baz callback",
+        status: Status.PASSED,
+      }),
+    ]),
+  );
+  const promiseUuid = tests.find((t) => t.name === "baz promise")!.uuid;
+  const syncUuid = tests.find((t) => t.name === "baz sync")!.uuid;
+  const callbackUuid = tests.find((t) => t.name === "baz callback")!.uuid;
+  expect(groups).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        children: [promiseUuid],
+        afters: [
+          expect.objectContaining({
+            name: String.raw`"after all" hook: foo promise`,
+            status: Status.PASSED,
+          }),
+        ],
       }),
       expect.objectContaining({
-        name: "qux",
-        status: Status.SKIPPED,
-        stage: Stage.FINISHED,
-        statusDetails: expect.objectContaining({
-          message: expect.stringContaining("Lorem Ipsum"),
-        }),
+        children: [promiseUuid],
+        afters: [
+          expect.objectContaining({
+            name: String.raw`"after all" hook: bar promise`,
+            status: Status.PASSED,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        children: [syncUuid],
+        afters: [
+          expect.objectContaining({
+            name: String.raw`"after all" hook: foo sync`,
+            status: Status.PASSED,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        children: [syncUuid],
+        afters: [
+          expect.objectContaining({
+            name: String.raw`"after all" hook: bar sync`,
+            status: Status.PASSED,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        children: [callbackUuid],
+        afters: [
+          expect.objectContaining({
+            name: String.raw`"after all" hook: foo callback`,
+            status: Status.PASSED,
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        children: [callbackUuid],
+        afters: [
+          expect.objectContaining({
+            name: String.raw`"after all" hook: bar callback`,
+            status: Status.PASSED,
+          }),
+        ],
       }),
     ]),
   );


### PR DESCRIPTION
### The changes

#### Reporting of failed hooks

If a hook fails, Mocha won't emit the `hook end` event. That caused the corresponding fixture to hang in the state until the process finishes instead of being written on disk.

Now, we're detecting those cases, and issuing the `cypress_hook_end` message in the Mocha's `fail` event if it corresponds to a hook error.

> [!NOTE]
> Spec-level after hooks are handled differently. See below.

#### Reporting of spec-level failed after hooks

In beta 10 we support spec-level `after` hooks by patching the `after` function to introduce two hooks instead of one. The first hook is the original user-defined one, while the second, the Allure-specific one, is responsible for flushing the messages of the original hook to Node.js.

That works just fine until the user-defined hook fails. In that case, Mocha skips its Allure-specific counterpart, which essentially precludes the hook from being reported.

With this PR, the mechanism is changed. Now, instead of inserting extra hooks, we wrap the original hook implementation function. The wrapper calls the original hook implementation, then:

  - if the hook fails, it reports all the messages to complete the spec (remember, we're talking about a spec-level `after` hook; if it fails, other such hooks will be skipped making the failed hook the last piece of user-defined code being executed and the last place capable of calling a Cypress task).
  - if the hook succeeded, it completes the spec only if that was the last spec-level `after` hook in the spec file.

All three types of functions are supported:

  - Synchronous: `after(() => { /* ... */ });`
  - Promise-based: `after(async () => { /* ... */ });`
  - Callback-based:`after((done) => { /* the code must eventually  call done*/ });` 

That technique also works better with `cypress open`. Previously we tried to complete the spec in Mocha's `end` event, which, TBH, never worked in the first place.

With `cypress run` we still rely on Cypress'es `after:spec` event because it allows us to attach the video.

#### Reporting of tests skipped because of a failed hook

If a hook fails, Mocha skips the remaining tests from the suite where the hook has been defined. This PR includes them (except those not in the test plan, if any) in the report with the status that depends on the failed hook type:

  - broken for `before` hooks.
  - skipped for `beforeEach` and `afterEach` hooks.

> [!NOTE]
> There are no skipped tests in case of a failed `after` hook.

Fixes #1072

### Open issues

There is a problem with failed after-fixture visibility. See #1122 for more details.

### Other minor changes

  - Add language specs to examples embedded into JS doc comments
  - Some unused code was removed

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
