### PR TITLE
Support allure metadata in playwright test and group annotations v2.0

### DIFF
--- a/packages/allure-js-commons/src/sdk/index.ts
+++ b/packages/allure-js-commons/src/sdk/index.ts
@@ -17,6 +17,7 @@ export {
   getStatusFromError,
   getMessageAndTraceFromError,
   isMetadataTag,
+  getMetadataLabel,
   extractMetadataFromString,
   isAllStepsEnded,
   isAnyStepFailed,

--- a/packages/allure-js-commons/src/sdk/utils.ts
+++ b/packages/allure-js-commons/src/sdk/utils.ts
@@ -73,6 +73,7 @@ type AllureTitleMetadataMatch = RegExpMatchArray & {
   };
 };
 
+export const allureMetadataRegexp = /(?:^|\s)@?allure\.(?<type>\S+)$/;
 export const allureTitleMetadataRegexp = /(?:^|\s)@?allure\.(?<type>\S+)[:=]("[^"]+"|'[^']+'|`[^`]+`|\S+)/;
 export const allureTitleMetadataRegexpGlobal = new RegExp(allureTitleMetadataRegexp, "g");
 export const allureIdRegexp = /(?:^|\s)@?allure\.id[:=](?<id>\S+)/;
@@ -96,7 +97,23 @@ export const getValueFromAllureTitleMetadataMatch = (match: AllureTitleMetadataM
 };
 
 export const isMetadataTag = (tag: string) => {
-  return allureTitleMetadataRegexp.test(tag);
+  return allureMetadataRegexp.test(tag);
+};
+
+export const getMetadataLabel = (tag: string, value?: string): Label | undefined => {
+  const match = tag.match(allureMetadataRegexp);
+  const type = match?.groups?.type;
+
+  if (!type) {
+    return undefined;
+  }
+
+  const [subtype, name] = type.split(".");
+
+  return {
+    name: subtype === "id" ? LabelName.ALLURE_ID : name,
+    value: value ?? "",
+  };
 };
 
 export const extractMetadataFromString = (

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -198,12 +198,12 @@ export class AllureReporter implements ReporterV2 {
     }
 
     if ("annotations" in test) {
-      const annotations: Label[] = test.annotations?.filter(
-        (annotation) => annotation.type !== "skip" && annotation.type !== "fixme",
-      ).map((annotation) => ({
-        name: annotation.type,
-        value: annotation.description!,
-      }));
+      const annotations: Label[] = test.annotations
+        ?.filter((annotation) => annotation.type !== "skip" && annotation.type !== "fixme")
+        .map((annotation) => ({
+          name: annotation.type,
+          value: annotation.description!,
+        }));
       result.labels!.push(...annotations);
     }
 

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -197,6 +197,16 @@ export class AllureReporter implements ReporterV2 {
       result.labels!.push(...tags);
     }
 
+    if ("annotations" in test) {
+      const annotations: Label[] = test.annotations?.filter(
+        (annotation) => annotation.type !== "skip" && annotation.type !== "fixme",
+      ).map((annotation) => ({
+        name: annotation.type,
+        value: annotation.description!,
+      }));
+      result.labels!.push(...annotations);
+    }
+
     if (project?.name) {
       result.parameters!.push({ name: "Project", value: project.name });
     }

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -33,6 +33,7 @@ import {
   ReporterRuntime,
   createDefaultWriter,
   escapeRegExp,
+  formatLink,
   getEnvironmentLabels,
   getFrameworkLabel,
   getHostLabel,
@@ -212,12 +213,22 @@ export class AllureReporter implements ReporterV2 {
         }
 
         if (annotation.type === "issue") {
-          result.links!.push({ type: LinkType.ISSUE, url: annotation.description! });
+          result.links!.push(
+            formatLink(this.options.links ?? {}, {
+              type: LinkType.ISSUE,
+              url: annotation.description!,
+            }),
+          );
           continue;
         }
 
         if (annotation.type === "tms" || annotation.type === "test_key") {
-          result.links!.push({ type: LinkType.TMS, url: annotation.description! });
+          result.links!.push(
+            formatLink(this.options.links ?? {}, {
+              type: LinkType.TMS,
+              url: annotation.description!,
+            }),
+          );
           continue;
         }
 

--- a/packages/allure-playwright/test/spec/annotations.spec.ts
+++ b/packages/allure-playwright/test/spec/annotations.spec.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { LabelName } from "allure-js-commons";
 import { runPlaywrightInlineTest } from "../utils.js";
 
 it("should support skip annotation", async () => {
@@ -55,4 +56,107 @@ it("should support fixme annotation", async () => {
       }),
     ]),
   );
+});
+
+
+it("should support allure metadata in playwright annotation", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+      import { LabelName } from 'allure-js-commons';
+      test('test full report', {
+        annotation: [
+          { type: "skip", description: "skipped via skip annotation" },
+          { type: "fixme", description: "skipped via fixme annotation" },
+          { type: "foo", description: "bar" },
+          { type: LabelName.ALLURE_ID, description: "foo" },
+          { type: LabelName.EPIC, description: "foo" },
+          { type: LabelName.FEATURE, description: "foo" },
+          { type: LabelName.LAYER, description: "foo" },
+          { type: LabelName.OWNER, description: "foo" },
+          { type: LabelName.PARENT_SUITE, description: "foo" },
+          { type: LabelName.SUB_SUITE, description: "foo" },
+          { type: LabelName.SUITE, description: "foo" },
+          { type: LabelName.SEVERITY, description: "foo" },
+          { type: LabelName.STORY, description: "foo" },
+          { type: LabelName.TAG, description: "foo" },
+        ],
+      }, async () => {
+      });
+      `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].labels).not.toContainEqual({ name: "fixme", value: "skipped via fixme annotation" });
+  expect(tests[0].labels).not.toContainEqual({ name: "skip", value: "skipped via skip annotation" });
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+});
+
+it("should support allure metadata in playwright group annotation", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+      import { LabelName } from 'allure-js-commons';
+      test.describe(
+        'nested',
+        {
+          annotation: [
+            { type: "foo", description: "bar" },
+            { type: LabelName.EPIC, description: "foo" },
+            { type: LabelName.FEATURE, description: "foo" },
+            { type: LabelName.LAYER, description: "foo" },
+            { type: LabelName.OWNER, description: "foo" },
+            { type: LabelName.PARENT_SUITE, description: "foo" },
+            { type: LabelName.SUB_SUITE, description: "foo" },
+            { type: LabelName.SUITE, description: "foo" },
+            { type: LabelName.SEVERITY, description: "foo" },
+            { type: LabelName.STORY, description: "foo" },
+            { type: LabelName.TAG, description: "foo" },
+          ],
+        },
+        () => {
+          test('test full report 1',  async () => {
+          });
+          test('test full report 2',  async () => {
+          });
+        },
+      );
+      `,
+  });
+
+  expect(tests).toHaveLength(2);
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+
+  expect(tests[1].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
 });

