### PR TITLE
feat(mocha): add support for extra reporters

### DIFF
--- a/packages/allure-mocha/src/extraReporters.ts
+++ b/packages/allure-mocha/src/extraReporters.ts
@@ -1,0 +1,150 @@
+import * as Mocha from "mocha";
+import path from "node:path";
+import type { ReporterDoneFn, ReporterEntry, ReporterModuleOrCtor, ReporterOptions } from "./types.js";
+
+type CanonicalReporterEntry = readonly [ReporterModuleOrCtor, ReporterOptions];
+type ShortReporterEntry = readonly [ReporterModuleOrCtor];
+type LoadedReporterEntry = readonly [Mocha.ReporterConstructor, ReporterOptions];
+
+export const enableExtraReporters = (
+  runner: Mocha.Runner,
+  options: Mocha.MochaOptions,
+  extraReportersConfig: ReporterEntry | readonly ReporterEntry[],
+) => {
+  const extraReporterEntries = Array.from(generateCanonicalizedReporterEntries(extraReportersConfig));
+  const loadedReporterEntries = loadReporters(extraReporterEntries);
+  return instantiateReporters(runner, options, loadedReporterEntries);
+};
+
+export const doneAll = (
+  reporters: readonly Mocha.reporters.Base[],
+  failures: number,
+  fn?: ((failures: number) => void) | undefined,
+) => {
+  const doneCallbacks = collectDoneCallbacks(reporters);
+  let callbacksToWait = doneCallbacks.length + 1;
+  const onReporterIsDone = () => {
+    if (--callbacksToWait === 0) {
+      fn?.(failures);
+    }
+  };
+
+  for (const done of doneCallbacks) {
+    done(failures, onReporterIsDone);
+  }
+
+  onReporterIsDone(); // handle the synchronous completion
+};
+
+const generateCanonicalizedReporterEntries = function* (
+  reporters: ReporterEntry | readonly ReporterEntry[] | undefined,
+): Generator<CanonicalReporterEntry, void, undefined> {
+  if (reporters) {
+    if (!(reporters instanceof Array)) {
+      yield [reporters, {}];
+    } else {
+      if (isReporterArrayEntry(reporters)) {
+        yield resolveReporterArrayEntry(reporters);
+      } else {
+        yield* reporters.map((e) => {
+          return resolveReporterEntry(e);
+        });
+      }
+    }
+  }
+};
+
+const loadReporters = (reporterEntries: readonly CanonicalReporterEntry[]): LoadedReporterEntry[] =>
+  reporterEntries.map(([moduleOrCtor, options]) => [loadReporterModule(moduleOrCtor), options]);
+
+const instantiateReporters = (
+  runner: Mocha.Runner,
+  options: Mocha.MochaOptions,
+  entries: readonly LoadedReporterEntry[],
+) => {
+  const reporters: Mocha.reporters.Base[] = [];
+  for (const [Reporter, reporterOptions] of entries) {
+    const optionsForReporter = {
+      ...options,
+      reporterOptions,
+      // eslint-disable-next-line quote-props
+      reporterOption: reporterOptions,
+      "reporter-option": reporterOptions,
+    };
+    reporters.push(new Reporter(runner, optionsForReporter));
+  }
+  return reporters;
+};
+
+const collectDoneCallbacks = (reporters: readonly Mocha.reporters.Base[]) => {
+  const doneCallbacks: ReporterDoneFn[] = [];
+  for (const reporter of reporters) {
+    if (reporter.done) {
+      doneCallbacks.push(reporter.done.bind(reporter));
+    }
+  }
+  return doneCallbacks;
+};
+
+const isReporterArrayEntry = (
+  reporters: ShortReporterEntry | CanonicalReporterEntry | readonly ReporterEntry[],
+): reporters is ShortReporterEntry | CanonicalReporterEntry => {
+  const [maybeReporterModuleOrCtor, maybeReporterOptions = {}] = reporters;
+  return (
+    !(maybeReporterModuleOrCtor instanceof Array) &&
+    typeof maybeReporterOptions === "object" &&
+    !(maybeReporterOptions instanceof Array)
+  );
+};
+
+const loadReporterModule = (moduleOrCtor: ReporterModuleOrCtor) => {
+  if (typeof moduleOrCtor === "string") {
+    const builtInReporters = Mocha.reporters as Record<string, Mocha.ReporterConstructor>;
+    const builtInReporterCtor = builtInReporters[moduleOrCtor];
+    if (builtInReporterCtor) {
+      return builtInReporterCtor;
+    }
+
+    const reporterModulePath = getReporterModulePath(moduleOrCtor);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+      return require(reporterModulePath) as Mocha.ReporterConstructor;
+    } catch (e: any) {
+      throw new Error(`Can't load the '${moduleOrCtor}' reporter from ${reporterModulePath}: ${e.message}`);
+    }
+  }
+
+  if (typeof moduleOrCtor !== "function") {
+    throw new Error(`A reporter value must be a string or a constructor. Got ${typeof moduleOrCtor}`);
+  }
+
+  return moduleOrCtor;
+};
+
+const getReporterModulePath = (module: string) => {
+  try {
+    return require.resolve(module);
+  } catch (e) {}
+
+  try {
+    return path.resolve(module);
+  } catch (e: any) {
+    throw new Error(`Can't resolve the '${module}' reporter's path: ${e.message}`);
+  }
+};
+
+const resolveReporterEntry = (reporterEntry: ReporterEntry): CanonicalReporterEntry => {
+  return reporterEntry instanceof Array ? resolveReporterArrayEntry(reporterEntry) : [reporterEntry, {}];
+};
+
+const resolveReporterArrayEntry = (
+  reporterEntry: ShortReporterEntry | CanonicalReporterEntry,
+): CanonicalReporterEntry => {
+  if (reporterEntry.length < 1 || reporterEntry.length > 2) {
+    throw new Error(
+      `If an extra reporter entry is an array, it must contain one or two elements. ${reporterEntry.length} found`,
+    );
+  }
+
+  return reporterEntry.length === 1 ? [...reporterEntry, {}] : [...reporterEntry];
+};

