### PR TITLE
feat(codeceptjs): add support for mocha reporters

### DIFF
--- a/packages/allure-codeceptjs/src/index.ts
+++ b/packages/allure-codeceptjs/src/index.ts
@@ -6,7 +6,16 @@ import { AllureCodeceptJsReporter } from "./reporter.js";
 
 const allurePlugin = (config: ReporterConfig) => {
   const mocha = container.mocha();
-  mocha.reporter(AllureCodeceptJsReporter.prototype.constructor, { ...config });
+
+  // At this point the configured reporter's constructor has been initialized and is available via the _reporter field.
+  // See https://github.com/mochajs/mocha/blob/05097db4f2e0118f033978b8503aec36b1867c55/lib/mocha.js#L352
+  // The field is not public but there is no other option to get the constructor; this is covered by tests in reporters.test.ts.
+  // eslint-disable-next-line no-underscore-dangle
+  const currentReporter = mocha._reporter;
+  mocha.reporter(AllureCodeceptJsReporter.prototype.constructor, {
+    ...config,
+    ...(currentReporter ? { extraReporters: [currentReporter, mocha.options.reporterOptions] } : {}),
+  });
 
   return {
     ...allureCodeceptJsLegacyApi,

--- a/packages/allure-codeceptjs/test/spec/labels.test.ts
+++ b/packages/allure-codeceptjs/test/spec/labels.test.ts
@@ -102,8 +102,7 @@ it("should not depend on CWD", async () => {
         });
       `,
     },
-    {},
-    "nested",
+    { cwd: "nested" },
   );
 
   expect(tests).toEqual(
@@ -141,8 +140,10 @@ it("should add labels from env variables", async () => {
       `,
     },
     {
-      ALLURE_LABEL_A: "a",
-      ALLURE_LABEL_B: "b",
+      env: {
+        ALLURE_LABEL_A: "a",
+        ALLURE_LABEL_B: "b",
+      },
     },
   );
 

--- a/packages/allure-codeceptjs/test/spec/reporters.test.ts
+++ b/packages/allure-codeceptjs/test/spec/reporters.test.ts
@@ -14,6 +14,23 @@ describe("mocha reporters", () => {
     expect(stdout.join("").split("\n")).toEqual(expect.arrayContaining([expect.stringMatching(/^foo --/)]));
   });
 
+  it("cli --steps should work out-of-box", async () => {
+    const { tests, stdout } = await runCodeceptJsInlineTest(
+      {
+        "foo.test.js": `
+          Feature("foo")
+          Scenario('bar', () => {});
+          `,
+      },
+      { args: ["--steps"] },
+    );
+
+    expect(tests).toEqual([expect.objectContaining({ name: "bar" })]);
+    expect(stdout.join("").split("\n")).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^foo --/), expect.stringMatching(/^ {2}bar/)]),
+    );
+  });
+
   it("should support Mocha's built-in reporters", async () => {
     const { tests, stdout } = await runCodeceptJsInlineTest({
       "foo.test.js": `

--- a/packages/allure-codeceptjs/test/spec/reporters.test.ts
+++ b/packages/allure-codeceptjs/test/spec/reporters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { issue } from "allure-js-commons";
 import { runCodeceptJsInlineTest } from "../utils.js";
 
 describe("mocha reporters", () => {
@@ -15,6 +16,8 @@ describe("mocha reporters", () => {
   });
 
   it("cli --steps should work out-of-box", async () => {
+    await issue("1167");
+
     const { tests, stdout } = await runCodeceptJsInlineTest(
       {
         "foo.test.js": `
@@ -143,4 +146,4 @@ describe("mocha reporters", () => {
     expect(tests).toEqual([expect.objectContaining({ name: "bar" })]);
     expect(stdoutLines).toEqual(expect.arrayContaining([String.raw`{"foo":{"bar":"baz"}}`]));
   });
-  });
+});

