### PR TITLE
Display skipped Vitest tests in report

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,10 +25,16 @@ $ git clone git@github.com:your-username/allure-js.git
 
 Note that latest NodeJS LTS is required (the most recent is 14.17.4) to proceed.
 
+Ensure you have `yarn` installed globally:
+```bash
+npm install --global yarn
+```
+
+
 Then install core dependencies:
 
 ```bash
-npm install
+yarn install
 ```
 
 Then build and link all packages:

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -45,11 +45,6 @@ export default class AllureVitestReporter implements Reporter {
   }
 
   async handleTask(task: Task) {
-    // do not report skipped tests
-    if (task.mode === "skip" && !task.result) {
-      return;
-    }
-
     if (task.type === "suite") {
       for (const innerTask of task.tasks) {
         await this.handleTask(innerTask);
@@ -125,6 +120,11 @@ export default class AllureVitestReporter implements Reporter {
           result.stage = Stage.PENDING;
           break;
         }
+      }
+
+      if (task.mode === "skip" && !task.result) {
+        result.status = Status.SKIPPED;
+        result.stage = Stage.PENDING;
       }
     });
     this.allureReporterRuntime!.stopTest(testUuid, { duration: task.result?.duration ?? 0 });

--- a/packages/allure-vitest/test/spec/simple.test.ts
+++ b/packages/allure-vitest/test/spec/simple.test.ts
@@ -64,7 +64,7 @@ describe("test status", () => {
     expect(tests[0].stage).toBe(Stage.PENDING);
   });
 
-  it("shouldn't report skipped tests and suites", async () => {
+  it("should report skipped tests and suites", async () => {
     const { tests } = await runVitestInlineTest({
       "sample.test.ts": `
     import { describe, test } from "vitest";
@@ -77,6 +77,10 @@ describe("test status", () => {
     `,
     });
 
-    expect(tests).toHaveLength(0);
+    expect(tests).toHaveLength(2);
+    expect(tests[0].status).toBe(Status.SKIPPED);
+    expect(tests[0].stage).toBe(Stage.PENDING);
+    expect(tests[1].status).toBe(Status.SKIPPED);
+    expect(tests[1].stage).toBe(Stage.PENDING);
   });
 });


### PR DESCRIPTION
### Context
When skipping tests using `it.skip` or `describe.skip` in Vitest, the skipped tests are not appearing in the test report as expected. This change includes the tests visually in the generated report, but does not impact the calculation of the pass/fail rate.

Before:
<img width="2367" height="701" alt="Screenshot 2025-10-27 at 10 17 39 AM" src="https://github.com/user-attachments/assets/490f2cdd-7e90-46b5-bc0e-578490d16eb7" />

After:
<img width="2363" height="707" alt="Screenshot 2025-10-27 at 10 18 17 AM" src="https://github.com/user-attachments/assets/7d0a6736-c770-463f-bae5-e1ea2ab67f45" />


#### Checklist
- [X] [Sign Allure CLA][cla]
- [X] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
