### PR TITLE
feat(allure-cypress): impose some limits on step parameter values created from Cypress command arguments

### DIFF
--- a/packages/allure-cypress/README.md
+++ b/packages/allure-cypress/README.md
@@ -71,13 +71,30 @@ Learn more about Allure Cypress from the official documentation at
 
 
 ## Allure Cypress options
-| Option          | Description                                                                                                          | Default            |
-|-----------------|----------------------------------------------------------------------------------------------------------------------|--------------------|
-| resultsDir      | The path of the results folder.                                                                                      | `./allure-results` |
-| videoOnFailOnly | When video capturing is enabled, set this option to `true` to attach the video to failed specs only.                 | `undefined`        |
-| links           | Allure Runtime API link templates.                                                                                   | `undefined`        |
-| environmentInfo | A set of key-value pairs to display in the Environment section of the report                                         | `undefined`        |
-| categories      | An array of category definitions, each describing a [category of defects](https://allurereport.org/docs/categories/) | `undefined`        |
+
+Customize Allure Cypress by providing a configuration object as the third argument
+of `allureCypress`.
+
+The following options are supported:
+
+| Option            | Description                                                                                                          | Default                         |
+|-------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| resultsDir        | The path of the results folder.                                                                                      | `./allure-results`              |
+| videoOnFailOnly   | When video capturing is enabled, set this option to `true` to attach the video to failed specs only.                 | `false`                         |
+| links             | Allure Runtime API link templates.                                                                                   | `undefined`                     |
+| stepsFromCommands | Options that affect how Allure creates steps from Cypress commands                                                   | See [below](#stepsfromcommands) |
+| environmentInfo   | A set of key-value pairs to display in the Environment section of the report                                         | `undefined`                     |
+| categories        | An array of category definitions, each describing a [category of defects](https://allurereport.org/docs/categories/) | `undefined`                     |
+
+### stepsFromCommands
+
+| Property          | Description                                                                                                                                 | Default |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| maxArgumentLength | The maximum length of the parameter value created from Cypress command argument. The rest of the characters are replaces with `...`.        | 128     |
+| maxArgumentDepth  | The maximum depth of the Cypress command argument (an array or an object) that will be converted to the corresponding step parameter value. | 3       |
+
+
+### Example
 
 Here is an example of the Allure Cypress configuration:
 
@@ -99,6 +116,10 @@ export default defineConfig({
             urlTemplate: "https://github.com/allure-framework/allure-js/issues/%s",
             nameTemplate: "ISSUE-%s",
           },
+        },
+        stepsFromCommands: {
+          maxArgumentLength: 64,
+          maxArgumentDepth: 5,
         },
         environmentInfo: {
           OS: os.platform(),
@@ -157,7 +178,39 @@ export default defineConfig({
 });
 ```
 
-## Known limitations
+## Common issues
+
+### The test plan feature doesn't work
+
+Make sure you pass the Cypress config as the second argument of `allureCypress`.
+
+Correct:
+
+```javascript
+allureCypress(on, config);
+```
+
+Also correct:
+
+```javascript
+allureCypress(on, config, {
+  resultsDir: "output",
+});
+```
+
+Incorrect (the test plan won't work):
+
+```javascript
+allureCypress(on);
+```
+
+Also incorrect (the legacy style; the test plan won't work either):
+
+```javascript
+allureCypress(on, {
+  resultsDir: "output",
+});
+```
 
 ### `setupNodeEvents` limitations
 

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -8,10 +8,7 @@ export const ALLURE_REPORT_STEP_COMMAND = "__allure_report_step_command__";
 
 export type AllureCypressConfig = ReporterConfig & {
   videoOnFailOnly?: boolean;
-  stepsFromCommands?: {
-    maxArgumentLength?: number;
-    maxArgumentDepth?: number;
-  };
+  stepsFromCommands?: Partial<AllureSpecState["config"]["stepsFromCommands"]>;
 };
 
 export type CypressSuite = Mocha.Suite & {

--- a/packages/allure-cypress/src/model.ts
+++ b/packages/allure-cypress/src/model.ts
@@ -8,6 +8,10 @@ export const ALLURE_REPORT_STEP_COMMAND = "__allure_report_step_command__";
 
 export type AllureCypressConfig = ReporterConfig & {
   videoOnFailOnly?: boolean;
+  stepsFromCommands?: {
+    maxArgumentLength?: number;
+    maxArgumentDepth?: number;
+  };
 };
 
 export type CypressSuite = Mocha.Suite & {
@@ -174,6 +178,12 @@ export type SpecContext = {
 };
 
 export type AllureSpecState = {
+  config: {
+    stepsFromCommands: {
+      maxArgumentLength: number;
+      maxArgumentDepth: number;
+    };
+  };
   initialized: boolean;
   testPlan: TestPlanV1 | null | undefined;
   messages: CypressMessage[];

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -32,7 +32,7 @@ import type {
   CypressTestStartMessage,
   SpecContext,
 } from "./model.js";
-import { last } from "./utils.js";
+import { defaultRuntimeConfig, last } from "./utils.js";
 
 export class AllureCypress {
   allureRuntime: ReporterRuntime;
@@ -489,19 +489,28 @@ export class AllureCypress {
   };
 }
 
-const getInitialSpecState = (): AllureSpecState => ({
+const createRuntimeState = (allureConfig?: AllureCypressConfig): AllureSpecState => ({
+  config: applyDefaultsToRuntimeConfig(allureConfig),
   initialized: false,
   messages: [],
   testPlan: parseTestPlan(),
 });
 
-/**
- * Explicitly enables the selective run feature.
- * @param config The Cypress configuration.
- */
-export const enableTestPlan = (config: Cypress.PluginConfigOptions) => {
-  config.env.allure = getInitialSpecState();
-  return config;
+const applyDefaultsToRuntimeConfig = ({
+  stepsFromCommands: {
+    maxArgumentLength = defaultRuntimeConfig.stepsFromCommands.maxArgumentLength,
+    maxArgumentDepth = defaultRuntimeConfig.stepsFromCommands.maxArgumentDepth,
+  } = defaultRuntimeConfig.stepsFromCommands,
+}: AllureCypressConfig = defaultRuntimeConfig): AllureSpecState["config"] => ({
+  stepsFromCommands: {
+    maxArgumentDepth,
+    maxArgumentLength,
+  },
+});
+
+const initializeRuntimeState = (cypressConfig: Cypress.PluginConfigOptions, allureConfig?: AllureCypressConfig) => {
+  cypressConfig.env.allure = createRuntimeState(allureConfig);
+  return cypressConfig;
 };
 
 /**
@@ -539,7 +548,7 @@ export const allureCypress = (
   allureCypressReporter.attachToCypress(on);
 
   if (cypressConfig && "env" in cypressConfig) {
-    enableTestPlan(cypressConfig);
+    initializeRuntimeState(cypressConfig, allureConfig);
   }
 
   return allureCypressReporter;

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -32,7 +32,7 @@ import type {
   CypressTestStartMessage,
   SpecContext,
 } from "./model.js";
-import { defaultRuntimeConfig, last } from "./utils.js";
+import { DEFAULT_RUNTIME_CONFIG, last } from "./utils.js";
 
 export class AllureCypress {
   allureRuntime: ReporterRuntime;
@@ -498,10 +498,10 @@ const createRuntimeState = (allureConfig?: AllureCypressConfig): AllureSpecState
 
 const getRuntimeConfigDefaults = ({
   stepsFromCommands: {
-    maxArgumentLength = defaultRuntimeConfig.stepsFromCommands.maxArgumentLength,
-    maxArgumentDepth = defaultRuntimeConfig.stepsFromCommands.maxArgumentDepth,
-  } = defaultRuntimeConfig.stepsFromCommands,
-}: AllureCypressConfig = defaultRuntimeConfig): AllureSpecState["config"] => ({
+    maxArgumentLength = DEFAULT_RUNTIME_CONFIG.stepsFromCommands.maxArgumentLength,
+    maxArgumentDepth = DEFAULT_RUNTIME_CONFIG.stepsFromCommands.maxArgumentDepth,
+  } = DEFAULT_RUNTIME_CONFIG.stepsFromCommands,
+}: AllureCypressConfig = DEFAULT_RUNTIME_CONFIG): AllureSpecState["config"] => ({
   stepsFromCommands: {
     maxArgumentDepth,
     maxArgumentLength,

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -490,13 +490,13 @@ export class AllureCypress {
 }
 
 const createRuntimeState = (allureConfig?: AllureCypressConfig): AllureSpecState => ({
-  config: applyDefaultsToRuntimeConfig(allureConfig),
+  config: getRuntimeConfigDefaults(allureConfig),
   initialized: false,
   messages: [],
   testPlan: parseTestPlan(),
 });
 
-const applyDefaultsToRuntimeConfig = ({
+const getRuntimeConfigDefaults = ({
   stepsFromCommands: {
     maxArgumentLength = defaultRuntimeConfig.stepsFromCommands.maxArgumentLength,
     maxArgumentDepth = defaultRuntimeConfig.stepsFromCommands.maxArgumentDepth,

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -26,6 +26,7 @@ import { ALLURE_REPORT_STEP_COMMAND } from "./model.js";
 import {
   dropCurrentTest,
   enqueueRuntimeMessage,
+  getConfig,
   getCurrentTest,
   getRuntimeMessages,
   setCurrentTest,
@@ -40,6 +41,7 @@ import {
   isTestReported,
   iterateTests,
   markTestAsReported,
+  stringifyCommandArgument,
   uint8ArrayToBase64,
 } from "./utils.js";
 
@@ -361,11 +363,12 @@ export const reportTestSkip = (test: CypressTest) => {
 };
 
 export const reportCommandStart = (command: CypressCommand) => {
+  const { maxArgumentDepth, maxArgumentLength } = getConfig().stepsFromCommands;
   enqueueRuntimeMessage({
     type: "cypress_command_start",
     data: {
       name: `Command "${command.attributes.name}"`,
-      args: command.attributes.args.map((arg) => (typeof arg === "string" ? arg : JSON.stringify(arg, null, 2))),
+      args: command.attributes.args.map((arg) => stringifyCommandArgument(arg, maxArgumentLength, maxArgumentDepth)),
       start: Date.now(),
     },
   });

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -363,7 +363,9 @@ export const reportTestSkip = (test: CypressTest) => {
 };
 
 export const reportCommandStart = (command: CypressCommand) => {
-  const { maxArgumentDepth, maxArgumentLength } = getConfig().stepsFromCommands;
+  const {
+    stepsFromCommands: { maxArgumentDepth, maxArgumentLength },
+  } = getConfig();
   enqueueRuntimeMessage({
     type: "cypress_command_start",
     data: {

--- a/packages/allure-cypress/src/runtime.ts
+++ b/packages/allure-cypress/src/runtime.ts
@@ -5,6 +5,7 @@ import {
   getStatusFromError,
   getUnfinishedStepsMessages,
   isPromise,
+  serialize,
 } from "allure-js-commons/sdk";
 import type { RuntimeMessage } from "allure-js-commons/sdk";
 import { getGlobalTestRuntime, setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
@@ -41,7 +42,6 @@ import {
   isTestReported,
   iterateTests,
   markTestAsReported,
-  stringifyCommandArgument,
   uint8ArrayToBase64,
 } from "./utils.js";
 
@@ -368,7 +368,9 @@ export const reportCommandStart = (command: CypressCommand) => {
     type: "cypress_command_start",
     data: {
       name: `Command "${command.attributes.name}"`,
-      args: command.attributes.args.map((arg) => stringifyCommandArgument(arg, maxArgumentLength, maxArgumentDepth)),
+      args: command.attributes.args.map((arg) =>
+        serialize(arg, { maxDepth: maxArgumentDepth, maxLength: maxArgumentLength }),
+      ),
       start: Date.now(),
     },
   });

--- a/packages/allure-cypress/src/state.ts
+++ b/packages/allure-cypress/src/state.ts
@@ -1,11 +1,11 @@
 import type { AllureSpecState, CypressMessage, CypressTest } from "./model.js";
-import { defaultRuntimeConfig } from "./utils.js";
+import { DEFAULT_RUNTIME_CONFIG } from "./utils.js";
 
 export const getAllureState = () => {
   let state = Cypress.env("allure") as AllureSpecState;
   if (!state) {
     state = {
-      config: defaultRuntimeConfig,
+      config: DEFAULT_RUNTIME_CONFIG,
       initialized: false,
       messages: [],
       testPlan: undefined,

--- a/packages/allure-cypress/src/state.ts
+++ b/packages/allure-cypress/src/state.ts
@@ -1,9 +1,11 @@
 import type { AllureSpecState, CypressMessage, CypressTest } from "./model.js";
+import { defaultRuntimeConfig } from "./utils.js";
 
 export const getAllureState = () => {
   let state = Cypress.env("allure") as AllureSpecState;
   if (!state) {
     state = {
+      config: defaultRuntimeConfig,
       initialized: false,
       messages: [],
       testPlan: undefined,
@@ -41,3 +43,5 @@ export const setCurrentTest = (test: CypressTest) => {
 export const dropCurrentTest = () => {
   getAllureState().currentTest = undefined;
 };
+
+export const getConfig = () => getAllureState().config;

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -5,6 +5,13 @@ import { ALLURE_REPORT_STEP_COMMAND, ALLURE_REPORT_SYSTEM_HOOK } from "./model.j
 import type { CypressCommand, CypressHook, CypressSuite, CypressTest } from "./model.js";
 import { getAllureTestPlan } from "./state.js";
 
+export const defaultRuntimeConfig = {
+  stepsFromCommands: {
+    maxArgumentLength: 128,
+    maxArgumentDepth: 3,
+  },
+};
+
 export const uint8ArrayToBase64 = (data: unknown) => {
   // @ts-ignore
   const u8arrayLike = Array.isArray(data) || data.buffer;
@@ -159,3 +166,33 @@ const removeSortedIndices = <T>(arr: T[], indices: readonly number[]) => {
     arr.splice(indices[i], 1);
   }
 };
+
+export const stringifyCommandArgument = (value: any, maxLength: number, maxDepth: number) => {
+  if (typeof value === "string") {
+    return limitString(value, maxLength);
+  }
+
+  const parents: object[] = [];
+  const circularReferenceRemover = function (this: object, _: string, v: unknown) {
+    if (typeof v !== "object" || v === null) {
+      return v;
+    }
+
+    while (parents.length > 0 && !Object.is(parents.at(-1), this)) {
+      parents.pop();
+    }
+
+    if (parents.length >= maxDepth + 1 || parents.includes(v)) {
+      return undefined;
+    }
+
+    parents.push(v);
+    return v;
+  };
+
+  const argumentText = JSON.stringify(value, circularReferenceRemover);
+  return limitString(argumentText, maxLength);
+};
+
+const limitString = (value: string, maxLength: number) =>
+  value.length <= maxLength ? value : `${value.substring(0, maxLength)}...`;

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -5,7 +5,7 @@ import { ALLURE_REPORT_STEP_COMMAND, ALLURE_REPORT_SYSTEM_HOOK } from "./model.j
 import type { CypressCommand, CypressHook, CypressSuite, CypressTest } from "./model.js";
 import { getAllureTestPlan } from "./state.js";
 
-export const defaultRuntimeConfig = {
+export const DEFAULT_RUNTIME_CONFIG = {
   stepsFromCommands: {
     maxArgumentLength: 128,
     maxArgumentDepth: 3,

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -166,33 +166,3 @@ const removeSortedIndices = <T>(arr: T[], indices: readonly number[]) => {
     arr.splice(indices[i], 1);
   }
 };
-
-export const stringifyCommandArgument = (value: any, maxLength: number, maxDepth: number) => {
-  if (typeof value === "string") {
-    return limitString(value, maxLength);
-  }
-
-  const parents: object[] = [];
-  const circularReferenceRemover = function (this: object, _: string, v: unknown) {
-    if (typeof v !== "object" || v === null) {
-      return v;
-    }
-
-    while (parents.length > 0 && !Object.is(parents.at(-1), this)) {
-      parents.pop();
-    }
-
-    if (parents.length >= maxDepth + 1 || parents.includes(v)) {
-      return undefined;
-    }
-
-    parents.push(v);
-    return v;
-  };
-
-  const argumentText = JSON.stringify(value, circularReferenceRemover);
-  return limitString(argumentText, maxLength);
-};
-
-const limitString = (value: string, maxLength: number) =>
-  value.length <= maxLength ? value : `${value.substring(0, maxLength)}...`;

--- a/packages/allure-cypress/test/spec/commands.test.ts
+++ b/packages/allure-cypress/test/spec/commands.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { Stage, Status } from "allure-js-commons";
+import { issue } from "allure-js-commons";
 import { runCypressInlineTest } from "../utils.js";
 
 it("reports test with cypress command", async () => {
@@ -25,7 +26,7 @@ it("reports test with cypress command", async () => {
         parameters: expect.arrayContaining([
           expect.objectContaining({
             name: String.raw`Argument [0]`,
-            value: JSON.stringify(1, null, 2),
+            value: JSON.stringify(1),
           }),
         ]),
       }),
@@ -43,7 +44,7 @@ it("reports test with cypress command", async () => {
         parameters: expect.arrayContaining([
           expect.objectContaining({
             name: String.raw`Argument [0]`,
-            value: JSON.stringify([1, 2, 3], null, 2),
+            value: JSON.stringify([1, 2, 3]),
           }),
         ]),
       }),
@@ -52,7 +53,7 @@ it("reports test with cypress command", async () => {
         parameters: expect.arrayContaining([
           expect.objectContaining({
             name: String.raw`Argument [0]`,
-            value: JSON.stringify({ foo: 1, bar: 2, baz: 3 }, null, 2),
+            value: JSON.stringify({ foo: 1, bar: 2, baz: 3 }),
           }),
         ]),
       }),
@@ -76,4 +77,147 @@ it("doesn't report cypress command when they shouldn't be reported", async () =>
   expect(tests[0].status).toBe(Status.PASSED);
   expect(tests[0].stage).toBe(Stage.FINISHED);
   expect(tests[0].steps).toHaveLength(0);
+});
+
+it("should impose limits on command arguments", async () => {
+  issue("1070");
+  const { tests } = await runCypressInlineTest({
+    "cypress/e2e/sample.cy.js": () => `
+      it("foo", () => {
+        const obj1 = {};
+        obj1.ref = obj1; // should remove a direct circular reference 'ref'
+        cy.wrap(obj1);
+
+        const sibling = {};
+        cy.wrap({ ref: { foo: sibling, bar: sibling } }); // it's okay to have the same object on different paths
+
+        const obj2 = { ref: {} };
+        obj2.ref.ref = obj2;
+        cy.wrap(obj2); // should remove an indirect circular reference 'ref.ref'
+
+        cy.wrap("A".repeat(1000)); // should truncate string values
+        cy.wrap(Array(1000).fill("A")); // should truncate objects
+        cy.wrap({ foo: { bar: { baz: { qux: {}, qut: 10 } } } }) // should remove 'qux' at nesting level 4 but keep 'qut'
+      });
+    `,
+  });
+
+  expect(tests).toEqual([
+    expect.objectContaining({
+      steps: [
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: JSON.stringify({}),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: JSON.stringify({ ref: { foo: {}, bar: {} } }),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: JSON.stringify({ ref: {} }),
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: `${"A".repeat(128)}...`,
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: `[${String.raw`"A",`.repeat(31)}"A"...`,
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: JSON.stringify({ foo: { bar: { baz: { qut: 10 } } } }),
+            },
+          ],
+        }),
+      ],
+    }),
+  ]);
+});
+
+it("should take the limits from the config", async () => {
+  issue("1070");
+  const { tests } = await runCypressInlineTest({
+    "cypress/e2e/sample.cy.js": () => `
+      it("foo", () => {
+        cy.wrap("A".repeat(100)); // should truncate string values
+        cy.wrap(Array(100).fill("A")); // should truncate objects
+        cy.wrap({ foo: { bar: { }, baz: "qux" } }) // should remove 'bar' at nesting level 2 but keep 'baz'
+      });
+    `,
+    "cypress.config.js": ({ allureCypressModuleBasePath }) => `
+      const { allureCypress } = require("${allureCypressModuleBasePath}/reporter.js");
+
+      module.exports = {
+        e2e: {
+          baseUrl: "https://allurereport.org",
+          viewportWidth: 1240,
+          setupNodeEvents: (on, config) => {
+            allureCypress(on, config, {
+              stepsFromCommands: {
+                maxArgumentLength: 25,
+                maxArgumentDepth: 1,
+              }
+            });
+
+            return config;
+          },
+        },
+      };
+    `,
+  });
+
+  expect(tests).toEqual([
+    expect.objectContaining({
+      steps: [
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: `${"A".repeat(25)}...`,
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: `[${String.raw`"A",`.repeat(6)}...`,
+            },
+          ],
+        }),
+        expect.objectContaining({
+          parameters: [
+            {
+              name: "Argument [0]",
+              value: JSON.stringify({ foo: { baz: "qux" } }),
+            },
+          ],
+        }),
+      ],
+    }),
+  ]);
 });

--- a/packages/allure-cypress/test/spec/commands.test.ts
+++ b/packages/allure-cypress/test/spec/commands.test.ts
@@ -97,7 +97,7 @@ it("should impose limits on command arguments", async () => {
 
         cy.wrap("A".repeat(1000)); // should truncate string values
         cy.wrap(Array(1000).fill("A")); // should truncate objects
-        cy.wrap({ foo: { bar: { baz: { qux: {}, qut: 10 } } } }) // should remove 'qux' at nesting level 4 but keep 'qut'
+        cy.wrap({ foo: { bar: { baz: {}, qux: "qut" } } }) // should remove 'baz' because it creates nesting level 4
       });
     `,
   });
@@ -149,7 +149,7 @@ it("should impose limits on command arguments", async () => {
           parameters: [
             {
               name: "Argument [0]",
-              value: JSON.stringify({ foo: { bar: { baz: { qut: 10 } } } }),
+              value: JSON.stringify({ foo: { bar: { qux: "qut" } } }),
             },
           ],
         }),
@@ -165,7 +165,7 @@ it("should take the limits from the config", async () => {
       it("foo", () => {
         cy.wrap("A".repeat(100)); // should truncate string values
         cy.wrap(Array(100).fill("A")); // should truncate objects
-        cy.wrap({ foo: { bar: { }, baz: "qux" } }) // should remove 'bar' at nesting level 2 but keep 'baz'
+        cy.wrap({ foo: { bar: { }, baz: "qux" } }) // should remove 'bar' that creates nesting level 3 but keep 'baz'
       });
     `,
     "cypress.config.js": ({ allureCypressModuleBasePath }) => `
@@ -179,7 +179,7 @@ it("should take the limits from the config", async () => {
             allureCypress(on, config, {
               stepsFromCommands: {
                 maxArgumentLength: 25,
-                maxArgumentDepth: 1,
+                maxArgumentDepth: 2,
               }
             });
 

--- a/packages/allure-js-commons/src/sdk/index.ts
+++ b/packages/allure-js-commons/src/sdk/index.ts
@@ -25,4 +25,5 @@ export {
   isPromise,
   hasLabel,
   stripAnsi,
+  serialize,
 } from "./utils.js";

--- a/packages/allure-js-commons/src/sdk/reporter/utils.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/utils.ts
@@ -137,18 +137,6 @@ export const getRelativePath = (filepath: string) => {
 
 export const deepClone = <T>(obj: T): T => JSON.parse(JSON.stringify(obj));
 
-export const serialize = (val: unknown): string => {
-  if (typeof val === "object" && !(val instanceof Map || val instanceof Set)) {
-    return JSON.stringify(val);
-  }
-
-  if (val === undefined) {
-    return "undefined";
-  }
-
-  return (val as any).toString();
-};
-
 export const getSuiteLabels = (suites: readonly string[]): Label[] => {
   if (suites.length === 0) {
     return [];

--- a/packages/allure-js-commons/src/sdk/types.ts
+++ b/packages/allure-js-commons/src/sdk/types.ts
@@ -110,3 +110,8 @@ export interface AllureResults {
   envInfo?: EnvironmentInfo;
   categories?: Category[];
 }
+
+export type SerializeOptions = {
+  maxDepth?: number;
+  maxLength?: number;
+};

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -141,3 +141,15 @@ export const getUnfinishedStepsMessages = (messages: RuntimeMessage[]) => {
 
 export const isPromise = <T = any>(obj: any): obj is PromiseLike<T> =>
   !!obj && (typeof obj === "object" || typeof obj === "function") && typeof obj.then === "function";
+
+export const serialize = (val: unknown): string => {
+  if (typeof val === "object" && !(val instanceof Map || val instanceof Set)) {
+    return JSON.stringify(val);
+  }
+
+  if (val === undefined) {
+    return "undefined";
+  }
+
+  return (val as any).toString();
+};

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -143,7 +143,10 @@ export const isPromise = <T = any>(obj: any): obj is PromiseLike<T> =>
   !!obj && (typeof obj === "object" || typeof obj === "function") && typeof obj.then === "function";
 
 export const serialize = (val: unknown): string => {
-  if (typeof val === "object" && !(val instanceof Map || val instanceof Set)) {
+  if (typeof val === "object") {
+    if (val instanceof Map || val instanceof Set) {
+      val = Array.from(val);
+    }
     return JSON.stringify(val);
   }
 

--- a/packages/allure-js-commons/test/sdk/reporter/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/utils.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { LabelName } from "../../../src/model.js";
-import { getSuiteLabels, serialize } from "../../../src/sdk/reporter/utils.js";
+import { getSuiteLabels } from "../../../src/sdk/reporter/utils.js";
 
 describe("getSuiteLabels", () => {
   describe("with empty suites", () => {
@@ -51,61 +51,6 @@ describe("getSuiteLabels", () => {
           value: "baz > beep > boop",
         },
       ]);
-    });
-  });
-});
-
-describe("serialize", () => {
-  describe("with object", () => {
-    it("returns JSON string", () => {
-      // eslint-disable-next-line @stylistic/quotes
-      expect(serialize({ foo: "bar" })).toBe('{"foo":"bar"}');
-    });
-  });
-
-  describe("with array", () => {
-    it("returns JSON string", () => {
-      // eslint-disable-next-line @stylistic/quotes
-      expect(serialize(["foo", "bar"])).toBe('["foo","bar"]');
-    });
-  });
-
-  describe("with map", () => {
-    it("returns JSON string", () => {
-      expect(serialize(new Map([["foo", "bar"]]))).toBe("[object Map]");
-    });
-  });
-
-  describe("with set", () => {
-    it("returns JSON string", () => {
-      expect(serialize(new Set(["foo", "bar"]))).toBe("[object Set]");
-    });
-  });
-
-  describe("with undefined", () => {
-    it("returns undefined string", () => {
-      expect(serialize(undefined)).toBe("undefined");
-    });
-  });
-
-  describe("with null", () => {
-    it("returns null string", () => {
-      expect(serialize(null)).toBe("null");
-    });
-  });
-
-  describe("with function", () => {
-    it("returns function string", () => {
-      expect(serialize(() => {})).toBe("() => {\n      }");
-    });
-  });
-
-  describe("with primitives", () => {
-    it("returns stringified value", () => {
-      // eslint-disable-next-line @stylistic/quotes
-      expect(serialize("foo")).toBe("foo");
-      expect(serialize(123)).toBe("123");
-      expect(serialize(true)).toBe("true");
     });
   });
 });

--- a/packages/allure-js-commons/test/sdk/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/utils.spec.ts
@@ -269,56 +269,87 @@ describe("isMetadataTag", () => {
 });
 
 describe("serialize", () => {
-  describe("with object", () => {
-    it("returns JSON string", () => {
-      // eslint-disable-next-line @stylistic/quotes
-      expect(serialize({ foo: "bar" })).toBe('{"foo":"bar"}');
+  describe("called with a primitive", () => {
+    describe("undefined", () => {
+      it("should return the 'undefined' constant", () => {
+        expect(serialize(undefined)).toBe("undefined");
+      });
+    });
+
+    describe("null", () => {
+      it("should return the 'null' constant", () => {
+        expect(serialize(null)).toBe("null");
+      });
+    });
+
+    describe("symbol", () => {
+      it("should return the same value as .toString()", () => {
+        const symbol = Symbol("foo");
+        expect(serialize(symbol)).toBe(symbol.toString());
+      });
+    });
+
+    describe("number", () => {
+      it("should return the text of the number", () => {
+        expect(serialize(1)).toBe("1");
+        expect(serialize(1.5)).toBe("1.5");
+      });
+    });
+
+    describe("bigint", () => {
+      it("should return the text of the bit int", () => {
+        expect(serialize(BigInt(1000000000000000) * BigInt(1000000000000000))).toBe("1000000000000000000000000000000");
+      });
+    });
+
+    describe("boolean", () => {
+      it("should return the 'true' or 'false' constant", () => {
+        expect(serialize(true)).toBe("true");
+        expect(serialize(false)).toBe("false");
+      });
+    });
+
+    describe("string", () => {
+      it("should return the string itself", () => {
+        expect(serialize("")).toBe("");
+        expect(serialize("foo")).toBe("foo");
+      });
     });
   });
 
-  describe("with array", () => {
-    it("returns JSON string", () => {
-      // eslint-disable-next-line @stylistic/quotes
-      expect(serialize(["foo", "bar"])).toBe('["foo","bar"]');
+  describe("called with an object", () => {
+    it("should return the same serialized object as JSON.stringify", () => {
+      expect(serialize({})).toBe(JSON.stringify({}));
+      expect(serialize({ foo: "bar" })).toBe(JSON.stringify({ foo: "bar" }));
+      expect(serialize({ foo: "bar", baz: "qux" })).toBe(JSON.stringify({ foo: "bar", baz: "qux" }));
+      expect(serialize({ foo: {bar: "qux"} })).toBe(JSON.stringify({ foo: {bar: "qux"} }));
     });
-  });
 
-  describe("with map", () => {
-    it("returns JSON string", () => {
-      expect(serialize(new Map([["foo", "bar"]]))).toBe("[object Map]");
+    describe("of type Array", () => {
+      it("should return the same serialized array as JSON.stringify", () => {
+        expect(serialize([])).toBe(JSON.stringify([]));
+        expect(serialize([1])).toBe(JSON.stringify([1]));
+        expect(serialize([1, "foo"])).toBe(JSON.stringify([1, "foo"]));
+        expect(serialize([1, "foo", [2, {bar: "baz"}]])).toBe(JSON.stringify([1, "foo", [2, {bar: "baz"}]]));
+      });
     });
-  });
 
-  describe("with set", () => {
-    it("returns JSON string", () => {
-      expect(serialize(new Set(["foo", "bar"]))).toBe("[object Set]");
+    describe("of type Map", () => {
+      it("should return array of the key-value pairs", () => {
+        expect(serialize(new Map())).toBe("[]");
+        expect(serialize(new Map([]))).toBe("[]");
+        expect(serialize(new Map([["foo", "bar"]]))).toBe(String.raw`[["foo","bar"]]`);
+        expect(serialize(new Map([[1, "foo"], [2, "bar"]]))).toBe(String.raw`[[1,"foo"],[2,"bar"]]`);
+      });
     });
-  });
 
-  describe("with undefined", () => {
-    it("returns undefined string", () => {
-      expect(serialize(undefined)).toBe("undefined");
-    });
-  });
-
-  describe("with null", () => {
-    it("returns null string", () => {
-      expect(serialize(null)).toBe("null");
-    });
-  });
-
-  describe("with function", () => {
-    it("returns function string", () => {
-      expect(serialize(() => {})).toBe("() => {\n      }");
-    });
-  });
-
-  describe("with primitives", () => {
-    it("returns stringified value", () => {
-      // eslint-disable-next-line @stylistic/quotes
-      expect(serialize("foo")).toBe("foo");
-      expect(serialize(123)).toBe("123");
-      expect(serialize(true)).toBe("true");
+    describe("of type Set", () => {
+      it("should return array of the set elements", () => {
+        expect(serialize(new Set())).toBe("[]");
+        expect(serialize(new Set([]))).toBe("[]");
+        expect(serialize(new Set([1]))).toBe("[1]");
+        expect(serialize(new Set([1, "foo", 2]))).toBe(String.raw`[1,"foo",2]`);
+      });
     });
   });
 });

--- a/packages/allure-js-commons/test/sdk/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/utils.spec.ts
@@ -355,6 +355,14 @@ describe("serialize", () => {
       const obj6: any = [1, "Lorem", ["Ipsum"]];
       obj6[2].push(obj6);
       expect(serialize(obj6)).toBe(JSON.stringify([1, "Lorem", ["Ipsum", null]]));
+
+      const obj7: Map<number, any> = new Map();
+      obj7.set(1, obj7);
+      expect(serialize(obj7)).toBe(JSON.stringify([[1, null]]));
+
+      const obj8: Set<any> = new Set();
+      obj8.add(obj8);
+      expect(serialize(obj8)).toBe(JSON.stringify([null]));
     });
 
     it("should limit the maximum size of the serialized object", () => {
@@ -371,6 +379,26 @@ describe("serialize", () => {
             // only primitives are included
             qux: 2,
           },
+        }),
+      );
+    });
+
+    it("should replace nested maps and sets with arrays", () => {
+      expect(
+        serialize({
+          foo: new Map([
+            [1, "a"],
+            [2, "b"],
+          ]),
+          bar: new Set([1, 2]),
+        }),
+      ).toBe(
+        JSON.stringify({
+          foo: [
+            [1, "a"],
+            [2, "b"],
+          ],
+          bar: [1, 2],
         }),
       );
     });

--- a/packages/allure-js-commons/test/sdk/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   getStatusFromError,
   isAnyStepFailed,
   isMetadataTag,
+  serialize,
 } from "../../src/sdk/utils.js";
 
 type Executable = StepResult | TestResult | FixtureResult;
@@ -264,5 +265,60 @@ describe("isMetadataTag", () => {
   });
   it("should match @allure.label tag", () => {
     expect(isMetadataTag("@allure.label.x=y")).toBeTruthy();
+  });
+});
+
+describe("serialize", () => {
+  describe("with object", () => {
+    it("returns JSON string", () => {
+      // eslint-disable-next-line @stylistic/quotes
+      expect(serialize({ foo: "bar" })).toBe('{"foo":"bar"}');
+    });
+  });
+
+  describe("with array", () => {
+    it("returns JSON string", () => {
+      // eslint-disable-next-line @stylistic/quotes
+      expect(serialize(["foo", "bar"])).toBe('["foo","bar"]');
+    });
+  });
+
+  describe("with map", () => {
+    it("returns JSON string", () => {
+      expect(serialize(new Map([["foo", "bar"]]))).toBe("[object Map]");
+    });
+  });
+
+  describe("with set", () => {
+    it("returns JSON string", () => {
+      expect(serialize(new Set(["foo", "bar"]))).toBe("[object Set]");
+    });
+  });
+
+  describe("with undefined", () => {
+    it("returns undefined string", () => {
+      expect(serialize(undefined)).toBe("undefined");
+    });
+  });
+
+  describe("with null", () => {
+    it("returns null string", () => {
+      expect(serialize(null)).toBe("null");
+    });
+  });
+
+  describe("with function", () => {
+    it("returns function string", () => {
+      expect(serialize(() => {})).toBe("() => {\n      }");
+    });
+  });
+
+  describe("with primitives", () => {
+    it("returns stringified value", () => {
+      // eslint-disable-next-line @stylistic/quotes
+      expect(serialize("foo")).toBe("foo");
+      expect(serialize(123)).toBe("123");
+      expect(serialize(true)).toBe("true");
+    });
   });
 });

--- a/packages/allure-mocha/src/legacy.ts
+++ b/packages/allure-mocha/src/legacy.ts
@@ -3,7 +3,7 @@ import type { ContentType, ParameterOptions } from "allure-js-commons";
 import { Status } from "allure-js-commons";
 import type { Category } from "allure-js-commons/sdk";
 import { getStatusFromError, isPromise } from "allure-js-commons/sdk";
-import { serialize } from "allure-js-commons/sdk/reporter";
+import { serialize } from "allure-js-commons/sdk";
 import { getLegacyApiRuntime } from "./legacyUtils.js";
 
 interface StepInterface {


### PR DESCRIPTION
### Context

Allure Cypress converts Cypress commands to Allure steps. Command argument values are converted to Allure step parameter values:

  - strings are left unmodified,
  - values of other types are converted with `JSON.stringify(value, null, 2)`.

The drawbacks:

  - A `TypeError: Converting circular structure to JSON` is thrown if the value is an object with circular references. This is often the case when using Cypress commands with complex UI objects like Vue components, etc. See some examples in issue #1070.
  - Complex objects and long strings/arrays can easily blow the report to ridiculous sizes

### `serialize` enhancements

We have an existing function `serialize` defined in `allure-js-commons/sdk/reporter/utils`, which behaves similarly to what Allure Cypress does with Cypress step arguments. This PR:

1. Moves it to `allure-js-commons/sdk/utils` to make it usable from environments other than Node.js.
2. Adds an optional argument, which, if given, must be an object with two optional properties: `maxDepth`, `maxLength`. The value of each property must be an integer number greater than or equal to 0 (which is the default). The value of zero means the property doesn't affect `serialize`.
3. Implements the following constraints imposed on the result of `serialize`:
      - If `maxDepth` is given and is greater than 0, properties that create nesting levels beyond that limit are precluded from serialization.
      - If `maxLength` is given and is greater than 0, and if the length of the resulting string is greater than that value, the remaining part of the string is replaced with `"..."`.

#### Examples

```javascript
const obj = {
  foo: {
    bar: {
      baz: ["Lorem", "Ipsum"],
      qux: "Dolor",
    },
  },
  bar: {},
};
const obj1 = {};
obj1.ref = obj1;
serialize(obj1); // returns "{}"

const obj2 = {
  // this is nesting level 1
  foo: {
    // this is nesting level 2
    bar: {
      // this is nesting level 3
      /* ... */ 
    },
    baz: "Lorem ipsum",
  },
};
serialize(obj2, { maxDepth: 2 }); // returns '{"foo":{"bar":"Lorem ipsum"}}'

serialize({ foo: "Lorem ipsum" }, { maxLength: 10 }); // returns '{"foo":"Lo...'
```

allure-cypress now uses `serialize` to convert Cypress command arguments to strings.

### Configuration changes

The PR introduces two new configuration properties `maxArgumentLength` and `maxArgumentDepth` to customize the abovementioned limits for allure-cypress. The properties are grouped under the `stepsFromCommands` option:

```javascript
import { defineConfig } from "cypress";
import { allureCypress } from "allure-cypress/reporter";

export default defineConfig({
  e2e: {
    setupNodeEvents: (on, config) => {
      allureCypress(on, config, {
        stepsFromCommands: {
          maxArgumentLength: 64,
          maxArgumentDepth: 5,
        },
      });

      return config;
    },
    // other Cypress options
  },
});
```

The default values are 128 (for `maxArgumentLength`) and 3 (for `maxArgumentDepth`).

Fixes #1070

### Other minor changes

  - improve maps and sets support by `serialize`: now they may nest in other objects and contain circular references, which are properly removed upon serialization. The values are serialized as arrays instead of the `"[object Map]"` and `"[object Set]"` literals.
  - document why the test plan feature may not work (because of the missing 2nd argument of `allureCypress`)

### Potential future changes

  - We may use the new `serialize` implementation to take objects of any types in `attachment` (currently, only strings and buffers are allowed);
  - May include an extra flag (e.g., `disabled`) into the `stepsFromCommands` object of the Allure Cypress config to preclude Cypress steps from getting into Allure Report (see allure-framework/allure2#2712).

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
