### PR TITLE
Fix "Sourcemap for ... points to missing source files" when running Vitest with Allure

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "strict": true,
     "sourceMap": true,
+    "inlineSources": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
### Context

Unlike other packages, `vitest` is built entirely by `tsc`, which, by default, doesn't include source content in generated source maps. This causes the following error:

```text
Sourcemap for "<project-dir>/node_modules/allure-vitest/dist/setup.js" points to missing source files
```

The PR adds a missing `inlineSources` option that fixes the error and aligns `allure-vitest` sourcemaps with those of other packages.

Fixes #1349
