### PR TITLE
Enchance global labels definition

### DIFF
--- a/packages/allure-cucumberjs/test/spec/globalLabels.test.ts
+++ b/packages/allure-cucumberjs/test/spec/globalLabels.test.ts
@@ -57,32 +57,36 @@ it("should handle global labels as map", async () => {
   );
 
   expect(tests).toHaveLength(2);
-  expect(tests[0].labels).toEqual(expect.arrayContaining([
-    {
-      name: "foo",
-      value: "bar",
-    },
-    {
-      name: "bar",
-      value: "beep",
-    },
-    {
-      name: "bar",
-      value: "boop",
-    },
-  ]));
-  expect(tests[1].labels).toEqual(expect.arrayContaining([
-    {
-      name: "foo",
-      value: "bar",
-    },
-    {
-      name: "bar",
-      value: "beep",
-    },
-    {
-      name: "bar",
-      value: "boop",
-    },
-  ]));
+  expect(tests[0].labels).toEqual(
+    expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]),
+  );
+  expect(tests[1].labels).toEqual(
+    expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]),
+  );
 });

--- a/packages/allure-cucumberjs/test/spec/globalLabels.test.ts
+++ b/packages/allure-cucumberjs/test/spec/globalLabels.test.ts
@@ -34,3 +34,55 @@ it("should handle global labels", async () => {
     value: "bar",
   });
 });
+
+it("should handle global labels as map", async () => {
+  const { tests } = await runCucumberInlineTest(
+    ["examples"],
+    ["examples"],
+    undefined,
+    (reporterFilePath) => `
+    module.exports = {
+      default: {
+        paths: ["./**/*.feature"],
+        format: ["summary", "${reporterFilePath}"],
+        formatOptions: {
+          globalLabels: {
+            foo: "bar",
+            bar: ["beep", "boop"],
+          }
+        }
+      }
+    }
+  `,
+  );
+
+  expect(tests).toHaveLength(2);
+  expect(tests[0].labels).toEqual(expect.arrayContaining([
+    {
+      name: "foo",
+      value: "bar",
+    },
+    {
+      name: "bar",
+      value: "beep",
+    },
+    {
+      name: "bar",
+      value: "boop",
+    },
+  ]));
+  expect(tests[1].labels).toEqual(expect.arrayContaining([
+    {
+      name: "foo",
+      value: "bar",
+    },
+    {
+      name: "bar",
+      value: "beep",
+    },
+    {
+      name: "bar",
+      value: "boop",
+    },
+  ]));
+});

--- a/packages/allure-cypress/test/spec/globalLabels.test.ts
+++ b/packages/allure-cypress/test/spec/globalLabels.test.ts
@@ -75,18 +75,20 @@ it("should handle global labels as map", async () => {
   });
 
   expect(tests).toHaveLength(1);
-  expect(tests[0].labels).toEqual(expect.arrayContaining([
-    {
-      name: "foo",
-      value: "bar",
-    },
-    {
-      name: "bar",
-      value: "beep",
-    },
-    {
-      name: "bar",
-      value: "boop",
-    },
-  ]));
+  expect(tests[0].labels).toEqual(
+    expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]),
+  );
 });

--- a/packages/allure-jasmine/test/spec/globalLabels.test.ts
+++ b/packages/allure-jasmine/test/spec/globalLabels.test.ts
@@ -55,18 +55,20 @@ it("should handle global labels as map", async () => {
   });
 
   expect(tests).toHaveLength(1);
-  expect(tests[0].labels).toEqual(expect.arrayContaining([
-    {
-      name: "foo",
-      value: "bar",
-    },
-    {
-      name: "bar",
-      value: "beep",
-    },
-    {
-      name: "bar",
-      value: "boop",
-    },
-  ]));
+  expect(tests[0].labels).toEqual(
+    expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]),
+  );
 });

--- a/packages/allure-jasmine/test/spec/globalLabels.test.ts
+++ b/packages/allure-jasmine/test/spec/globalLabels.test.ts
@@ -31,3 +31,42 @@ it("should handle global labels", async () => {
     value: "bar",
   });
 });
