### PR TITLE
fix: invalid position of "types" in "exports"

### DIFF
--- a/packages/allure-codeceptjs/package.json
+++ b/packages/allure-codeceptjs/package.json
@@ -21,9 +21,9 @@
   "license": "Apache-2.0",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/allure-cucumberjs/package.json
+++ b/packages/allure-cucumberjs/package.json
@@ -27,14 +27,14 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     },
     "./reporter": {
+      "types": "./dist/types/reporter.d.ts",
       "import": "./dist/esm/reporter.js",
-      "require": "./dist/cjs/reporter.js",
-      "types": "./dist/types/reporter.d.ts"
+      "require": "./dist/cjs/reporter.js"
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/allure-cypress/package.json
+++ b/packages/allure-cypress/package.json
@@ -25,14 +25,14 @@
   "author": "Qameta Software <allure@qameta.io> (https://qameta.io/)",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     },
     "./reporter": {
+      "types": "./dist/types/reporter.d.ts",
       "import": "./dist/esm/reporter.js",
-      "require": "./dist/cjs/reporter.js",
-      "types": "./dist/types/reporter.d.ts"
+      "require": "./dist/cjs/reporter.js"
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/allure-jasmine/package.json
+++ b/packages/allure-jasmine/package.json
@@ -26,6 +26,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/allure-jest/package.json
+++ b/packages/allure-jest/package.json
@@ -28,10 +28,12 @@
   },
   "exports": {
     "./node": {
+      "types": "./dist/types/node.d.ts",
       "import": "./dist/esm/node.js",
       "require": "./dist/cjs/node.js"
     },
     "./jsdom": {
+      "types": "./dist/types/jsdom.d.ts",
       "import": "./dist/esm/jsdom.js",
       "require": "./dist/cjs/jsdom.js"
     }

--- a/packages/allure-js-commons/package.json
+++ b/packages/allure-js-commons/package.json
@@ -34,27 +34,27 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts",
       "default": "./dist/cjs/index.js"
     },
     "./sdk": {
+      "types": "./dist/types/sdk/index.d.ts",
       "import": "./dist/esm/sdk/index.js",
       "require": "./dist/cjs/sdk/index.js",
-      "types": "./dist/types/sdk/index.d.ts",
       "default": "./dist/cjs/sdk/index.js"
     },
     "./sdk/reporter": {
+      "types": "./dist/types/sdk/reporter/index.d.ts",
       "import": "./dist/esm/sdk/reporter/index.js",
       "require": "./dist/cjs/sdk/reporter/index.js",
-      "types": "./dist/types/sdk/reporter/index.d.ts",
       "default": "./dist/cjs/sdk/reporter/index.js"
     },
     "./sdk/runtime": {
+      "types": "./dist/types/sdk/runtime/index.d.ts",
       "import": "./dist/esm/sdk/runtime/index.js",
       "require": "./dist/cjs/sdk/runtime/index.js",
-      "types": "./dist/types/sdk/runtime/index.d.ts",
       "default": "./dist/cjs/sdk/runtime/index.js"
     }
   },

--- a/packages/allure-mocha/package.json
+++ b/packages/allure-mocha/package.json
@@ -26,14 +26,14 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.js"
     },
     "./runtime": {
+      "types": "./dist/types/legacy.d.ts",
       "import": "./dist/esm/legacy.js",
-      "require": "./dist/cjs/legacy.js",
-      "types": "./dist/types/legacy.d.ts"
+      "require": "./dist/cjs/legacy.js"
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/allure-playwright/package.json
+++ b/packages/allure-playwright/package.json
@@ -26,18 +26,18 @@
   },
   "exports": {
     ".": {
-      "require": "./dist/cjs/index.js",
       "types": "./dist/types/index.d.ts",
+      "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     },
     "./testplan": {
-      "require": "./dist/cjs/testplan.js",
       "types": "./dist/types/testplan.d.ts",
+      "require": "./dist/cjs/testplan.js",
       "default": "./dist/cjs/testplan.js"
     },
     "./autoconfig": {
-      "require": "./dist/cjs/autoconfig.js",
       "types": "./dist/types/autoconfig.d.ts",
+      "require": "./dist/cjs/autoconfig.js",
       "default": "./dist/cjs/autoconfig.js"
     }
   },

--- a/packages/allure-vitest/package.json
+++ b/packages/allure-vitest/package.json
@@ -27,13 +27,13 @@
   "type": "module",
   "exports": {
     "./reporter": {
-      "import": "./dist/reporter.js",
       "types": "./dist/reporter.d.ts",
+      "import": "./dist/reporter.js",
       "default": "./dist/reporter.js"
     },
     "./setup": {
-      "import": "./dist/setup.js",
       "types": "./dist/setup.d.ts",
+      "import": "./dist/setup.js",
       "default": "./dist/setup.js"
     }
   },


### PR DESCRIPTION
### Context
When resolving types, TypeScript always uses the "types" entry of "exports" (provided it exists) regardless of its position and whether or not a previous entry had matched.

This is considered a bug and shouldn't be relied upon. See the details here: microsoft/TypeScript#50762.

This PR puts every "types" entry to the first place. This makes the resolution by TypeScript the same as the one performed by Node.