### PR TITLE
fix(codeceptjs): add support for native asserts

### DIFF
--- a/packages/allure-codeceptjs/src/reporter.ts
+++ b/packages/allure-codeceptjs/src/reporter.ts
@@ -89,10 +89,14 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
     // @ts-ignore
     if (promise) {
       promise.catch((err) => {
-        if (err instanceof Error) {
+        if (!err.message && typeof err.inspect === "function") {
+          // AssertionFailedError doesn't set message attribute
+          err.message = err.inspect();
+        }
+        if (err instanceof Error || err.constructor.name === "Error") {
           this.runtime.updateStep(currentStep, (step) => {
-            step.status = getStatusFromError(err);
-            step.statusDetails = { ...step.statusDetails, ...getMessageAndTraceFromError(err) };
+            step.status = getStatusFromError(err as Error);
+            step.statusDetails = { ...step.statusDetails, ...getMessageAndTraceFromError(err as Error) };
           });
         }
         return Promise.reject(err);

--- a/packages/allure-codeceptjs/test/spec/assert.test.ts
+++ b/packages/allure-codeceptjs/test/spec/assert.test.ts
@@ -1,0 +1,99 @@
+import { expect, it } from "vitest";
+import { Status } from "allure-js-commons";
+import { runCodeceptJsInlineTest } from "../utils.js";
+
+it("should support codeceptjs assertions", async () => {
+  const { tests } = await runCodeceptJsInlineTest({
+    "nested/login.test.js": `
+        const { container } = require('codeceptjs')
+
+        Feature("login-feature");
+        Scenario("assert scenario", async ({ I }) => {
+          await I.pass();
+          await I.fail();
+        });
+      `,
+    "codecept.conf.js": `
+        const path = require("node:path");
+        const { setCommonPlugins } = require("@codeceptjs/configure");
+
+        setCommonPlugins();
+
+        exports.config = {
+          tests: "./**/*.test.js",
+          output: path.resolve(__dirname, "./output"),
+          plugins: {
+            allure: {
+              require: require.resolve("allure-codeceptjs"),
+              enabled: true,
+            },
+          },
+          helpers: {
+            Playwright: {
+              require: "./helper.js",
+            },
+          },
+        };
+      `,
+    "helper.js": `
+        const Helper = require("@codeceptjs/helper");
+        const { writeFile } = require("fs/promises");
+        const path = require("path");
+        const AssertionFailedError = require("./assert.js");
+
+        class MyHooksHelper extends Helper {
+
+          async pass() {
+            await Promise.resolve();
+          }
+
+          async fail() {
+            await Promise.reject(new AssertionFailedError({ actual: "1", expected: "2"}));
+          }
+
+        }
+
+        module.exports = MyHooksHelper;
+      `,
+    "assert.js": `
+        function AssertionFailedError(params) {
+          this.params = params;
+          this.actual = this.params.actual;
+          this.expected = this.params.expected;
+
+          this.inspect = () => {
+            return "expect " + this.expected + " but " + this.actual;
+          }
+        }
+
+        AssertionFailedError.prototype = Object.create(Error.prototype);
+        AssertionFailedError.constructor = AssertionFailedError;
+        module.exports = AssertionFailedError;
+      `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "assert scenario",
+        status: Status.FAILED,
+        statusDetails: expect.objectContaining({
+          message: "expect 2 but 1",
+        }),
+        steps: [
+          expect.objectContaining({
+            name: "I pass",
+          }),
+          expect.objectContaining({
+            name: "I fail",
+            status: Status.FAILED,
+            statusDetails: expect.objectContaining({
+              message: "expect 2 but 1",
+            }),
+          }),
+        ],
+      }),
+    ]),
+  );
+});

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -17,6 +17,7 @@ export const getStatusFromError = (error: Partial<Error>): Status => {
     case error.stack && /@vitest\/expect/gi.test(error.stack):
     case error.stack && /playwright\/lib\/matchers\/expect\.js/gi.test(error.stack):
     case "matcherResult" in error:
+    case "expected" in error && "actual" in error:
       return Status.FAILED;
     default:
       return Status.BROKEN;

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -17,7 +17,7 @@ export const getStatusFromError = (error: Partial<Error>): Status => {
     case error.stack && /@vitest\/expect/gi.test(error.stack):
     case error.stack && /playwright\/lib\/matchers\/expect\.js/gi.test(error.stack):
     case "matcherResult" in error:
-    case "expected" in error && "actual" in error:
+    case "inspect" in error && typeof error.inspect === "function":
       return Status.FAILED;
     default:
       return Status.BROKEN;


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

CodeceptJS has an internal AssertionFailedError. The proposed change adds
support for it.

fixes #1195 

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js