### PR TITLE
Generate provenance for published packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
@@ -21,6 +23,6 @@ jobs:
         run: |
           yarn install
           yarn build
-      - run: yarn workspaces foreach -Avv --no-private npm publish
+      - run: yarn workspaces foreach -Avv --no-private npm publish --provenance --tolerate-republish
         env:
           YARN_NPM_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}


### PR DESCRIPTION
The PR enabled the provenance statements for the published npm packages.

#### Extra changes

  - add `--tolerate-republish` to avoid `workspace foreach` exit early with a failure in case one of the packages is already published