--- a/packages/allure-playwright/test/spec/annotations.spec.ts
+++ b/packages/allure-playwright/test/spec/annotations.spec.ts
@@ -58,7 +58,6 @@ it("should support fixme annotation", async () => {
   );
 });
 
-
 it("should support allure metadata in playwright annotation", async () => {
   const { tests } = await runPlaywrightInlineTest({
     "sample.test.js": `

--- a/packages/allure-playwright/test/spec/annotations.spec.ts
+++ b/packages/allure-playwright/test/spec/annotations.spec.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest";
-import { LabelName } from "allure-js-commons";
+import { LabelName, LinkType } from "allure-js-commons";
 import { runPlaywrightInlineTest } from "../utils.js";
 
 it("should support skip annotation", async () => {
@@ -67,18 +67,13 @@ it("should support allure metadata in playwright annotation", async () => {
         annotation: [
           { type: "skip", description: "skipped via skip annotation" },
           { type: "fixme", description: "skipped via fixme annotation" },
-          { type: "foo", description: "bar" },
-          { type: LabelName.ALLURE_ID, description: "foo" },
-          { type: LabelName.EPIC, description: "foo" },
-          { type: LabelName.FEATURE, description: "foo" },
-          { type: LabelName.LAYER, description: "foo" },
-          { type: LabelName.OWNER, description: "foo" },
-          { type: LabelName.PARENT_SUITE, description: "foo" },
-          { type: LabelName.SUB_SUITE, description: "foo" },
-          { type: LabelName.SUITE, description: "foo" },
-          { type: LabelName.SEVERITY, description: "foo" },
-          { type: LabelName.STORY, description: "foo" },
-          { type: LabelName.TAG, description: "foo" },
+          { type: "@allure.id", description: "foo" },
+          { type: "@allure.label.foo", description: "bar" },
+          { type: "allure.label.epic", description: "baz" },
+          { type: "issue", description: "anything 2" },
+          { type: "tms", description: "anything 3" },
+          { type: "test_key", description: "anything 4" },
+          { type: "description", description: "new test description" },
         ],
       }, async () => {
       });
@@ -86,20 +81,59 @@ it("should support allure metadata in playwright annotation", async () => {
   });
 
   expect(tests).toHaveLength(1);
-  expect(tests[0].labels).not.toContainEqual({ name: "fixme", value: "skipped via fixme annotation" });
+  expect(tests[0].description).toBe("new test description");
+  expect(tests[0].labels).not.toContainEqual({ name: "description", value: "new test description" });
   expect(tests[0].labels).not.toContainEqual({ name: "skip", value: "skipped via skip annotation" });
-  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].labels).not.toContainEqual({
+    name: "fixme",
+    value: "skipped via fixme annotation",
+  });
   expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "baz" });
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.ISSUE, url: "anything 2" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.TMS, url: "anything 3" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.TMS, url: "anything 4" });
+});
+
+it("should append unknown playwright annotation to the test description", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+      import { LabelName } from 'allure-js-commons';
+      test('test full report', {
+        annotation: [
+          { type: "skip", description: "skipped via skip annotation" },
+          { type: "fixme", description: "skipped via fixme annotation" },
+          { type: "@allure.id", description: "foo" },
+          { type: "@allure.label.foo", description: "bar" },
+          { type: "allure.label.epic", description: "baz" },
+          { type: "issue", description: "anything 2" },
+          { type: "tms", description: "anything 3" },
+          { type: "test_key", description: "anything 4" },
+          { type: "description", description: "new test description" },
+          { type: "unknown", description: "unknown annotation" },
+        ],
+      }, async () => {
+      });
+      `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].description).toBe("new test description");
+  expect(tests[0].labels).not.toContainEqual({ name: "description", value: "new test description" });
+  expect(tests[0].labels).not.toContainEqual({ name: "skip", value: "skipped via skip annotation" });
+  expect(tests[0].labels).not.toContainEqual({
+    name: "fixme",
+    value: "skipped via fixme annotation",
+  });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "baz" });
+  expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.ISSUE, url: "anything 2" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.TMS, url: "anything 3" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.TMS, url: "anything 4" });
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "unknown: unknown annotation" }));
 });
 
 it("should support allure metadata in playwright group annotation", async () => {
@@ -111,17 +145,16 @@ it("should support allure metadata in playwright group annotation", async () => 
         'nested',
         {
           annotation: [
-            { type: "foo", description: "bar" },
-            { type: LabelName.EPIC, description: "foo" },
-            { type: LabelName.FEATURE, description: "foo" },
-            { type: LabelName.LAYER, description: "foo" },
-            { type: LabelName.OWNER, description: "foo" },
-            { type: LabelName.PARENT_SUITE, description: "foo" },
-            { type: LabelName.SUB_SUITE, description: "foo" },
-            { type: LabelName.SUITE, description: "foo" },
-            { type: LabelName.SEVERITY, description: "foo" },
-            { type: LabelName.STORY, description: "foo" },
-            { type: LabelName.TAG, description: "foo" },
+            { type: "skip", description: "skipped via skip annotation" },
+            { type: "fixme", description: "skipped via fixme annotation" },
+            { type: "@allure.id", description: "foo" },
+            { type: "@allure.label.foo", description: "bar" },
+            { type: "allure.label.epic", description: "baz" },
+            { type: "issue", description: "anything 2" },
+            { type: "tms", description: "anything 3" },
+            { type: "test_key", description: "anything 4" },
+            { type: "description", description: "new test description" },
+            { type: "unknown", description: "unknown annotation" },
           ],
         },
         () => {
@@ -135,27 +168,32 @@ it("should support allure metadata in playwright group annotation", async () => 
   });
 
   expect(tests).toHaveLength(2);
+  expect(tests[0].description).toBe("new test description");
+  expect(tests[0].labels).not.toContainEqual({ name: "description", value: "new test description" });
+  expect(tests[0].labels).not.toContainEqual({ name: "skip", value: "skipped via skip annotation" });
+  expect(tests[0].labels).not.toContainEqual({
+    name: "fixme",
+    value: "skipped via fixme annotation",
+  });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "baz" });
   expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
-  expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
-
+  expect(tests[0].links).toContainEqual({ type: LinkType.ISSUE, url: "anything 2" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.TMS, url: "anything 3" });
+  expect(tests[0].links).toContainEqual({ type: LinkType.TMS, url: "anything 4" });
+  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "unknown: unknown annotation" }));
+  expect(tests[1].description).toBe("new test description");
+  expect(tests[1].labels).not.toContainEqual({ name: "description", value: "new test description" });
+  expect(tests[1].labels).not.toContainEqual({ name: "skip", value: "skipped via skip annotation" });
+  expect(tests[1].labels).not.toContainEqual({
+    name: "fixme",
+    value: "skipped via fixme annotation",
+  });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+  expect(tests[1].labels).toContainEqual({ name: LabelName.EPIC, value: "baz" });
   expect(tests[1].labels).toContainEqual({ name: "foo", value: "bar" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
-  expect(tests[1].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
+  expect(tests[1].links).toContainEqual({ type: LinkType.ISSUE, url: "anything 2" });
+  expect(tests[1].links).toContainEqual({ type: LinkType.TMS, url: "anything 3" });
+  expect(tests[1].links).toContainEqual({ type: LinkType.TMS, url: "anything 4" });
+  expect(tests[1].steps).toContainEqual(expect.objectContaining({ name: "unknown: unknown annotation" }));
 });

--- a/packages/allure-playwright/test/spec/runtime/legacy/tags.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/legacy/tags.spec.ts
@@ -24,7 +24,7 @@ it("sets multiply tags", async () => {
         { name: LabelName.TAG, value: "TestInfo" },
         { name: LabelName.TAG, value: "some" },
         { name: LabelName.TAG, value: "other" },
-        { name: LabelName.TAG, value: "other" },
+        { name: LabelName.TAG, value: "tags" },
       ]),
     }),
   ]);

