### PR TITLE
Add support for actual and expected values in errors

### DIFF
--- a/packages/allure-js-commons/src/model.ts
+++ b/packages/allure-js-commons/src/model.ts
@@ -35,6 +35,8 @@ export type ParameterOptions = Pick<Parameter, "mode" | "excluded">;
 export interface StatusDetails {
   message?: string;
   trace?: string;
+  actual?: string;
+  expected?: string;
 }
 
 // don't use the interface as is, use Results types instead

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -46,13 +46,13 @@ export const stripAnsi = (str: string): string => {
 
 export const getMessageAndTraceFromError = (error: Error | { message?: string; stack?: string }): StatusDetails => {
   const { message, stack } = error;
-  const actual = "actual" in error ? serialize(error.actual) : undefined;
-  const expected = "expected" in error ? serialize(error.expected) : undefined;
+  const actual = "actual" in error && error.actual !== undefined ? { actual: serialize(error.actual) } : {};
+  const expected = "expected" in error && error.expected !== undefined ? { expected: serialize(error.expected) } : {};
   return {
     message: message ? stripAnsi(message) : undefined,
     trace: stack ? stripAnsi(stack) : undefined,
-    actual,
-    expected,
+    ...actual,
+    ...expected,
   };
 };
 

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -44,13 +44,15 @@ export const stripAnsi = (str: string): string => {
   return str.replace(regex, "");
 };
 
-export const getMessageAndTraceFromError = (
-  error: Error | { message?: string; stack?: string },
-): Pick<StatusDetails, "message" | "trace"> => {
+export const getMessageAndTraceFromError = (error: Error | { message?: string; stack?: string }): StatusDetails => {
   const { message, stack } = error;
+  const actual = "actual" in error ? serialize(error.actual) : undefined;
+  const expected = "expected" in error ? serialize(error.expected) : undefined;
   return {
     message: message ? stripAnsi(message) : undefined,
     trace: stack ? stripAnsi(stack) : undefined,
+    actual,
+    expected,
   };
 };
 

--- a/packages/allure-js-commons/test/sdk/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/utils.spec.ts
@@ -531,6 +531,13 @@ describe("getMessageAndTraceFromError", () => {
     });
   });
 
+  it("should ignore undefined actual value", () => {
+    const error: Error & { actual?: string } = new Error("some message");
+    error.actual = undefined;
+    const result = getMessageAndTraceFromError(error);
+    expect(result).not.toHaveProperty("actual");
+  });
+
   it("should return expected from error", () => {
     const error: Error & { expected?: string } = new Error("some message");
     error.expected = "some expected value";
@@ -538,5 +545,12 @@ describe("getMessageAndTraceFromError", () => {
     expect(result).toMatchObject({
       expected: "some expected value",
     });
+  });
+
+  it("should ignore undefined expected value", () => {
+    const error: Error & { expected?: string } = new Error("some message");
+    error.expected = undefined;
+    const result = getMessageAndTraceFromError(error);
+    expect(result).not.toHaveProperty("expected");
   });
 });

