### PR TITLE
feat(cypress): differentiate browser/node in exports

### DIFF
--- a/packages/allure-cypress/package.json
+++ b/packages/allure-cypress/package.json
@@ -26,13 +26,21 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "node": {
+        "import": "./dist/esm/reporter.js",
+        "require": "./dist/cjs/reporter.js"
+      },
+      "browser": {
+        "import": "./dist/esm/index.js",
+        "require": "./dist/cjs/index.js"
+      }
     },
     "./reporter": {
       "types": "./dist/types/reporter.d.ts",
-      "import": "./dist/esm/reporter.js",
-      "require": "./dist/cjs/reporter.js"
+      "node": {
+        "import": "./dist/esm/reporter.js",
+        "require": "./dist/cjs/reporter.js"
+      }
     }
   },
   "main": "./dist/cjs/index.js",

--- a/packages/allure-cypress/test/utils.ts
+++ b/packages/allure-cypress/test/utils.ts
@@ -80,8 +80,8 @@ export const runCypressInlineTest = async (
 
   await step("Prepare files", async () => {
     const allureCommonsModulePath = require.resolve("allure-js-commons");
-    const allureCypressModulePath = require.resolve("allure-cypress");
-    const allureCypressReporterModulePath = require.resolve("allure-cypress/reporter");
+    const allureCypressReporterModulePath = require.resolve("allure-cypress");
+    const allureCypressModulePath = join(dirname(allureCypressReporterModulePath), "index.js");
 
     // eslint-disable-next-line guard-for-in
     for (const testFile in testFilesToWrite) {


### PR DESCRIPTION
### Context
The PR adds the `node` and `browser` conditions into allure-cypress's `exports` section, which allows importing "allure-cypress" in both the browser and the Node sides:

```ts
import "allure-cypress"; // the browser side code in support/e2e.js
import { allureCypress } from "allure-cypress"; // in cypress.config.js
import { allureCypress } from "allure-cypress/reporter"; // the same as above; backward compatibility
```

Additionally, users who mistakenly import "allure-cypress/reporter" in the browser-side code will get a more clear `Could not resolve "allure-cypress/reporter"` error instead of failing somewhere deep inside of "allure-js-commons" code with some failed Node-related import like "node:fs".