--- a/packages/allure-playwright/test/spec/runtime/modern/tags.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/tags.spec.ts
@@ -25,7 +25,7 @@ it("sets multiply tags", async () => {
         { name: LabelName.TAG, value: "TestInfo" },
         { name: LabelName.TAG, value: "some" },
         { name: LabelName.TAG, value: "other" },
-        { name: LabelName.TAG, value: "other" },
+        { name: LabelName.TAG, value: "tags" },
       ]),
     }),
   ]);

--- a/packages/allure-playwright/vitest.config.ts
+++ b/packages/allure-playwright/vitest.config.ts
@@ -4,7 +4,8 @@ export default defineConfig({
   test: {
     dir: "./test/spec",
     fileParallelism: false,
-    testTimeout: 25000,
+    // testTimeout: 25000,
+    testTimeout: Infinity,
     setupFiles: ["./vitest-setup.ts"],
     reporters: ["verbose", ["allure-vitest/reporter", { resultsDir: "./out/allure-results" }]],
     typecheck: {

--- a/packages/allure-playwright/vitest.config.ts
+++ b/packages/allure-playwright/vitest.config.ts
@@ -4,8 +4,7 @@ export default defineConfig({
   test: {
     dir: "./test/spec",
     fileParallelism: false,
-    // testTimeout: 25000,
-    testTimeout: Infinity,
+    testTimeout: 25000,
     setupFiles: ["./vitest-setup.ts"],
     reporters: ["verbose", ["allure-vitest/reporter", { resultsDir: "./out/allure-results" }]],
     typecheck: {


### PR DESCRIPTION

<!---
Thank you so much for sending us a pull request! 

Make sure you have a clear name for your pull request. 
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context
<!---
Describe the problem or feature in addition to a link to the issues
-->

The PR is a just continuation of #1220.

After a short discussion with @baev, we decided to divide Playwright annotations on 3 different types:

- well-known annotations such as `fixme`, `issue`, `skip` etc., which should be processed in a certain way
- Allure Metadata annotations which starts with `@allure.` or `allure.` prefix (e.g. `@allure.id` or `allure.label.epic`) which appears in the labels
- rest annotations which should be presented as empty steps with name matching `annotation name: annotation description` pattern

#### Checklist
- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