--- a/packages/allure-js-commons/test/sdk/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/utils.spec.ts
@@ -518,7 +518,7 @@ describe("getMessageAndTraceFromError", () => {
   it("should return trace from error", () => {
     const result = getMessageAndTraceFromError(new Error("some message"));
     expect(result).toMatchObject({
-      trace: expect.stringContaining("allure-js-commons/test/sdk/utils.spec.ts"),
+      trace: expect.stringMatching(/allure-js-commons.test.sdk.utils\.spec\.ts/),
     });
   });
 

--- a/packages/allure-js-commons/test/sdk/utils.spec.ts
+++ b/packages/allure-js-commons/test/sdk/utils.spec.ts
@@ -5,6 +5,7 @@ import type { FixtureResult, StepResult, TestResult } from "../../src/model.js";
 import {
   allureLabelRegexp,
   extractMetadataFromString,
+  getMessageAndTraceFromError,
   getStatusFromError,
   isAnyStepFailed,
   isMetadataTag,
@@ -502,6 +503,40 @@ describe("serialize", () => {
         [{ "": obj }, "", obj],
         [obj, "foo", "bar"],
       ]);
+    });
+  });
+});
+
+describe("getMessageAndTraceFromError", () => {
+  it("should return message from error", () => {
+    const result = getMessageAndTraceFromError(new Error("some message"));
+    expect(result).toMatchObject({
+      message: "some message",
+    });
+  });
+
+  it("should return trace from error", () => {
+    const result = getMessageAndTraceFromError(new Error("some message"));
+    expect(result).toMatchObject({
+      trace: expect.stringContaining("allure-js-commons/test/sdk/utils.spec.ts"),
+    });
+  });
+
+  it("should return actual from error", () => {
+    const error: Error & { actual?: string } = new Error("some message");
+    error.actual = "some actual value";
+    const result = getMessageAndTraceFromError(error);
+    expect(result).toMatchObject({
+      actual: "some actual value",
+    });
+  });
+
+  it("should return expected from error", () => {
+    const error: Error & { expected?: string } = new Error("some message");
+    error.expected = "some expected value";
+    const result = getMessageAndTraceFromError(error);
+    expect(result).toMatchObject({
+      expected: "some expected value",
     });
   });
 });

--- a/packages/allure-vitest/test/spec/expect.test.ts
+++ b/packages/allure-vitest/test/spec/expect.test.ts
@@ -47,4 +47,28 @@ describe("expect", () => {
       },
     ]);
   });
+
+  // this is the way vitest process errors
+  it("should add actual and expected values when regular exception is thrown", async () => {
+    const { tests } = await runVitestInlineTest(`
+    import { test, expect } from "vitest";
+
+    test("fail test", () => {
+      throw new Error("fail!")
+    });
+
+  `);
+
+    expect(tests).toHaveLength(1);
+    expect(tests).toMatchObject([
+      {
+        name: "fail test",
+        status: "broken",
+        statusDetails: {
+          expected: "undefined",
+          actual: "undefined",
+        },
+      },
+    ]);
+  });
 });

--- a/packages/allure-vitest/test/spec/expect.test.ts
+++ b/packages/allure-vitest/test/spec/expect.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { runVitestInlineTest } from "../utils.js";
+
+describe("expect", () => {
+  it("should add actual and expected values when using expect", async () => {
+    const { tests } = await runVitestInlineTest(`
+    import { test, expect } from "vitest";
+
+    test("fail test", () => {
+      expect("a value").toEqual("the other one");
+    });
+
+  `);
+
+    expect(tests).toHaveLength(1);
+    expect(tests).toMatchObject([
+      {
+        name: "fail test",
+        status: "failed",
+        statusDetails: {
+          message: "expected 'a value' to deeply equal 'the other one'",
+          expected: "the other one",
+          actual: "a value",
+        },
+      },
+    ]);
+  });
+  it("should add actual and expected values when using expect with match object", async () => {
+    const { tests } = await runVitestInlineTest(`
+    import { test, expect } from "vitest";
+
+    test("fail test", () => {
+      expect({ nested: { obj: "value", n: 123}}).toMatchObject({ nested: { obj: "some"} });
+    });
+
+  `);
+
+    expect(tests).toHaveLength(1);
+    expect(tests).toMatchObject([
+      {
+        name: "fail test",
+        status: "failed",
+        statusDetails: {
+          expected: "Object {\n" + '  "nested": Object {\n' + '    "obj": "some",\n' + "  },\n" + "}",
+          actual: "Object {\n" + '  "nested": Object {\n' + '    "obj": "value",\n' + "  },\n" + "}",
+        },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

New model fields: `statusDetails.actual` and `statusDetails.expected`
that can be used to provide `actual` and `expected` values for errors.

Actual and expected values automatically processed  when `getMessageAndTraceFromError` method is used to get 
message and trace from error (almost all the integrations)

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js