+
+it("should handle global labels as map", async () => {
+  const { tests } = await runJasmineInlineTest({
+    "spec/sample.spec.js": `
+    it("should pass 1", () => {
+      expect(true).toBe(true);
+    });
+  `,
+    "spec/helpers/allure.js": `
+  const AllureJasmineReporter = require("allure-jasmine");
+
+  const reporter = new AllureJasmineReporter({
+    testMode: true,
+    globalLabels: {
+      foo: "bar",
+      bar: ["beep", "boop"],
+    }
+  });
+
+  jasmine.getEnv().addReporter(reporter);
+`,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).toEqual(expect.arrayContaining([
+    {
+      name: "foo",
+      value: "bar",
+    },
+    {
+      name: "bar",
+      value: "beep",
+    },
+    {
+      name: "bar",
+      value: "boop",
+    },
+  ]));
+});

--- a/packages/allure-jest/test/spec/globalLabels.test.ts
+++ b/packages/allure-jest/test/spec/globalLabels.test.ts
@@ -32,3 +32,43 @@ it("should handle global labels", async () => {
     value: "bar",
   });
 });
+
+it("should handle global labels as map", async () => {
+  const { tests } = await runJestInlineTest({
+    "sample.spec.js": `
+      it("should pass", () => {
+        expect(true).toBe(true);
+      });
+    `,
+    "jest.config.js": ({ allureJestNodePath }) => `
+      const config = {
+        bail: false,
+        testEnvironment: "${allureJestNodePath}",
+        testEnvironmentOptions: {
+          globalLabels: {
+            foo: "bar",
+            bar: ["beep", "boop"],
+          }
+        },
+      };
+
+      module.exports = config;
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).toEqual(expect.arrayContaining([
+    {
+      name: "foo",
+      value: "bar",
+    },
+    {
+      name: "bar",
+      value: "beep",
+    },
+    {
+      name: "bar",
+      value: "boop",
+    },
+  ]));
+});

--- a/packages/allure-jest/test/spec/globalLabels.test.ts
+++ b/packages/allure-jest/test/spec/globalLabels.test.ts
@@ -57,18 +57,20 @@ it("should handle global labels as map", async () => {
   });
 
   expect(tests).toHaveLength(1);
-  expect(tests[0].labels).toEqual(expect.arrayContaining([
-    {
-      name: "foo",
-      value: "bar",
-    },
-    {
-      name: "bar",
-      value: "beep",
-    },
-    {
-      name: "bar",
-      value: "boop",
-    },
-  ]));
+  expect(tests[0].labels).toEqual(
+    expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]),
+  );
 });

--- a/packages/allure-js-commons/src/sdk/reporter/ReporterRuntime.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/ReporterRuntime.ts
@@ -4,7 +4,7 @@ import {
   type Attachment,
   type AttachmentOptions,
   type FixtureResult,
-  Label,
+  type Label,
   Stage,
   type StepResult,
   type TestResult,
@@ -27,7 +27,6 @@ import { hasSkipLabel } from "./testplan.js";
 import type {
   FixtureResultWrapper,
   FixtureType,
-  GlobalLabelsConfig,
   LinkConfig,
   ReporterRuntimeConfig,
   TestScope,
@@ -108,7 +107,14 @@ export class ReporterRuntime {
   linkConfig?: LinkConfig;
   globalLabels: Label[] = [];
 
-  constructor({ writer, listeners = [], environmentInfo, categories, links, globalLabels }: ReporterRuntimeConfig) {
+  constructor({
+    writer,
+    listeners = [],
+    environmentInfo,
+    categories,
+    links,
+    globalLabels = {},
+  }: ReporterRuntimeConfig) {
     this.writer = resolveWriter(writer);
     this.notifier = new Notifier({ listeners });
     this.categories = categories;
@@ -117,8 +123,8 @@ export class ReporterRuntime {
 
     if (Array.isArray(globalLabels)) {
       this.globalLabels = globalLabels;
-    } else if (Object.keys(globalLabels as GlobalLabelsConfig).length) {
-      this.globalLabels = Object.entries(globalLabels as GlobalLabelsConfig).flatMap(([name, value]) => {
+    } else if (Object.keys(globalLabels).length) {
+      this.globalLabels = Object.entries(globalLabels).flatMap(([name, value]) => {
         if (Array.isArray(value)) {
           return value.map((v) => ({ name, value: v }));
         }

--- a/packages/allure-js-commons/src/sdk/reporter/types.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/types.ts
@@ -47,10 +47,12 @@ export type LinkConfig<TOpts extends LinkTypeOptions = LinkTypeOptions> = Partia
 
 export type WriterDescriptor = [cls: string, ...args: readonly unknown[]] | string;
 
+export type GlobalLabelsConfig = Record<string, string | string[]>
+
 export interface ReporterConfig {
   readonly resultsDir?: string;
   readonly links?: LinkConfig;
-  readonly globalLabels?: Label[];
+  readonly globalLabels?: Label[] | GlobalLabelsConfig;
   readonly listeners?: LifecycleListener[];
   readonly environmentInfo?: EnvironmentInfo;
   readonly categories?: Category[];

--- a/packages/allure-js-commons/src/sdk/reporter/types.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/types.ts
@@ -1,6 +1,7 @@
 import type {
   FixtureResult,
   Label,
+  LabelName,
   Link,
   LinkType,
   Parameter,
@@ -47,7 +48,7 @@ export type LinkConfig<TOpts extends LinkTypeOptions = LinkTypeOptions> = Partia
 
 export type WriterDescriptor = [cls: string, ...args: readonly unknown[]] | string;
 
-export type GlobalLabelsConfig = Record<string, string | string[]>;
+export type GlobalLabelsConfig = Partial<Record<LabelName, string | string[]>> & Record<string, string | string[]>;
 
 export interface ReporterConfig {
   readonly resultsDir?: string;

--- a/packages/allure-js-commons/src/sdk/reporter/types.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/types.ts
@@ -47,7 +47,7 @@ export type LinkConfig<TOpts extends LinkTypeOptions = LinkTypeOptions> = Partia
 
 export type WriterDescriptor = [cls: string, ...args: readonly unknown[]] | string;
 
-export type GlobalLabelsConfig = Record<string, string | string[]>
+export type GlobalLabelsConfig = Record<string, string | string[]>;
 
 export interface ReporterConfig {
   readonly resultsDir?: string;

--- a/packages/allure-mocha/test/spec/framework/globalLabels.test.ts
+++ b/packages/allure-mocha/test/spec/framework/globalLabels.test.ts
@@ -31,25 +31,27 @@ describe("global labels", () => {
         globalLabels: {
           foo: "bar",
           bar: ["beep", "boop"],
-        }
+        },
       },
       ["plain-mocha", "testInSuite"],
     );
 
     expect(results.tests).toHaveLength(1);
-    expect(results.tests[0].labels).toEqual(expect.arrayContaining([
-      {
-        name: "foo",
-        value: "bar",
-      },
-      {
-        name: "bar",
-        value: "beep",
-      },
-      {
-        name: "bar",
-        value: "boop",
-      },
-    ]));
+    expect(results.tests[0].labels).toEqual(
+      expect.arrayContaining([
+        {
+          name: "foo",
+          value: "bar",
+        },
+        {
+          name: "bar",
+          value: "beep",
+        },
+        {
+          name: "bar",
+          value: "boop",
+        },
+      ]),
+    );
   });
 });

--- a/packages/allure-mocha/test/spec/framework/globalLabels.test.ts
+++ b/packages/allure-mocha/test/spec/framework/globalLabels.test.ts
@@ -1,11 +1,11 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { AllureResults } from "allure-js-commons/sdk";
 import { runMochaInlineTest } from "../../utils.js";
 
 describe("global labels", () => {
   let results: AllureResults;
 
-  beforeAll(async () => {
+  it("should handle global labels", async () => {
     results = await runMochaInlineTest(
       {
         globalLabels: [
@@ -17,13 +17,39 @@ describe("global labels", () => {
       },
       ["plain-mocha", "testInSuite"],
     );
-  });
 
-  it("should handle global labels", () => {
     expect(results.tests).toHaveLength(1);
     expect(results.tests[0].labels[0]).toEqual({
       name: "foo",
       value: "bar",
     });
+  });
+
+  it("should handle global labels as map", async () => {
+    results = await runMochaInlineTest(
+      {
+        globalLabels: {
+          foo: "bar",
+          bar: ["beep", "boop"],
+        }
+      },
+      ["plain-mocha", "testInSuite"],
+    );
+
+    expect(results.tests).toHaveLength(1);
+    expect(results.tests[0].labels).toEqual(expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]));
   });
 });

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -4,7 +4,7 @@ import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { type Label, Status, attachment, attachmentPath, logStep, parameter, step } from "allure-js-commons";
 import type { AllureResults, Category } from "allure-js-commons/sdk";
-import { MessageReader, getPosixPath, type GlobalLabelsConfig } from "allure-js-commons/sdk/reporter";
+import { type GlobalLabelsConfig, MessageReader, getPosixPath } from "allure-js-commons/sdk/reporter";
 import type { AllureMochaReporterConfig } from "../src/types.js";
 
 type MochaRunOptions = {

--- a/packages/allure-mocha/test/utils.ts
+++ b/packages/allure-mocha/test/utils.ts
@@ -4,7 +4,7 @@ import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import * as path from "node:path";
 import { type Label, Status, attachment, attachmentPath, logStep, parameter, step } from "allure-js-commons";
 import type { AllureResults, Category } from "allure-js-commons/sdk";
-import { MessageReader, getPosixPath } from "allure-js-commons/sdk/reporter";
+import { MessageReader, getPosixPath, type GlobalLabelsConfig } from "allure-js-commons/sdk/reporter";
 import type { AllureMochaReporterConfig } from "../src/types.js";
 
 type MochaRunOptions = {
@@ -15,7 +15,7 @@ type MochaRunOptions = {
   extraReporters?: AllureMochaReporterConfig["extraReporters"];
   inputFiles?: string[];
   outputFiles?: Record<string, string>;
-  globalLabels?: Label[];
+  globalLabels?: Label[] | GlobalLabelsConfig;
 };
 
 type TestPlanEntryFixture = {

--- a/packages/allure-playwright/test/spec/globalLabels.test.ts
+++ b/packages/allure-playwright/test/spec/globalLabels.test.ts
@@ -34,18 +34,20 @@ it("should handle global labels", async () => {
   });
 
   expect(tests).toHaveLength(1);
-  expect(tests[0].labels).toEqual(expect.arrayContaining([
-    {
-      name: "foo",
-      value: "bar",
-    },
-    {
-      name: "bar",
-      value: "beep",
-    },
-    {
-      name: "bar",
-      value: "boop",
-    },
-  ]));
+  expect(tests[0].labels).toEqual(
+    expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]),
+  );
 });

--- a/packages/allure-playwright/test/spec/globalLabels.test.ts
+++ b/packages/allure-playwright/test/spec/globalLabels.test.ts
@@ -16,12 +16,10 @@ it("should handle global labels", async () => {
              require.resolve("allure-playwright"),
              {
                resultsDir: "./allure-results",
-               globalLabels: [
-                 {
-                   name: "foo",
-                   value: "bar"
+                 globalLabels: {
+                   foo: "bar",
+                   bar: ["beep", "boop"],
                  }
-               ]
              },
            ],
            ["dot"],
@@ -36,8 +34,18 @@ it("should handle global labels", async () => {
   });
 
   expect(tests).toHaveLength(1);
-  expect(tests[0].labels[0]).toEqual({
-    name: "foo",
-    value: "bar",
-  });
+  expect(tests[0].labels).toEqual(expect.arrayContaining([
+    {
+      name: "foo",
+      value: "bar",
+    },
+    {
+      name: "bar",
+      value: "beep",
+    },
+    {
+      name: "bar",
+      value: "boop",
+    },
+  ]));
 });

--- a/packages/allure-vitest/test/spec/globalLabels.test.ts
+++ b/packages/allure-vitest/test/spec/globalLabels.test.ts
@@ -23,12 +23,10 @@ describe("global labels", () => {
                   "allure-vitest/reporter",
                   {
                     resultsDir: "allure-results",
-                    globalLabels: [
-                      {
-                        name: "foo",
-                        value: "bar"
+                      globalLabels: {
+                        foo: "bar",
+                        bar: ["beep", "boop"],
                       }
-                    ]
                   }
                 ],
               ],
@@ -39,9 +37,19 @@ describe("global labels", () => {
     );
 
     expect(tests).toHaveLength(1);
-    expect(tests[0].labels[0]).toEqual({
-      name: "foo",
-      value: "bar",
-    });
+    expect(tests[0].labels).toEqual(expect.arrayContaining([
+      {
+        name: "foo",
+        value: "bar",
+      },
+      {
+        name: "bar",
+        value: "beep",
+      },
+      {
+        name: "bar",
+        value: "boop",
+      },
+    ]));
   });
 });

--- a/packages/allure-vitest/test/spec/globalLabels.test.ts
+++ b/packages/allure-vitest/test/spec/globalLabels.test.ts
@@ -37,19 +37,21 @@ describe("global labels", () => {
     );
 
     expect(tests).toHaveLength(1);
-    expect(tests[0].labels).toEqual(expect.arrayContaining([
-      {
-        name: "foo",
-        value: "bar",
-      },
-      {
-        name: "bar",
-        value: "beep",
-      },
-      {
-        name: "bar",
-        value: "boop",
-      },
-    ]));
+    expect(tests[0].labels).toEqual(
+      expect.arrayContaining([
+        {
+          name: "foo",
+          value: "bar",
+        },
+        {
+          name: "bar",
+          value: "beep",
+        },
+        {
+          name: "bar",
+          value: "boop",
+        },
+      ]),
+    );
   });
 });


### PR DESCRIPTION
### Context

Previously it was possible to use array of `Label` type to configure global labels. Now users can define them by `Record<string, string | string[]>` as well.

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
