### PR TITLE
fix(playwright): keep runtime steps in execution order

### DIFF
--- a/packages/allure-js-commons/test/sdk/reporter/ReporterRuntime.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/ReporterRuntime.spec.ts
@@ -439,6 +439,78 @@ describe("ReporterRuntime", () => {
       );
     });
 
+    it("should keep nested runtime steps in source order when using applyRuntimeMessages only", () => {
+      const writer = mockWriter();
+      const runtime = new ReporterRuntime({ writer });
+      const rootUuid = runtime.startTest({ name: "steps" });
+
+      runtime.applyRuntimeMessages(rootUuid, [
+        { type: "step_start", data: { name: "1: lambda", start: 10 } },
+        { type: "step_start", data: { name: "1.1: log", start: 11 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 11 } },
+        { type: "step_start", data: { name: "1.2: lambda", start: 12 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 13 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 14 } },
+        { type: "step_start", data: { name: "2: lambda", start: 20 } },
+        { type: "step_start", data: { name: "2.1: log", start: 21 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 21 } },
+        { type: "step_start", data: { name: "2.2: lambda", start: 22 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 23 } },
+        { type: "step_start", data: { name: "2.3: log", start: 24 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 24 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 25 } },
+      ]);
+
+      runtime.stopTest(rootUuid);
+      runtime.writeTest(rootUuid);
+
+      const [testResult] = writer.writeResult.mock.calls[0];
+
+      expect(testResult.steps.map((step) => step.name)).toEqual(["1: lambda", "2: lambda"]);
+      expect(testResult.steps[0].steps.map((step) => step.name)).toEqual(["1.1: log", "1.2: lambda"]);
+      expect(testResult.steps[1].steps.map((step) => step.name)).toEqual(["2.1: log", "2.2: lambda", "2.3: log"]);
+    });
+
+    it("should append buffered runtime log steps after already-stopped lambda steps in the hybrid flow", () => {
+      const writer = mockWriter();
+      const runtime = new ReporterRuntime({ writer });
+      const rootUuid = runtime.startTest({ name: "steps" });
+
+      const firstLambdaUuid = runtime.startStep(rootUuid, undefined, { name: "1: lambda", start: 10 });
+      const firstNestedLambdaUuid = runtime.startStep(rootUuid, firstLambdaUuid, { name: "1.2: lambda", start: 12 });
+      runtime.stopStep(firstNestedLambdaUuid!, { stop: 13 });
+      runtime.stopStep(firstLambdaUuid!, { stop: 14 });
+
+      const secondLambdaUuid = runtime.startStep(rootUuid, undefined, { name: "2: lambda", start: 20 });
+      const secondNestedLambdaUuid = runtime.startStep(rootUuid, secondLambdaUuid, { name: "2.2: lambda", start: 22 });
+      runtime.stopStep(secondNestedLambdaUuid!, { stop: 23 });
+      runtime.stopStep(secondLambdaUuid!, { stop: 24 });
+
+      runtime.applyRuntimeMessages(rootUuid, [
+        { type: "step_start", data: { name: "1.1: log", start: 11 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 11 } },
+        { type: "step_start", data: { name: "2.1: log", start: 21 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 21 } },
+        { type: "step_start", data: { name: "2.3: log", start: 25 } },
+        { type: "step_stop", data: { status: Status.PASSED, stop: 25 } },
+      ]);
+
+      runtime.stopTest(rootUuid);
+      runtime.writeTest(rootUuid);
+
+      const [testResult] = writer.writeResult.mock.calls[0];
+
+      expect(testResult.steps.map((step) => step.name)).toEqual([
+        "1: lambda",
+        "2: lambda",
+        "1.1: log",
+        "2.1: log",
+        "2.3: log",
+      ]);
+      expect(testResult.steps[0].steps.map((step) => step.name)).toEqual(["1.2: lambda"]);
+      expect(testResult.steps[1].steps.map((step) => step.name)).toEqual(["2.2: lambda"]);
+    });
+
     it("should ignore results with ALLURE_TESTPLAN_SKIP label", () => {
       const writer = mockWriter();
       const runtime = new ReporterRuntime({ writer });

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -920,6 +920,10 @@ export class AllureReporter implements ReporterV2 {
   }
 
   private isEmptyPassedHookRoot(step: StepResult) {
+    if (this.options.detail) {
+      return false;
+    }
+
     return (
       (step.name === BEFORE_HOOKS_ROOT_STEP_TITLE || step.name === AFTER_HOOKS_ROOT_STEP_TITLE) &&
       step.steps.length === 0 &&

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -76,6 +76,8 @@ export class AllureReporter implements ReporterV2 {
   private readonly attachmentTargets: Map<string, AttachmentTarget[]> = new Map();
   private beforeHooksStepsStack: Map<string, ShallowStepsStack> = new Map();
   private afterHooksStepsStack: Map<string, ShallowStepsStack> = new Map();
+  private pendingAttachmentTasks: Map<string, Promise<void>[]> = new Map();
+  private readonly attachmentTargetByStep = new WeakMap<TestStep, AttachmentTarget>();
   private readonly pwStepUuid = new WeakMap<TestStep, string>();
   private readonly testPlan = parseTestPlan();
 
@@ -296,6 +298,257 @@ export class AllureReporter implements ReporterV2 {
     return stack;
   }
 
+  private queueAttachmentTask(testId: string, task: Promise<void>) {
+    const tasks = this.pendingAttachmentTasks.get(testId) ?? [];
+    tasks.push(task);
+    this.pendingAttachmentTasks.set(testId, tasks);
+  }
+
+  private async flushAttachmentTasks(testId: string) {
+    const tasks = this.pendingAttachmentTasks.get(testId) ?? [];
+
+    this.pendingAttachmentTasks.delete(testId);
+
+    if (tasks.length > 0) {
+      await Promise.all(tasks);
+    }
+  }
+
+  private recordAttachmentTarget(testId: string, target: AttachmentTarget) {
+    const targets = this.attachmentTargets.get(testId) ?? [];
+    targets.push(target);
+    this.attachmentTargets.set(testId, targets);
+  }
+
+  private getHookStepsStack(testId: string, hookStep: AttachStack) {
+    return hookStep.hookScope === "before"
+      ? this.beforeHooksStepsStack.get(testId)
+      : this.afterHooksStepsStack.get(testId);
+  }
+
+  private removeHookAttachmentPlaceholder(steps: StepResult[], stepUuid: string): boolean {
+    const index = steps.findIndex((step) => step.uuid === stepUuid);
+
+    if (index !== -1) {
+      steps.splice(index, 1);
+      return true;
+    }
+
+    for (const step of steps) {
+      if (this.removeHookAttachmentPlaceholder(step.steps, stepUuid)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private addAttachmentToHookStep(
+    test: TestCase,
+    hookStep: AttachStack,
+    attachment: { name: string; contentType: string; path?: string; body?: Buffer },
+  ) {
+    const targetStack = this.getHookStepsStack(test.id, hookStep);
+
+    if (!targetStack) {
+      return;
+    }
+
+    const stepResult = targetStack.findStepByUuid(hookStep.uuid);
+
+    if (!stepResult) {
+      return;
+    }
+
+    const fileName = targetStack.addAttachment(attachment, this.allureRuntime!.writer);
+    stepResult.attachments.push({
+      name: attachment.name,
+      type: attachment.contentType,
+      source: fileName,
+    });
+  }
+
+  private addRuntimeAttachmentToHookStack(
+    targetStack: ShallowStepsStack,
+    attachment: { name: string; contentType: string; path?: string; body?: Buffer },
+    options?: { wrapInStep?: boolean; timestamp?: number },
+  ) {
+    const currentStep = targetStack.currentStep();
+
+    if (!currentStep) {
+      return;
+    }
+
+    const addAttachment = (stepResult: StepResult) => {
+      const fileName = targetStack.addAttachment(attachment, this.allureRuntime!.writer);
+      stepResult.attachments.push({
+        name: attachment.name,
+        type: attachment.contentType,
+        source: fileName,
+      });
+    };
+
+    if (options?.wrapInStep) {
+      targetStack.startStep({
+        name: attachment.name,
+        start: options.timestamp,
+      });
+      addAttachment(targetStack.currentStep()!);
+      targetStack.stopStep({ stop: options.timestamp });
+      return;
+    }
+
+    addAttachment(currentStep);
+  }
+
+  private processHookRuntimeMessage(
+    test: TestCase,
+    testUuid: string,
+    hookStep: AttachStack,
+    attachment: { name: string; contentType: string; path?: string; body?: Buffer },
+  ) {
+    if (!attachment.body) {
+      return false;
+    }
+
+    const targetStack = this.getHookStepsStack(test.id, hookStep);
+
+    if (!targetStack) {
+      return false;
+    }
+
+    this.removeHookAttachmentPlaceholder(targetStack.steps, hookStep.uuid);
+
+    const message = JSON.parse(attachment.body.toString()) as RuntimeMessage;
+
+    switch (message.type) {
+      case "step_start":
+        targetStack.startStep({ ...message.data });
+        return true;
+      case "step_stop": {
+        const currentStep = targetStack.currentStep();
+
+        if (!currentStep) {
+          return false;
+        }
+
+        targetStack.updateStep((stepResult) => {
+          if (message.data.status && !stepResult.status) {
+            stepResult.status = message.data.status;
+          }
+
+          if (message.data.statusDetails) {
+            stepResult.statusDetails = { ...stepResult.statusDetails, ...message.data.statusDetails };
+          }
+        });
+        targetStack.stopStep({ stop: message.data.stop });
+        return true;
+      }
+      case "step_metadata": {
+        const currentStep = targetStack.currentStep();
+
+        if (!currentStep) {
+          return false;
+        }
+
+        if (message.data.name) {
+          currentStep.name = message.data.name;
+        }
+
+        currentStep.parameters.push(...(message.data.parameters ?? []));
+        return true;
+      }
+      case "attachment_content":
+        this.addRuntimeAttachmentToHookStack(
+          targetStack,
+          {
+            name: message.data.name,
+            body: Buffer.from(message.data.content, message.data.encoding),
+            contentType: message.data.contentType,
+          },
+          {
+            wrapInStep: message.data.wrapInStep,
+            timestamp: message.data.timestamp,
+          },
+        );
+        return true;
+      case "attachment_path":
+        this.addRuntimeAttachmentToHookStack(
+          targetStack,
+          {
+            name: message.data.name,
+            path: message.data.path,
+            contentType: message.data.contentType,
+          },
+          {
+            wrapInStep: message.data.wrapInStep,
+            timestamp: message.data.timestamp,
+          },
+        );
+        return true;
+      default:
+        this.queueAttachmentTask(test.id, this.processAttachment(testUuid, undefined, attachment));
+        return true;
+    }
+  }
+
+  private shouldProcessAttachmentAtTestEnd(attachment: { name: string; contentType: string; path?: string }) {
+    if (attachment.name.match(diffEndRegexp)) {
+      return true;
+    }
+
+    if (attachment.contentType === "application/vnd.allure.playwright-trace") {
+      return true;
+    }
+
+    return attachment.name === "trace" && attachment.contentType === "application/zip";
+  }
+
+  private processStepEndAttachments(test: TestCase, step: TestStep) {
+    const testUuid = this.allureResultsUuids.get(test.id)!;
+    const stepAttachments = step.attachments ?? [];
+    const stepInfo = this.attachmentTargetByStep.get(step);
+    const hasExplicitParent = Boolean(stepInfo?.hookStep || stepInfo?.stepUuid);
+
+    if (stepAttachments.length === 0) {
+      if (stepInfo) {
+        this.recordAttachmentTarget(test.id, stepInfo);
+      }
+      return;
+    }
+
+    for (const attachment of stepAttachments) {
+      const isRuntimeMessage = attachment.contentType === ALLURE_RUNTIME_MESSAGE_CONTENT_TYPE;
+      const attachmentTarget: AttachmentTarget = {
+        ...stepInfo,
+        name: attachment.name,
+      };
+
+      this.recordAttachmentTarget(test.id, attachmentTarget);
+
+      if (this.shouldProcessAttachmentAtTestEnd(attachment) || (!isRuntimeMessage && !hasExplicitParent)) {
+        continue;
+      }
+
+      attachmentTarget.processedAtStepEnd = true;
+
+      if (stepInfo?.hookStep && isRuntimeMessage) {
+        if (!this.processHookRuntimeMessage(test, testUuid, stepInfo.hookStep, attachment)) {
+          attachmentTarget.processedAtStepEnd = false;
+        }
+        continue;
+      }
+
+      if (stepInfo?.hookStep) {
+        this.addAttachmentToHookStep(test, stepInfo.hookStep, attachment);
+        continue;
+      }
+
+      const attachmentStepUuid = stepInfo?.hookStep?.uuid ?? stepInfo?.stepUuid;
+      this.queueAttachmentTask(test.id, this.processAttachment(testUuid, attachmentStepUuid, attachment));
+    }
+  }
+
   onStepBegin(test: TestCase, _result: PlaywrightTestResult, step: TestStep): void {
     const isRootBeforeHook = step.title === BEFORE_HOOKS_ROOT_STEP_TITLE;
     const isRootAfterHook = step.title === AFTER_HOOKS_ROOT_STEP_TITLE;
@@ -319,9 +572,10 @@ export class AllureReporter implements ReporterV2 {
 
     if (["test.attach", "attach"].includes(step.category) && !isHookStep) {
       const parent = step.parent ? (this.pwStepUuid.get(step.parent) ?? null) : null;
-      const targets = this.attachmentTargets.get(test.id) ?? [];
-      targets.push({ name: normalizeAttachStepTitle(step.title), stepUuid: parent ?? undefined });
-      this.attachmentTargets.set(test.id, targets);
+      this.attachmentTargetByStep.set(step, {
+        name: normalizeAttachStepTitle(step.title),
+        stepUuid: parent ?? undefined,
+      });
       return;
     }
 
@@ -335,19 +589,21 @@ export class AllureReporter implements ReporterV2 {
         stack.startStep(baseStep);
 
         stack.updateStep((stepResult) => {
-          hookStepWithUuid = { ...step, uuid: stepResult.uuid as string } as AttachStack;
+          hookStepWithUuid = {
+            ...step,
+            uuid: stepResult.uuid as string,
+            hookScope: isBeforeHookDescendant ? "before" : "after",
+          } as AttachStack;
           stepResult.name = normalizeHookTitle(stepResult.name!);
           stepResult.stage = Stage.FINISHED;
         });
         stack.stopStep();
 
-        const targets = this.attachmentTargets.get(test.id) ?? [];
-        targets.push({
+        this.attachmentTargetByStep.set(step, {
           name: attachmentName,
           hookStep: hookStepWithUuid,
           stepUuid: attachmentName === "Allure Step Metadata" ? parentHookStepUuid : undefined,
         });
-        this.attachmentTargets.set(test.id, targets);
         return;
       }
 
@@ -398,8 +654,9 @@ export class AllureReporter implements ReporterV2 {
     if (this.#shouldIgnoreStep(step)) {
       return;
     }
-    // ignore test.attach steps since attachments are already in the report
+
     if (["test.attach", "attach"].includes(step.category)) {
+      this.processStepEndAttachments(test, step);
       return;
     }
     const testUuid = this.allureResultsUuids.get(test.id)!;
@@ -527,17 +784,21 @@ export class AllureReporter implements ReporterV2 {
       const isRuntimeMessage = attachment.contentType === ALLURE_RUNTIME_MESSAGE_CONTENT_TYPE;
       const stepInfo = takeByName(attachment.name);
 
+      if (stepInfo?.processedAtStepEnd) {
+        continue;
+      }
+
       if (isRuntimeMessage) {
         const message = attachment.body ? (JSON.parse(attachment.body.toString()) as RuntimeMessage) : undefined;
 
         if (stepInfo?.hookStep) {
-          const targetStack = isBeforeHookStep(stepInfo.hookStep) ? beforeHooksStack : afterHooksStack;
+          const targetStack = this.getHookStepsStack(test.id, stepInfo.hookStep);
           this.removeStepFromHookStack(targetStack, stepInfo.hookStep.uuid);
         }
 
         if (message?.type === "step_metadata" && stepInfo?.stepUuid) {
           if (stepInfo.hookStep) {
-            const targetStack = isBeforeHookStep(stepInfo.hookStep) ? beforeHooksStack : afterHooksStack;
+            const targetStack = this.getHookStepsStack(test.id, stepInfo.hookStep);
             this.processHookStepMetadataMessage(targetStack, stepInfo.stepUuid, message);
           } else {
             this.processStepMetadataMessage(stepInfo.stepUuid, message);
@@ -551,11 +812,10 @@ export class AllureReporter implements ReporterV2 {
       }
 
       if (stepInfo?.hookStep) {
-        const hookStep = stepInfo.hookStep;
-        const targetStack = isBeforeHookStep(hookStep) ? beforeHooksStack : afterHooksStack;
+        const targetStack = this.getHookStepsStack(test.id, stepInfo.hookStep);
 
         if (targetStack) {
-          const stepResult = targetStack.findStepByUuid(hookStep.uuid);
+          const stepResult = targetStack.findStepByUuid(stepInfo.hookStep.uuid);
           if (stepResult) {
             const fileName = targetStack.addAttachment(attachment, this.allureRuntime!.writer);
             stepResult.attachments.push({
@@ -575,6 +835,8 @@ export class AllureReporter implements ReporterV2 {
 
       await this.processAttachment(testUuid, undefined, attachment);
     }
+
+    await this.flushAttachmentTasks(test.id);
 
     // FIXME: temp logic for labels override, we need it here to keep the reporter compatible with v2 API
     // in next iterations we need to implement the logic for every javascript integration
@@ -603,12 +865,12 @@ export class AllureReporter implements ReporterV2 {
       });
 
       if (beforeHooksStack) {
-        testResult.steps.unshift(...beforeHooksStack.steps);
+        testResult.steps.unshift(...this.pruneEmptyHookRoots(beforeHooksStack.steps));
       }
       this.beforeHooksStepsStack.delete(test.id);
 
       if (afterHooksStack) {
-        testResult.steps.push(...afterHooksStack.steps);
+        testResult.steps.push(...this.pruneEmptyHookRoots(afterHooksStack.steps));
       }
       this.afterHooksStepsStack.delete(test.id);
 
@@ -617,6 +879,7 @@ export class AllureReporter implements ReporterV2 {
     this.allureRuntime!.stopTest(testUuid, { duration: result.duration });
     this.allureRuntime!.writeTest(testUuid);
     this.attachmentTargets.delete(test.id);
+    this.pendingAttachmentTasks.delete(test.id);
   }
 
   async addSkippedResults() {
@@ -656,6 +919,24 @@ export class AllureReporter implements ReporterV2 {
     return false;
   }
 
+  private isEmptyPassedHookRoot(step: StepResult) {
+    return (
+      (step.name === BEFORE_HOOKS_ROOT_STEP_TITLE || step.name === AFTER_HOOKS_ROOT_STEP_TITLE) &&
+      step.steps.length === 0 &&
+      step.attachments.length === 0 &&
+      step.status === Status.PASSED
+    );
+  }
+
+  private pruneEmptyHookRoots(steps: StepResult[]): StepResult[] {
+    return steps
+      .map((step) => ({
+        ...step,
+        steps: this.pruneEmptyHookRoots(step.steps),
+      }))
+      .filter((step) => !this.isEmptyPassedHookRoot(step));
+  }
+
   private removeStepFromHookStack(stack: ShallowStepsStack | undefined, stepUuid: string) {
     if (!stack) {
       return;
@@ -668,13 +949,7 @@ export class AllureReporter implements ReporterV2 {
           ...step,
           steps: removeRecursively(step.steps),
         }))
-        .filter(
-          (step) =>
-            (step.name !== BEFORE_HOOKS_ROOT_STEP_TITLE && step.name !== AFTER_HOOKS_ROOT_STEP_TITLE) ||
-            step.steps.length > 0 ||
-            step.attachments.length > 0 ||
-            step.status !== Status.PASSED,
-        );
+        .filter((step) => !this.isEmptyPassedHookRoot(step));
     };
 
     stack.steps = removeRecursively(stack.steps);

--- a/packages/allure-playwright/src/model.ts
+++ b/packages/allure-playwright/src/model.ts
@@ -14,14 +14,18 @@ export interface AllurePlaywrightReporterConfig extends ReporterConfig {
   suiteTitle?: boolean;
 }
 
+export type HookScope = "before" | "after";
+
 export interface AttachStack extends TestStep {
   uuid: string;
+  hookScope: HookScope;
 }
 
 export type AttachmentTarget = {
   name: string;
   stepUuid?: string;
   hookStep?: AttachStack;
+  processedAtStepEnd?: boolean;
 };
 
 export interface ReporterV2 {

--- a/packages/allure-playwright/test/spec/hooks.spec.ts
+++ b/packages/allure-playwright/test/spec/hooks.spec.ts
@@ -250,11 +250,7 @@ it("should keep buffered log steps ordered with lambda steps in after hooks", as
   });
   expect(afterHooks!.steps[0].steps.map((step) => step.name)).toEqual(["1: lambda", "2: lambda"]);
   expect(afterHooks!.steps[0].steps[0].steps.map((step) => step.name)).toEqual(["1.1: log", "1.2: lambda"]);
-  expect(afterHooks!.steps[0].steps[1].steps.map((step) => step.name)).toEqual([
-    "2.1: log",
-    "2.2: lambda",
-    "2.3: log",
-  ]);
+  expect(afterHooks!.steps[0].steps[1].steps.map((step) => step.name)).toEqual(["2.1: log", "2.2: lambda", "2.3: log"]);
 });
 
 it("should hook steps have attachments", async () => {

--- a/packages/allure-playwright/test/spec/hooks.spec.ts
+++ b/packages/allure-playwright/test/spec/hooks.spec.ts
@@ -177,6 +177,86 @@ it("keeps correct hooks structure when something failed", async () => {
   });
 });
 
+it("should keep buffered log steps ordered with lambda steps in before hooks", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.ts": `
+      import { test } from "@playwright/test";
+      import { logStep, step } from "allure-js-commons";
+
+      test.beforeEach(async () => {
+        await step("1: lambda", async () => {
+          await logStep("1.1: log");
+          await step("1.2: lambda", async () => {});
+        });
+
+        await test.step("2: lambda", async () => {
+          await logStep("2.1: log");
+          await test.step("2.2: lambda", async () => {});
+          await logStep("2.3: log");
+        });
+      });
+
+      test("steps", async () => {});
+    `,
+  });
+
+  const [testResult] = tests;
+  const beforeHooks = testResult.steps.find((step) => step.name === "Before Hooks");
+
+  expect(beforeHooks).toBeDefined();
+  expect(beforeHooks!.steps).toHaveLength(1);
+  expect(beforeHooks!.steps[0]).toMatchObject({
+    name: "beforeEach hook",
+  });
+  expect(beforeHooks!.steps[0].steps.map((step) => step.name)).toEqual(["1: lambda", "2: lambda"]);
+  expect(beforeHooks!.steps[0].steps[0].steps.map((step) => step.name)).toEqual(["1.1: log", "1.2: lambda"]);
+  expect(beforeHooks!.steps[0].steps[1].steps.map((step) => step.name)).toEqual([
+    "2.1: log",
+    "2.2: lambda",
+    "2.3: log",
+  ]);
+});
+
+it("should keep buffered log steps ordered with lambda steps in after hooks", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.ts": `
+      import { test } from "@playwright/test";
+      import { logStep, step } from "allure-js-commons";
+
+      test.afterEach(async () => {
+        await step("1: lambda", async () => {
+          await logStep("1.1: log");
+          await step("1.2: lambda", async () => {});
+        });
+
+        await test.step("2: lambda", async () => {
+          await logStep("2.1: log");
+          await test.step("2.2: lambda", async () => {});
+          await logStep("2.3: log");
+        });
+      });
+
+      test("steps", async () => {});
+    `,
+  });
+
+  const [testResult] = tests;
+  const afterHooks = testResult.steps.find((step) => step.name === "After Hooks");
+
+  expect(afterHooks).toBeDefined();
+  expect(afterHooks!.steps).toHaveLength(1);
+  expect(afterHooks!.steps[0]).toMatchObject({
+    name: "afterEach hook",
+  });
+  expect(afterHooks!.steps[0].steps.map((step) => step.name)).toEqual(["1: lambda", "2: lambda"]);
+  expect(afterHooks!.steps[0].steps[0].steps.map((step) => step.name)).toEqual(["1.1: log", "1.2: lambda"]);
+  expect(afterHooks!.steps[0].steps[1].steps.map((step) => step.name)).toEqual([
+    "2.1: log",
+    "2.2: lambda",
+    "2.3: log",
+  ]);
+});
+
 it("should hook steps have attachments", async () => {
   const results = await runPlaywrightInlineTest({
     "sample.test.js": `

--- a/packages/allure-playwright/test/spec/runtime/modern/steps.spec.ts
+++ b/packages/allure-playwright/test/spec/runtime/modern/steps.spec.ts
@@ -112,6 +112,37 @@ it("should support log steps", async () => {
   );
 });
 
+it("should keep buffered log steps ordered with lambda steps", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.ts": `
+      import { test } from "@playwright/test";
+      import { logStep, step } from "allure-js-commons";
+
+      test("steps", async () => {
+        await step("1: lambda", async () => {
+          await logStep("1.1: log");
+          await step("1.2: lambda", async () => {});
+        });
+
+        await test.step("2: lambda", async () => {
+          await logStep("2.1: log");
+          await test.step("2.2: lambda", async () => {});
+          await logStep("2.3: log");
+        });
+      });
+    `,
+  });
+
+  const [testResult] = tests;
+  expect(testResult.steps.map((step) => step.name)).toEqual(["Before Hooks", "1: lambda", "2: lambda", "After Hooks"]);
+
+  const firstLambda = testResult.steps[1];
+  const secondLambda = testResult.steps[2];
+
+  expect(firstLambda.steps.map((step) => step.name)).toEqual(["1.1: log", "1.2: lambda"]);
+  expect(secondLambda.steps.map((step) => step.name)).toEqual(["2.1: log", "2.2: lambda", "2.3: log"]);
+});
+
 it("should allow to set step metadata through its context", async () => {
   const { tests } = await runPlaywrightInlineTest({
     "sample.test.ts": `


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

This fixes step ordering in `allure-playwright` when `logStep()` is mixed with Playwright steps.

Nested runtime steps now appear where they were actually executed, including inside `beforeEach` and `afterEach`, instead of showing up as separate top-level items or raw metadata steps.

Fixes [#1444](https://github.com/allure-framework/allure-js/issues/1444).

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js