--- a/packages/allure-codeceptjs/test/spec/reporters.test.ts
+++ b/packages/allure-codeceptjs/test/spec/reporters.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { runCodeceptJsInlineTest } from "../utils.js";
+
+describe("mocha reporters", () => {
+  it("cli should be enabled by default", async () => {
+    const { tests, stdout } = await runCodeceptJsInlineTest({
+      "foo.test.js": `
+        Feature("foo")
+        Scenario('bar', () => {});
+        `,
+    });
+
+    expect(tests).toEqual([expect.objectContaining({ name: "bar" })]);
+    expect(stdout.join("").split("\n")).toEqual(expect.arrayContaining([expect.stringMatching(/^foo --/)]));
+  });
+
+  it("should support Mocha's built-in reporters", async () => {
+    const { tests, stdout } = await runCodeceptJsInlineTest({
+      "foo.test.js": `
+        Feature("foo")
+        Scenario('bar', () => {});
+        `,
+      "codecept.conf.js": `
+        const path = require("node:path");
+        exports.config = {
+          tests: "./**/*.test.js",
+          output: path.resolve(__dirname, "./output"),
+          plugins: {
+            allure: {
+              require: require.resolve("allure-codeceptjs"),
+              enabled: true,
+            },
+          },
+          mocha: {
+            reporter: "json",
+          },
+        };
+      `,
+    });
+
+    const stdoutLines = stdout.join("").split("\n");
+
+    expect(tests).toEqual([expect.objectContaining({ name: "bar" })]);
+    const jsonString = stdoutLines.slice(stdoutLines.indexOf("{")).join("");
+    expect(JSON.parse(jsonString)).toMatchObject({
+      stats: expect.objectContaining({
+        suites: 1,
+        tests: 1,
+      }),
+    });
+    expect(stdoutLines).not.toEqual(
+      // no default cli reporter
+      expect.arrayContaining([expect.stringMatching(/^foo --/)]),
+    );
+  });
+
+  it("should support local reporters", async () => {
+    const { tests, stdout } = await runCodeceptJsInlineTest({
+      "foo.test.js": `
+        Feature("foo")
+        Scenario('bar', () => {});
+        `,
+      "reporter.cjs": `
+        module.exports = function (r, o) {
+          r.on("start", () => {
+            console.log(JSON.stringify(o.reporterOptions));
+          });
+        };
+      `,
+      "codecept.conf.js": `
+        const path = require("node:path");
+        exports.config = {
+          tests: "./**/*.test.js",
+          output: path.resolve(__dirname, "./output"),
+          plugins: {
+            allure: {
+              require: require.resolve("allure-codeceptjs"),
+              enabled: true,
+            },
+          },
+          mocha: {
+            reporter: "reporter.cjs",
+            reporterOptions: { foo: "bar" },
+          },
+        };
+      `,
+    });
+
+    const stdoutLines = stdout.join("").split("\n");
+
+    expect(tests).toEqual([expect.objectContaining({ name: "bar" })]);
+    expect(stdoutLines).toEqual(expect.arrayContaining([String.raw`{"foo":"bar"}`]));
+  });
+
+  it("should support reporter constructors", async () => {
+    const { tests, stdout } = await runCodeceptJsInlineTest({
+      "foo.test.js": `
+        Feature("foo")
+        Scenario('bar', () => {});
+        `,
+      "codecept.conf.js": `
+        const path = require("node:path");
+        exports.config = {
+          tests: "./**/*.test.js",
+          output: path.resolve(__dirname, "./output"),
+          plugins: {
+            allure: {
+              require: require.resolve("allure-codeceptjs"),
+              enabled: true,
+            },
+          },
+          mocha: {
+            reporter: function (r, o) {
+              r.on("start", () => {
+                console.log(JSON.stringify(o.reporterOptions));
+              });
+            },
+            reporterOptions: { foo: { bar: "baz" } },
+          },
+        };
+      `,
+    });
+
+    const stdoutLines = stdout.join("").split("\n");
+
+    expect(tests).toEqual([expect.objectContaining({ name: "bar" })]);
+    expect(stdoutLines).toEqual(expect.arrayContaining([String.raw`{"foo":{"bar":"baz"}}`]));
+  });
+  });

--- a/packages/allure-codeceptjs/test/spec/testplan.test.ts
+++ b/packages/allure-codeceptjs/test/spec/testplan.test.ts
@@ -37,7 +37,7 @@ it("should support test plan", async () => {
       [testPlanFilename]: `${JSON.stringify(exampleTestPlan)}`,
     },
     {
-      ALLURE_TESTPLAN_PATH: `./${testPlanFilename}`,
+      env: { ALLURE_TESTPLAN_PATH: `./${testPlanFilename}` },
     },
   );
 

--- a/packages/allure-codeceptjs/vitest.config.ts
+++ b/packages/allure-codeceptjs/vitest.config.ts
@@ -6,7 +6,21 @@ export default defineConfig({
     fileParallelism: false,
     testTimeout: 5000,
     setupFiles: ["./vitest-setup.ts"],
-    reporters: ["default", ["allure-vitest/reporter", { resultsDir: "./out/allure-results" }]],
+    reporters: [
+      "default",
+      [
+        "allure-vitest/reporter",
+        {
+          resultsDir: "./out/allure-results",
+          links: {
+            issue: {
+              urlTemplate: "https://github.com/allure-framework/allure-js/issues/%s",
+              nameTemplate: "Issue %s",
+            },
+          },
+        },
+      ],
+    ],
     typecheck: {
       enabled: true,
       tsconfig: "./test/tsconfig.json",


### PR DESCRIPTION
### Context
CodeceptJS allows providing a reporter to an underlying instance of Mocha. Allure CodeceptJS itself is implemented as a reporter (based on Allure Mocha). It overwrites any configured reporter with itself, which prevents it from running alongside other reporters, including the default one, `cli`.

The incompatibility with `cli` manifests itself, particularly in the non-working `--steps`, `--debug`, and `--verbose` CLI options (see #1167).

#1182 allows extra reporters to run with the Allure Mocha reporter. This PR uses that functionality to enable the use of a user-provided reporter or a default one together with Allure CodeceptJS.

**caveat:** The implementation takes the configured reporter's constructor via the non-public `Mocha._reporter` field. It's quite stable, though (the field hasn't changed since Mocha v1.0), and the behavior is covered with tests in `reporters.test.ts`.

#### Other changes

  - stdout and stderr are now included in the Allure Report of Allure CodeceptJS
  - an issue template was added to the Allure Vitest config of Allure CodeceptJS

Closes #1167.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
