### PR TITLE
chore: improve interop between prettier and eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -137,7 +137,7 @@ module.exports = {
     "@typescript-eslint/prefer-namespace-keyword": "error",
     "@typescript-eslint/prefer-regexp-exec": "off",
     "@typescript-eslint/prefer-promise-reject-errors": "off",
-    "@stylistic/quotes": ["error", "double"],
+    "@stylistic/quotes": ["error", "double", { avoidEscape: true }],
     "@typescript-eslint/restrict-template-expressions": [
       "error",
       {

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -9,4 +9,5 @@ module.exports = {
   importOrderSeparation: false,
   importOrderSortSpecifiers: true,
   importOrderParserPlugins: ["typescript", "decorators-legacy"],
+  quoteProps: "consistent",
 };

--- a/packages/allure-codeceptjs/test/utils.ts
+++ b/packages/allure-codeceptjs/test/utils.ts
@@ -24,7 +24,6 @@ export const runCodeceptJsInlineTest = async (
 ): Promise<RunResult> => {
   const testFiles = {
     // package.json is used to find project root in case of absolute file paths are used
-    // eslint-disable-next-line @stylistic/quotes
     "package.json": '{ "name": "dummy"}',
     "codecept.conf.js": await readFile(resolvePath(__dirname, "./samples/codecept.conf.js"), "utf-8"),
     "helper.js": await readFile(resolvePath(__dirname, "./samples/helper.js"), "utf-8"),

--- a/packages/allure-jasmine/test/utils.ts
+++ b/packages/allure-jasmine/test/utils.ts
@@ -13,7 +13,6 @@ export const runJasmineInlineTest = async (
   const testDir = path.join(__dirname, "fixtures", randomUUID());
   const testFiles = {
     // package.json is used to find project root in case of absolute file paths are used
-    // eslint-disable-next-line @stylistic/quotes
     "package.json": '{ "name": "dummy"}',
     "spec/support/jasmine.json": await readFile(path.join(__dirname, "./samples/spec/support/jasmine.json"), "utf8"),
     // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/packages/allure-mocha/src/extraReporters.ts
+++ b/packages/allure-mocha/src/extraReporters.ts
@@ -72,7 +72,7 @@ const instantiateReporters = (
       ...options,
       reporterOptions,
       // eslint-disable-next-line quote-props
-      reporterOption: reporterOptions,
+      "reporterOption": reporterOptions,
       "reporter-option": reporterOptions,
     };
     reporters.push(new Reporter(runner, optionsForReporter));

--- a/packages/allure-mocha/test/spec/framework/fixtures.test.ts
+++ b/packages/allure-mocha/test/spec/framework/fixtures.test.ts
@@ -1,4 +1,3 @@
-/* eslint @stylistic/quotes: off */
 import { beforeAll, describe, expect, it } from "vitest";
 import type { Assertion } from "vitest";
 import type { TestResult, TestResultContainer } from "allure-js-commons";

--- a/packages/allure-mocha/test/spec/framework/retries.test.ts
+++ b/packages/allure-mocha/test/spec/framework/retries.test.ts
@@ -148,7 +148,6 @@ describe("retries", () => {
       expect(befores).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            // eslint-disable-next-line @stylistic/quotes
             name: '"before each" hook',
             steps: expect.arrayContaining([
               expect.objectContaining({
@@ -164,7 +163,6 @@ describe("retries", () => {
       expect(afters).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            // eslint-disable-next-line @stylistic/quotes
             name: '"after each" hook',
             steps: expect.arrayContaining([
               expect.objectContaining({

--- a/packages/newman-reporter-allure/src/index.ts
+++ b/packages/newman-reporter-allure/src/index.ts
@@ -465,7 +465,6 @@ class AllureReporter {
       val
         .replace("\n", "")
         .replace("\r", "")
-        // eslint-disable-next-line @stylistic/quotes
         .replace('"', '"')
     );
   }

--- a/packages/newman-reporter-allure/src/index.ts
+++ b/packages/newman-reporter-allure/src/index.ts
@@ -461,12 +461,7 @@ class AllureReporter {
   }
 
   #escape(val: string) {
-    return (
-      val
-        .replace("\n", "")
-        .replace("\r", "")
-        .replace('"', '"')
-    );
+    return val.replace("\n", "").replace("\r", "").replace('"', '"');
   }
 }
 

--- a/packages/newman-reporter-allure/test/spec/errorMessage.test.ts
+++ b/packages/newman-reporter-allure/test/spec/errorMessage.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { server } from "../mocks/server.js";
 import { runNewmanCollection } from "../utils.js";

--- a/packages/newman-reporter-allure/test/spec/exec.test.ts
+++ b/packages/newman-reporter-allure/test/spec/exec.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { server } from "../mocks/server.js";
 import { runNewmanCollection } from "../utils.js";

--- a/packages/newman-reporter-allure/test/spec/globalLabels.test.ts
+++ b/packages/newman-reporter-allure/test/spec/globalLabels.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { server } from "../mocks/server.js";
 import { runNewmanCollection } from "../utils.js";

--- a/packages/newman-reporter-allure/test/spec/headers.test.ts
+++ b/packages/newman-reporter-allure/test/spec/headers.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { server } from "../mocks/server.js";
 import { runNewmanCollection } from "../utils.js";

--- a/packages/newman-reporter-allure/test/spec/requestError.test.ts
+++ b/packages/newman-reporter-allure/test/spec/requestError.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { server } from "../mocks/server.js";
 import { runNewmanCollection } from "../utils.js";

--- a/packages/newman-reporter-allure/test/spec/simple.test.ts
+++ b/packages/newman-reporter-allure/test/spec/simple.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { LabelName, Stage, Status } from "allure-js-commons";
 import { server } from "../mocks/server.js";

--- a/packages/newman-reporter-allure/test/spec/syntaxError.test.ts
+++ b/packages/newman-reporter-allure/test/spec/syntaxError.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @stylistic/quotes */
 import { afterAll, afterEach, beforeAll, expect, test } from "vitest";
 import { server } from "../mocks/server.js";
 import { runNewmanCollection } from "../utils.js";


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

- Set `quoteProps` to `"consistent"` to match ESLint's `quote-props` rule.
- Set `avoidEscape` to `true` for ESLint's `@stylistic/quotes` rule to match Prettier's formatting behavior when dealing with strings with double quote characters inside (e.g., `'"foo"="bar"'`).

ref https://github.com/allure-framework/allure3/pull/29

#### Checklist
- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js