--- a/packages/allure-mocha/src/types.ts
+++ b/packages/allure-mocha/src/types.ts
@@ -1,4 +1,6 @@
+import type { ReporterConstructor } from "mocha";
 import type { Label } from "allure-js-commons";
+import type { ReporterConfig } from "allure-js-commons/sdk/reporter";
 
 export type TestPlanIndices = {
   fullNameIndex: ReadonlySet<string>;
@@ -18,3 +20,15 @@ export type HookCategory = "before" | "after";
 export type HookScope = "all" | "each";
 
 export type HookType = [category?: HookCategory, scope?: HookScope];
+
+export type AllureMochaReporterConfig = ReporterConfig & {
+  extraReporters?: ReporterEntry | ReporterEntry[];
+};
+
+export type ReporterModuleOrCtor = ReporterConstructor | string;
+
+export type ReporterOptions = Record<string, any>;
+
+export type ReporterEntry = ReporterModuleOrCtor | [ReporterModuleOrCtor] | [ReporterModuleOrCtor, ReporterOptions];
+
+export type ReporterDoneFn = (failures: number, fn?: ((failures: number) => void) | undefined) => void;

--- a/packages/allure-mocha/test/samples/customReporter.cjs
+++ b/packages/allure-mocha/test/samples/customReporter.cjs
@@ -1,0 +1,13 @@
+const Mocha = require("mocha");
+
+class CustomReporter extends Mocha.reporters.Base {
+  constructor(runner, opts) {
+    super(runner, opts);
+    runner.on("start", () => {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(opts.reporterOptions));
+    });
+  }
+}
+
+module.exports = CustomReporter;

