### PR TITLE
Fix api steps nesting issue in allure-cypress

### DIFF
--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -13,7 +13,7 @@ export const DEFAULT_RUNTIME_CONFIG = {
  * @returns An array of popped items. The first popped item becomes the first element of this array.
  */
 export const popUntilFindIncluded = <T>(items: T[], pred: (value: T) => boolean) => {
-  const index = items.findIndex(pred);
+  const index = items.findLastIndex(pred);
   return index !== -1 ? toReversed(items.splice(index)) : [];
 };
 

--- a/packages/allure-cypress/test/spec/commands.test.ts
+++ b/packages/allure-cypress/test/spec/commands.test.ts
@@ -577,7 +577,10 @@ describe("mixed steps", () => {
       logGroupStop,
       testStop,
     ];
-    const actualOrder = [...expectedOrder].sort();
+
+    expect(expectedOrder.every((e) => e !== undefined)).toBeTruthy();
+
+    const actualOrder = [...expectedOrder].sort((f, s) => f! - s!);
 
     expect(actualOrder).toEqual(expectedOrder);
   });
@@ -907,7 +910,10 @@ describe("failed and broken tests with mixed steps", () => {
       apiStep1StopBroken,
       testStopBroken,
     ];
-    const actualOrder = [...expectedOrder].sort();
+
+    expect(expectedOrder.every((e) => e !== undefined)).toBeTruthy();
+
+    const actualOrder = [...expectedOrder].sort((f, s) => f! - s!);
 
     expect(actualOrder).toEqual(expectedOrder);
   });

--- a/packages/allure-cypress/test/spec/runtime/modern/steps.test.ts
+++ b/packages/allure-cypress/test/spec/runtime/modern/steps.test.ts
@@ -53,31 +53,59 @@ it("multiple steps", async () => {
   expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "baz" }));
 });
 
-it("nested steps", async () => {
+it("nested steps with API calls", async () => {
   const { tests } = await runCypressInlineTest({
     "cypress/e2e/sample.cy.js": ({ allureCommonsModulePath }) => `
     import { label, step } from "${allureCommonsModulePath}";
 
     it("step", () => {
-      step("foo", () => {
-        step("bar", () => {
-           step("baz", () => {
-             label("foo", "bar");
-           });
+      step("step 1", () => {
+        step("step 1.1", () => {
+          step("step 1.1.1", () => {
+            label("foo", "1");
+          });
+          step("step 1.1.2", () => {
+            label("bar", "2");
+          });
+        });
+        step("step 1.2", () => {
+          step("step 1.2.1", () => {
+            label("baz", "3");
+          });
+          step("step 1.2.2", () => {
+            label("qux", "4");
+          });
         });
       });
     });
   `,
   });
 
-  expect(tests).toHaveLength(1);
-  expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
-  expect(tests[0].steps).toHaveLength(1);
-  expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "foo" }));
-  expect(tests[0].steps[0].steps).toHaveLength(1);
-  expect(tests[0].steps[0].steps).toContainEqual(expect.objectContaining({ name: "bar" }));
-  expect(tests[0].steps[0].steps[0].steps).toHaveLength(1);
-  expect(tests[0].steps[0].steps[0].steps).toContainEqual(expect.objectContaining({ name: "baz" }));
+  expect(tests).toMatchObject([
+    expect.objectContaining({
+      labels: expect.arrayContaining([
+        { name: "foo", value: "1" },
+        { name: "bar", value: "2" },
+        { name: "baz", value: "3" },
+        { name: "qux", value: "4" },
+      ]),
+      steps: [
+        expect.objectContaining({
+          name: "step 1",
+          steps: [
+            expect.objectContaining({
+              name: "step 1.1",
+              steps: [expect.objectContaining({ name: "step 1.1.1" }), expect.objectContaining({ name: "step 1.1.2" })],
+            }),
+            expect.objectContaining({
+              name: "step 1.2",
+              steps: [expect.objectContaining({ name: "step 1.2.1" }), expect.objectContaining({ name: "step 1.2.2" })],
+            }),
+          ],
+        }),
+      ],
+    }),
+  ]);
 });
 
 it("step with attachments", async () => {


### PR DESCRIPTION
### Context

In Cypress, when a lambda step is stopped, all its nested command log steps are also stopped. This is done via `popUntilFindIncluded` in `packages/allure-cypress/src/utils.ts`, which pops items until the predicate returns `true`. But the implementation uses `findIndex` instead of `findLastIndex`, resulting in more items being popped than expected.

The PR fixes the function and makes the nested steps test cover the case.

Fixes #1247

#### Extra change

  - fix [typescript-eslint(require-array-sort-compare)](https://oxc.rs/docs/guide/usage/linter/rules/typescript/require-array-sort-compare.html) and add undefined checks in step timing tests

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
