### PR TITLE
Support allure metadata in playwright test and group annotations

### DIFF
--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -198,12 +198,12 @@ export class AllureReporter implements ReporterV2 {
     }
 
     if ("annotations" in test) {
-      const annotations: Label[] = test.annotations?.filter(
-        (annotation) => annotation.type !== "skip" && annotation.type !== "fixme",
-      ).map((annotation) => ({
-        name: annotation.type,
-        value: annotation.description!,
-      }));
+      const annotations: Label[] = test.annotations
+        ?.filter((annotation) => annotation.type !== "skip" && annotation.type !== "fixme")
+        .map((annotation) => ({
+          name: annotation.type,
+          value: annotation.description!,
+        }));
       result.labels!.push(...annotations);
     }
 

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -197,6 +197,16 @@ export class AllureReporter implements ReporterV2 {
       result.labels!.push(...tags);
     }
 
+    if ("annotations" in test) {
+      const annotations: Label[] = test.annotations?.filter(
+        (annotation) => annotation.type !== "skip" && annotation.type !== "fixme",
+      ).map((annotation) => ({
+        name: annotation.type,
+        value: annotation.description!,
+      }));
+      result.labels!.push(...annotations);
+    }
+
     if (project?.name) {
       result.parameters!.push({ name: "Project", value: project.name });
     }

--- a/packages/allure-playwright/test/spec/annotations.spec.ts
+++ b/packages/allure-playwright/test/spec/annotations.spec.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { LabelName } from "allure-js-commons";
 import { runPlaywrightInlineTest } from "../utils.js";
 
 it("should support skip annotation", async () => {
@@ -55,4 +56,107 @@ it("should support fixme annotation", async () => {
       }),
     ]),
   );
+});
+
+
+it("should support allure metadata in playwright annotation", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+      import { LabelName } from 'allure-js-commons';
+      test('test full report', {
+        annotation: [
+          { type: "skip", description: "skipped via skip annotation" },
+          { type: "fixme", description: "skipped via fixme annotation" },
+          { type: "foo", description: "bar" },
+          { type: LabelName.ALLURE_ID, description: "foo" },
+          { type: LabelName.EPIC, description: "foo" },
+          { type: LabelName.FEATURE, description: "foo" },
+          { type: LabelName.LAYER, description: "foo" },
+          { type: LabelName.OWNER, description: "foo" },
+          { type: LabelName.PARENT_SUITE, description: "foo" },
+          { type: LabelName.SUB_SUITE, description: "foo" },
+          { type: LabelName.SUITE, description: "foo" },
+          { type: LabelName.SEVERITY, description: "foo" },
+          { type: LabelName.STORY, description: "foo" },
+          { type: LabelName.TAG, description: "foo" },
+        ],
+      }, async () => {
+      });
+      `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).not.toContainEqual({ name: "fixme", value: "skipped via fixme annotation" });
+  expect(tests[0].labels).not.toContainEqual({ name: "skip", value: "skipped via skip annotation" });
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+});
+
+it("should support allure metadata in playwright group annotation", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+      import { LabelName } from 'allure-js-commons';
+      test.describe(
+        'nested',
+        {
+          annotation: [
+            { type: "foo", description: "bar" },
+            { type: LabelName.EPIC, description: "foo" },
+            { type: LabelName.FEATURE, description: "foo" },
+            { type: LabelName.LAYER, description: "foo" },
+            { type: LabelName.OWNER, description: "foo" },
+            { type: LabelName.PARENT_SUITE, description: "foo" },
+            { type: LabelName.SUB_SUITE, description: "foo" },
+            { type: LabelName.SUITE, description: "foo" },
+            { type: LabelName.SEVERITY, description: "foo" },
+            { type: LabelName.STORY, description: "foo" },
+            { type: LabelName.TAG, description: "foo" },
+          ],
+        },
+        () => {
+          test('test full report 1',  async () => {
+          });
+          test('test full report 2',  async () => {
+          });
+        },
+      );
+      `,
+  });
+
+  expect(tests).toHaveLength(2);
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+
+  expect(tests[1].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
 });

--- a/packages/allure-playwright/test/spec/annotations.spec.ts
+++ b/packages/allure-playwright/test/spec/annotations.spec.ts
@@ -58,7 +58,6 @@ it("should support fixme annotation", async () => {
   );
 });
 
-
 it("should support allure metadata in playwright annotation", async () => {
   const { tests } = await runPlaywrightInlineTest({
     "sample.test.js": `

--- a/packages/allure-playwright/test/spec/runtime/legacy/tags.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/legacy/tags.spec.ts
@@ -24,7 +24,7 @@ it("sets multiply tags", async () => {
         { name: LabelName.TAG, value: "TestInfo" },
         { name: LabelName.TAG, value: "some" },
         { name: LabelName.TAG, value: "other" },
-        { name: LabelName.TAG, value: "other" },
+        { name: LabelName.TAG, value: "tags" },
       ]),
     }),
   ]);

--- a/packages/allure-playwright/test/spec/runtime/modern/tags.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/tags.spec.ts
@@ -25,7 +25,7 @@ it("sets multiply tags", async () => {
         { name: LabelName.TAG, value: "TestInfo" },
         { name: LabelName.TAG, value: "some" },
         { name: LabelName.TAG, value: "other" },
-        { name: LabelName.TAG, value: "other" },
+        { name: LabelName.TAG, value: "tags" },
       ]),
     }),
   ]);


### PR DESCRIPTION
Support allure metadata in playwright test and group annotations closes #1188 

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->
```
      import { test } from '@playwright/test';
      import { LabelName } from 'allure-js-commons';
      test('test full report', {
        annotation: [
          { type: "foo", description: "bar" },
          { type: LabelName.ALLURE_ID, description: "foo" },
          { type: LabelName.EPIC, description: "foo" },
          { type: LabelName.FEATURE, description: "foo" },
          { type: LabelName.LAYER, description: "foo" },
          { type: LabelName.OWNER, description: "foo" },
          { type: LabelName.PARENT_SUITE, description: "foo" },
          { type: LabelName.SUB_SUITE, description: "foo" },
          { type: LabelName.SUITE, description: "foo" },
          { type: LabelName.SEVERITY, description: "foo" },
          { type: LabelName.STORY, description: "foo" },
          { type: LabelName.TAG, description: "foo" },
        ],
      }, async () => {
      });
```

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js