--- a/packages/allure-mocha/test/samples/reporter.cjs
+++ b/packages/allure-mocha/test/samples/reporter.cjs
@@ -6,7 +6,7 @@ class ProcessMessageAllureReporter extends AllureMochaReporter {
     if (opts.reporterOptions?.emitFiles !== "true") {
       (opts.reporterOptions ??= {}).writer = "MessageWriter";
     }
-    for (const key of ["environmentInfo", "categories"]) {
+    for (const key of ["environmentInfo", "categories", "extraReporters"]) {
       if (typeof opts.reporterOptions?.[key] === "string") {
         opts.reporterOptions[key] = JSON.parse(Buffer.from(opts.reporterOptions[key], "base64Url").toString());
       }

--- a/packages/allure-mocha/test/samples/runner.js
+++ b/packages/allure-mocha/test/samples/runner.js
@@ -35,6 +35,9 @@ for (let i = 0; i < args.length; i++) {
     case "--categories":
       reporterOptions.categories = JSON.parse(Buffer.from(args[++i], "base64url").toString());
       break;
+    case "--extra-reporters":
+      reporterOptions.extraReporters = JSON.parse(Buffer.from(args[++i], "base64url").toString());
+      break;
   }
 }
 

--- a/packages/allure-mocha/test/spec/framework/extraReporters.test.ts
+++ b/packages/allure-mocha/test/spec/framework/extraReporters.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, test } from "vitest";
+import { runMochaInlineTest } from "../../utils.js";
+
+describe("extra reporters", () => {
+  describe("json", () => {
+    test("configuration by name", async () => {
+      const { tests, stdout } = await runMochaInlineTest({ extraReporters: "json" }, "plain-mocha/testInSuite");
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(JSON.parse(stdout.join(""))).toMatchObject({
+        stats: expect.objectContaining({
+          suites: 1,
+          tests: 1,
+          passes: 1,
+        }),
+      });
+    });
+
+    test("configuration by name in array", async () => {
+      const { tests, stdout } = await runMochaInlineTest({ extraReporters: ["json"] }, "plain-mocha/testInSuite");
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(JSON.parse(stdout.join(""))).toMatchObject({
+        stats: expect.objectContaining({
+          suites: 1,
+          tests: 1,
+          passes: 1,
+        }),
+      });
+    });
+
+    test("configuration by name and option", async () => {
+      const { tests, stdout, outputFiles } = await runMochaInlineTest(
+        {
+          extraReporters: ["json", { output: "output.json" }],
+          outputFiles: { "output.json": "application/json" },
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+
+      expect(JSON.parse(outputFiles.get("output.json")?.toString("utf-8") ?? "null")).toMatchObject({
+        stats: expect.objectContaining({
+          suites: 1,
+          tests: 1,
+          passes: 1,
+        }),
+      });
+
+      expect(stdout).toEqual([]);
+    });
+  });
+
+  describe("two entries", () => {
+    test("both are strings", async () => {
+      const { tests, stdout } = await runMochaInlineTest(
+        {
+          extraReporters: ["json-stream", "xunit"],
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(stdout).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^\["start",/),
+          expect.stringMatching(/^\["pass",/),
+          expect.stringMatching(/^\["end",/),
+
+          expect.stringMatching(/^<testsuite/),
+          expect.stringMatching(/^<testcase/),
+          expect.stringMatching(/testsuite>\s*$/),
+        ]),
+      );
+    });
+
+    test("both are option-less arrays", async () => {
+      const { tests, stdout } = await runMochaInlineTest(
+        {
+          extraReporters: [["json-stream"], ["xunit"]],
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(stdout).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^\["start",/),
+          expect.stringMatching(/^\["pass",/),
+          expect.stringMatching(/^\["end",/),
+
+          expect.stringMatching(/^<testsuite/),
+          expect.stringMatching(/^<testcase/),
+          expect.stringMatching(/testsuite>\s*$/),
+        ]),
+      );
+    });
+
+    test("first entry has options", async () => {
+      const { tests, stdout, outputFiles } = await runMochaInlineTest(
+        {
+          extraReporters: [["json", { output: "output.json" }], "xunit"],
+          outputFiles: { "output.json": "application/json" },
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(stdout).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^<testsuite/),
+          expect.stringMatching(/^<testcase/),
+          expect.stringMatching(/testsuite>\s*$/),
+        ]),
+      );
+      expect(stdout).not.toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^\["start",/),
+          expect.stringMatching(/^\["pass",/),
+          expect.stringMatching(/^\["end",/),
+        ]),
+      );
+      expect(JSON.parse(outputFiles.get("output.json")?.toString("utf-8") ?? "null")).toMatchObject({
+        stats: expect.objectContaining({
+          suites: 1,
+          tests: 1,
+          passes: 1,
+        }),
+      });
+    });
+
+    test("second entry has options", async () => {
+      const { tests, stdout, outputFiles } = await runMochaInlineTest(
+        {
+          extraReporters: ["json", ["xunit", { output: "output.xml" }]],
+          outputFiles: { "output.xml": "application/xml" },
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(JSON.parse(stdout.join(""))).toMatchObject({
+        stats: expect.objectContaining({
+          suites: 1,
+          tests: 1,
+          passes: 1,
+        }),
+      });
+      expect(stdout).not.toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^<testsuite/),
+          expect.stringMatching(/^<testcase/),
+          expect.stringMatching(/testsuite>\s*$/),
+        ]),
+      );
+      expect(outputFiles.get("output.xml")?.toString("utf-8")).toMatch(/<testsuite[^<]+<testcase[^<]+<\/testsuite>/);
+    });
+
+    test("both entries have options", async () => {
+      const { tests, stdout, outputFiles } = await runMochaInlineTest(
+        {
+          extraReporters: [
+            ["json", { output: "output.json" }],
+            ["xunit", { output: "output.xml" }],
+          ],
+          outputFiles: {
+            "output.json": "application/json",
+            "output.xml": "application/xml",
+          },
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(stdout).toEqual([]);
+      expect(JSON.parse(outputFiles.get("output.json")?.toString("utf-8") ?? "null")).toMatchObject({
+        stats: expect.objectContaining({
+          suites: 1,
+          tests: 1,
+          passes: 1,
+        }),
+      });
+      expect(outputFiles.get("output.xml")?.toString("utf-8")).toMatch(/<testsuite[^<]+<testcase[^<]+<\/testsuite>/);
+    });
+
+    test("both reporters have done callback", async () => {
+      const { tests, stdout, outputFiles } = await runMochaInlineTest(
+        {
+          extraReporters: [
+            ["xunit", { output: "output1.xml" }],
+            ["xunit", { output: "output2.xml" }],
+          ],
+          outputFiles: {
+            "output1.xml": "application/xml",
+            "output2.xml": "application/xml",
+          },
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(stdout).toEqual([]);
+      expect(outputFiles.get("output1.xml")?.toString("utf-8")).toMatch(/<testsuite[^<]+<testcase[^<]+<\/testsuite>/);
+      expect(outputFiles.get("output2.xml")?.toString("utf-8")).toMatch(/<testsuite[^<]+<testcase[^<]+<\/testsuite>/);
+    });
+  });
+
+  describe("errors", () => {
+    test("a reporter must be a string", async () => {
+      const { exitCode, stderr } = await runMochaInlineTest(
+        // @ts-ignore
+        { extraReporters: 1 },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(exitCode).not.toEqual(0);
+      expect(stderr).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("A reporter value must be a string or a constructor. Got number"),
+        ]),
+      );
+    });
+
+    test("a reporter module must exist", async () => {
+      const { exitCode, stderr } = await runMochaInlineTest(
+        // @ts-ignore
+        { extraReporters: "foo" },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(exitCode).not.toEqual(0);
+      expect(stderr).toEqual(expect.arrayContaining([expect.stringContaining("Can't load the 'foo' reporter")]));
+    });
+
+    test("a reporter entry can't be an empty array", async () => {
+      const { exitCode, stderr } = await runMochaInlineTest(
+        // @ts-ignore
+        { extraReporters: [] },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(exitCode).not.toEqual(0);
+      expect(stderr).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(
+            "If an extra reporter entry is an array, it must contain one or two elements. 0 found",
+          ),
+        ]),
+      );
+    });
+
+    test("a reporter entry's module must be a string", async () => {
+      const { exitCode, stderr } = await runMochaInlineTest(
+        // @ts-ignore
+        { extraReporters: [1] },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(exitCode).not.toEqual(0);
+      expect(stderr).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("A reporter value must be a string or a constructor. Got number"),
+        ]),
+      );
+    });
+
+    test("a reporter module in the array must be a string", async () => {
+      const { exitCode, stderr } = await runMochaInlineTest(
+        // @ts-ignore
+        { extraReporters: [[1]] },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(exitCode).not.toEqual(0);
+      expect(stderr).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("A reporter value must be a string or a constructor. Got number"),
+        ]),
+      );
+    });
+
+    test("a reporter entry in the array can't be an empty array", async () => {
+      const { exitCode, stderr } = await runMochaInlineTest(
+        // @ts-ignore
+        { extraReporters: [[]] },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(exitCode).not.toEqual(0);
+      expect(stderr).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining(
+            "If an extra reporter entry is an array, it must contain one or two elements. 0 found",
+          ),
+        ]),
+      );
+    });
+  });
+});

--- a/packages/allure-mocha/test/spec/framework/extraReporters.test.ts
+++ b/packages/allure-mocha/test/spec/framework/extraReporters.test.ts
@@ -206,6 +206,34 @@ describe("extra reporters", () => {
     });
   });
 
+  describe("local reporter", () => {
+    test("local reporter without options", async () => {
+      const { tests, stdout } = await runMochaInlineTest(
+        {
+          extraReporters: "./customReporter.cjs",
+          inputFiles: ["customReporter.cjs"],
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(JSON.parse(stdout.join(""))).toEqual({});
+    });
+
+    test("local reporter with options", async () => {
+      const { tests, stdout } = await runMochaInlineTest(
+        {
+          extraReporters: ["./customReporter.cjs", { foo: "bar" }],
+          inputFiles: ["customReporter.cjs"],
+        },
+        "plain-mocha/testInSuite",
+      );
+
+      expect(tests).toEqual([expect.objectContaining({ name: "a test in a suite" })]);
+      expect(JSON.parse(stdout.join(""))).toEqual({ foo: "bar" });
+    });
+  });
+
   describe("errors", () => {
     test("a reporter must be a string", async () => {
       const { exitCode, stderr } = await runMochaInlineTest(

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -169,7 +169,6 @@ abstract class AllureMochaTestRunner {
 
     const messageReader = new AllureMochaMessageReader();
 
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     testProcess.on("message", messageReader.handleMessage);
 
     const stdout: string[] = [];

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -5,17 +5,27 @@ import * as path from "node:path";
 import { Status, attachment, attachmentPath, logStep, parameter, step } from "allure-js-commons";
 import type { AllureResults, Category } from "allure-js-commons/sdk";
 import { MessageReader, getPosixPath } from "allure-js-commons/sdk/reporter";
+import type { AllureMochaReporterConfig } from "../src/types.js";
 
 type MochaRunOptions = {
   env?: { [keys: string]: string };
   testplan?: readonly TestPlanEntryFixture[];
   environmentInfo?: { [keys: string]: string };
   categories?: readonly Category[];
+  extraReporters?: AllureMochaReporterConfig["extraReporters"];
+  outputFiles?: Record<string, string>;
 };
 
 type TestPlanEntryFixture = {
   id?: string | number;
   selector?: TestPlanSelectorEntryFixture;
+};
+
+type AllureMochaRunResults = AllureResults & {
+  outputFiles: Map<string, Buffer>;
+  exitCode: number;
+  stdout: string[];
+  stderr: string[];
 };
 
 type TestPlanSelectorEntryFixture = [file: readonly string[], name: string];
@@ -81,7 +91,7 @@ abstract class AllureMochaTestRunner {
     const filesToCopy = [...this.getFilesToCopy(testDir)];
     const filesToTransform = [
       ...this.getFilesToTransform(testDir),
-      ...samples.map((sample) => this.getSampleEntry(sample, this.specsPath, testDir)),
+      ...samples.map((sample) => this.#getSampleEntry(sample, this.specsPath, testDir)),
     ];
     const scriptArgs = this.getScriptArgs();
 
@@ -134,7 +144,7 @@ abstract class AllureMochaTestRunner {
         version: "1.0",
         tests: this.config.testplan.map((test) => ({
           id: test.id,
-          selector: test.selector ? this.resolveTestplanSelector(selectorPrefix, test.selector) : undefined,
+          selector: test.selector ? this.#resolveTestplanSelector(selectorPrefix, test.selector) : undefined,
         })),
       });
       await writeFile(testplanPath, content, { encoding: "utf-8" });
@@ -171,7 +181,7 @@ abstract class AllureMochaTestRunner {
       stderr.push(chunk.toString());
     });
 
-    return await new Promise<AllureResults>((resolve, reject) => {
+    return await new Promise<AllureMochaRunResults>((resolve, reject) => {
       testProcess.on("exit", async (code, signal) => {
         if (stdout.length) {
           await attachment("stdout", stdout.join("\n"), "text/plain");
@@ -181,10 +191,19 @@ abstract class AllureMochaTestRunner {
         }
         await messageReader.attachErrors();
         await messageReader.attachResults();
+
+        const outputFiles = await this.#reportOtherOutputFiles(testDir);
+
         await rm(testDir, { recursive: true });
 
         if ((code ?? -1) >= 0 && !signal) {
-          resolve(messageReader.results);
+          resolve({
+            ...messageReader.results,
+            outputFiles,
+            exitCode: code as number,
+            stdout,
+            stderr,
+          });
         } else if (signal) {
           reject(new Error(`mocha was interrupted with ${signal}`));
         } else {
@@ -216,17 +235,37 @@ abstract class AllureMochaTestRunner {
 
   protected encodeCategories = () => this.toBase64Url(this.config.categories);
 
+  protected encodeExtraReporters = () => this.toBase64Url(this.config.extraReporters);
+
   protected toBase64Url = (value: any) => Buffer.from(JSON.stringify(value)).toString("base64url");
 
-  private getSampleEntry = (name: string | readonly string[], samplesDir: string, testDir: string) => {
+  #getSampleEntry = (name: string | readonly string[], samplesDir: string, testDir: string) => {
     if (name instanceof Array) {
       name = path.join(...name);
     }
     return this.getTransformEntry(`${name}.spec`, SPEC_FORMAT, testDir, samplesDir);
   };
 
-  private resolveTestplanSelector = (prefix: string, [file, name]: TestPlanSelectorEntryFixture) => {
+  #resolveTestplanSelector = (prefix: string, [file, name]: TestPlanSelectorEntryFixture) => {
     return getPosixPath(`${path.join(prefix, ...file)}.spec${SPEC_EXT}: ${name}`);
+  };
+
+  #reportOtherOutputFiles = async (testDir: string) => {
+    if (!this.config.outputFiles) {
+      return new Map<string, Buffer>();
+    }
+
+    return await step("other output files", async () => {
+      const outputFiles = new Map<string, Buffer>();
+      for (const [file, contentType] of Object.entries(this.config.outputFiles ?? {})) {
+        try {
+          const content = await readFile(path.join(testDir, file));
+          outputFiles.set(file, content);
+          await attachment(file, content, { contentType, fileExtension: path.extname(file) });
+        } catch {}
+      }
+      return outputFiles;
+    });
   };
 
   getFilesToCopy: (testDir: string) => readonly [string, string][] = () => [];
@@ -245,6 +284,9 @@ class AllureMochaCliTestRunner extends AllureMochaTestRunner {
     }
     if (this.config.categories) {
       args.push("--reporter-option", `categories=${this.encodeCategories()}`);
+    }
+    if (this.config.extraReporters) {
+      args.push("--reporter-option", `extraReporters=${this.encodeExtraReporters()}`);
     }
     return args;
   };
@@ -273,6 +315,9 @@ class AllureMochaCodeTestRunner extends AllureMochaTestRunner {
     }
     if (this.config.categories) {
       args.push("--categories", this.encodeCategories());
+    }
+    if (this.config.extraReporters) {
+      args.push("--extra-reporters", this.encodeExtraReporters());
     }
     return args;
   };

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -13,6 +13,7 @@ type MochaRunOptions = {
   environmentInfo?: { [keys: string]: string };
   categories?: readonly Category[];
   extraReporters?: AllureMochaReporterConfig["extraReporters"];
+  inputFiles?: string[];
   outputFiles?: Record<string, string>;
 };
 
@@ -88,7 +89,10 @@ abstract class AllureMochaTestRunner {
 
     const testDir = path.join(this.runResultsDir, randomUUID());
 
-    const filesToCopy = [...this.getFilesToCopy(testDir)];
+    const filesToCopy = [
+      ...this.getFilesToCopy(testDir),
+      ...(this.config.inputFiles?.map((f) => this.getCopyEntry(f, testDir)) ?? []),
+    ];
     const filesToTransform = [
       ...this.getFilesToTransform(testDir),
       ...samples.map((sample) => this.#getSampleEntry(sample, this.specsPath, testDir)),


### PR DESCRIPTION
### Context
The PR makes it possible to enable additional reporters to run alongside Allure Mocha.

### Examples

The feature is controlled by a new configuration property:`extraReporters`. Its values may take the following forms:

  - A string: 
    ```js
    { extraReporters: "json" }
    ```
    This is usable from the CLI or config files:
    ```shell
    npx mocha -R allure-mocha -O extraReporters=json
    ```

    *.mocharc.json:*
    ```json
    {
      "reporter": "allure-mocha",
      "reporterOptions": [
        "extraReporters=json"
      ],
    }
    ```
  - An array of one or two elements, where the second element (if present) is an options object:
    ```js
    { extraReporters: ["json", { output: "output.json" }] }
    ```
  - An array of elements, each taking one of the above forms:
    ```js
    {
      extraReporters: [
        ["json", {output: "output.json"}],
        "mochawesome",
      ],
    }
    ```

Closes #1134.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
