### PR TITLE
Fix Allure metadata attribution in concurrent Vitest tests

### DIFF
--- a/packages/allure-vitest/README.md
+++ b/packages/allure-vitest/README.md
@@ -54,14 +54,13 @@ Install Allure Report separately when you want to render the generated `allure-r
 
 ## Usage
 
-Add next changes to your config file if you want to use vitest to run NodeJS tests only:
+Add the reporter to your config file if you want to use Vitest to run Node.js tests only:
 
 ```diff
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-+    setupFiles: ["allure-vitest/setup"],
     reporters: [
       "default",
       "allure-vitest/reporter",
@@ -70,15 +69,17 @@ export default defineConfig({
 });
 ```
 
-In case if you want to use [vitest for browser testing](https://vitest.dev/guide/browser/) add next changes:
+The reporter registers the Allure setup module automatically. If your project already lists `allure-vitest/setup` in
+`setupFiles`, you can keep it for compatibility or remove it from the config.
+
+If you want to use [Vitest for browser testing](https://vitest.dev/guide/browser/), add the browser provider config:
 
 ```diff
 import { defineConfig } from "vitest/config";
-+ import { commands } from "allure-vitest/browser"
++ import { playwright } from "@vitest/browser-playwright";
 
 export default defineConfig({
   test: {
-+    setupFiles: ["allure-vitest/browser/setup"],
     reporters: [
       "default",
       "allure-vitest/reporter",
@@ -91,12 +92,16 @@ export default defineConfig({
     instances: [
       { browser: "chromium" },
     ],
-+    commands: {
-+      ...commands,
-+    }
   },
 });
 ```
+
+The reporter also registers `allure-vitest/browser/setup` and the Allure browser command automatically when browser
+mode is enabled. If your project already lists them in the config, you can keep them for compatibility or remove them.
+
+Browser mode does not have a stable async context primitive equivalent to Node.js `AsyncLocalStorage`, so Allure runtime
+API calls in `describe.concurrent` browser tests may still be attributed incorrectly after async boundaries. Prefer
+non-concurrent browser tests when using the context-free Allure runtime API.
 
 ### View the report
 

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -21,10 +21,13 @@ import type { RunnerTask as Task } from "vitest";
 import type { TestModule, Vitest } from "vitest/node";
 import type { Reporter } from "vitest/reporters";
 
+import { commands as allureBrowserCommands } from "./browser/index.js";
 import { takeGlobalRuntimeMessages } from "./runtime.js";
 import { getTestMetadata } from "./utils.js";
 
 const setupModulePath = fileURLToPath(new URL("./setup.js", import.meta.url));
+
+const browserSetupModulePath = fileURLToPath(new URL("./browser/setup.js", import.meta.url));
 
 const normalizeSetupFilePath = (setupFilePath: string) =>
   setupFilePath.startsWith("file://") ? fileURLToPath(setupFilePath) : setupFilePath;
@@ -56,16 +59,22 @@ export default class AllureVitestReporter implements Reporter {
 
   private registerSetupFile(vitest: Vitest) {
     for (const project of vitest.projects) {
-      if (project.config.browser.enabled) {
-        continue;
-      }
+      const setupFilePath = project.config.browser.enabled ? browserSetupModulePath : setupModulePath;
 
       const hasSetupFile = project.config.setupFiles.some(
-        (setupFile) => normalizeSetupFilePath(setupFile) === setupModulePath,
+        (setupFile) => normalizeSetupFilePath(setupFile) === setupFilePath,
       );
 
       if (!hasSetupFile) {
-        project.config.setupFiles.unshift(setupModulePath);
+        project.config.setupFiles.unshift(setupFilePath);
+      }
+
+      if (project.config.browser.enabled) {
+        project.config.browser.commands ??= {};
+
+        for (const [name, command] of Object.entries(allureBrowserCommands)) {
+          project.config.browser.commands[name] ??= command;
+        }
       }
     }
   }

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import { Stage, Status } from "allure-js-commons";
 import type { RuntimeMessage } from "allure-js-commons/sdk";
 import { getMessageAndTraceFromError, getStatusFromError } from "allure-js-commons/sdk";
@@ -16,11 +18,16 @@ import {
   md5,
 } from "allure-js-commons/sdk/reporter";
 import type { RunnerTask as Task } from "vitest";
-import type { TestModule } from "vitest/node";
+import type { TestModule, Vitest } from "vitest/node";
 import type { Reporter } from "vitest/reporters";
 
 import { takeGlobalRuntimeMessages } from "./runtime.js";
 import { getTestMetadata } from "./utils.js";
+
+const setupModulePath = fileURLToPath(new URL("./setup.js", import.meta.url));
+
+const normalizeSetupFilePath = (setupFilePath: string) =>
+  setupFilePath.startsWith("file://") ? fileURLToPath(setupFilePath) : setupFilePath;
 
 export default class AllureVitestReporter implements Reporter {
   private allureReporterRuntime?: ReporterRuntime;
@@ -31,7 +38,9 @@ export default class AllureVitestReporter implements Reporter {
     this.config = config;
   }
 
-  onInit() {
+  onInit(vitest: Vitest) {
+    this.registerSetupFile(vitest);
+
     const { listeners, resultsDir, ...config } = this.config;
 
     this.allureReporterRuntime = new ReporterRuntime({
@@ -43,6 +52,22 @@ export default class AllureVitestReporter implements Reporter {
     this.allureReporterRuntime.writeCategoriesDefinitions();
     this.allureReporterRuntime.writeEnvironmentInfo();
     this.globalRuntimeMessages = [];
+  }
+
+  private registerSetupFile(vitest: Vitest) {
+    for (const project of vitest.projects) {
+      if (project.config.browser.enabled) {
+        continue;
+      }
+
+      const hasSetupFile = project.config.setupFiles.some(
+        (setupFile) => normalizeSetupFilePath(setupFile) === setupModulePath,
+      );
+
+      if (!hasSetupFile) {
+        project.config.setupFiles.unshift(setupModulePath);
+      }
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/array-type

--- a/packages/allure-vitest/src/runtime.ts
+++ b/packages/allure-vitest/src/runtime.ts
@@ -9,6 +9,8 @@ export const ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_META_KEY = "allureGlobalRunti
 
 export const ALLURE_VITEST_RUNTIME_MESSAGES_META_KEY = "allureRuntimeMessages";
 
+export const ALLURE_VITEST_ASYNC_CONTEXT_KEY = "__allureVitestAsyncContext";
+
 export type RuntimeMessageMetaKey =
   | typeof ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_META_KEY
   | typeof ALLURE_VITEST_RUNTIME_MESSAGES_META_KEY;
@@ -16,6 +18,27 @@ export type RuntimeMessageMetaKey =
 export type RuntimeMessageTaskMeta = TaskMeta & {
   [ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_META_KEY]?: RuntimeMessage[];
   [ALLURE_VITEST_RUNTIME_MESSAGES_META_KEY]?: RuntimeMessage[];
+};
+
+type AllureVitestAsyncContext = {
+  currentTaskStorage: {
+    getStore: () => Task | undefined;
+  };
+  activeTasks?: {
+    has: (task: Task) => boolean;
+  };
+};
+
+const getCurrentTask = (): Task | undefined => {
+  const holder = globalThis as unknown as Record<string, AllureVitestAsyncContext | undefined>;
+  const asyncContext = holder[ALLURE_VITEST_ASYNC_CONTEXT_KEY];
+  const task = asyncContext?.currentTaskStorage.getStore();
+
+  if (task) {
+    return asyncContext?.activeTasks?.has(task) ?? true ? task : undefined;
+  }
+
+  return getCurrentTest();
 };
 
 export const addGlobalMessage = (message: RuntimeMessage) => {
@@ -101,7 +124,7 @@ export class BaseVitestTestRuntime extends BaseMessageTestRuntime {
   }
 
   protected processMessage(message: RuntimeMessage): boolean {
-    const currentTest = getCurrentTest();
+    const currentTest = getCurrentTask();
 
     if (isGlobalRuntimeMessage(message)) {
       if (currentTest) {

--- a/packages/allure-vitest/src/runtime.ts
+++ b/packages/allure-vitest/src/runtime.ts
@@ -35,7 +35,7 @@ const getCurrentTask = (): Task | undefined => {
   const task = asyncContext?.currentTaskStorage.getStore();
 
   if (task) {
-    return asyncContext?.activeTasks?.has(task) ?? true ? task : undefined;
+    return (asyncContext?.activeTasks?.has(task) ?? true) ? task : undefined;
   }
 
   return getCurrentTest();

--- a/packages/allure-vitest/src/setup.ts
+++ b/packages/allure-vitest/src/setup.ts
@@ -1,10 +1,97 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { Task, Test } from "@vitest/runner";
 import { parseTestPlan } from "allure-js-commons/sdk/reporter";
 import { setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+import { VitestTestRunner } from "vitest/runners";
 
 import { allureVitestLegacyApi } from "./legacy.js";
+import { ALLURE_VITEST_ASYNC_CONTEXT_KEY } from "./runtime.js";
 import { existsInTestPlan } from "./utils.js";
 import { VitestTestRuntime } from "./VitestTestRuntime.js";
+
+const ALLURE_VITEST_RUNNER_PATCHED_KEY = Symbol.for("allure-vitest.runnerPatched");
+
+type AllureVitestAsyncContext = {
+  currentTaskStorage: AsyncLocalStorage<Test>;
+  activeTasks: WeakSet<Test>;
+};
+
+type PatchedRunner = typeof VitestTestRunner.prototype & {
+  [ALLURE_VITEST_RUNNER_PATCHED_KEY]?: true;
+  onAfterRetryTask?: (test: Task, retryInfo: { retry: number; repeats: number }) => unknown;
+};
+
+const getAsyncContext = (): AllureVitestAsyncContext => {
+  const holder = globalThis as unknown as Record<string, AllureVitestAsyncContext | undefined>;
+
+  return (holder[ALLURE_VITEST_ASYNC_CONTEXT_KEY] ??= {
+    currentTaskStorage: new AsyncLocalStorage<Test>(),
+    activeTasks: new WeakSet<Test>(),
+  });
+};
+
+const patchVitestRunner = () => {
+  const prototype = VitestTestRunner.prototype as PatchedRunner;
+
+  if (prototype[ALLURE_VITEST_RUNNER_PATCHED_KEY]) {
+    return;
+  }
+
+  const originalOnBeforeRunTask = prototype.onBeforeRunTask;
+  const originalOnAfterRetryTask = prototype.onAfterRetryTask;
+  const originalOnAfterRunTask = prototype.onAfterRunTask;
+
+  const releaseTask = (test: Task) => {
+    getAsyncContext().activeTasks.delete(test as Test);
+  };
+
+  const releaseNonRunnableTask = (test: Task) => {
+    if (test.mode !== "run" && test.mode !== "queued") {
+      releaseTask(test);
+    }
+  };
+
+  const releaseDynamicallySkippedTask = (test: Task) => {
+    const result = (test as Test).result as { pending?: boolean; state?: string } | undefined;
+
+    if (result?.pending || result?.state === "skip") {
+      releaseTask(test);
+    }
+  };
+
+  prototype.onBeforeRunTask = async function allureOnBeforeRunTask(test: Task) {
+    const asyncContext = getAsyncContext();
+
+    asyncContext.activeTasks.add(test as Test);
+    asyncContext.currentTaskStorage.enterWith(test as Test);
+
+    await originalOnBeforeRunTask.call(this, test);
+
+    releaseNonRunnableTask(test);
+  };
+
+  prototype.onAfterRetryTask = function allureOnAfterRetryTask(test: Task, retryInfo) {
+    try {
+      return originalOnAfterRetryTask?.call(this, test, retryInfo);
+    } finally {
+      releaseDynamicallySkippedTask(test);
+    }
+  };
+
+  prototype.onAfterRunTask = async function allureOnAfterRunTask(test: Task) {
+    try {
+      return await originalOnAfterRunTask.call(this, test);
+    } finally {
+      releaseTask(test);
+    }
+  };
+
+  prototype[ALLURE_VITEST_RUNNER_PATCHED_KEY] = true;
+};
+
+patchVitestRunner();
 
 beforeAll(() => {
   globalThis.allureTestPlan = parseTestPlan();

--- a/packages/allure-vitest/test/spec/categories.test.ts
+++ b/packages/allure-vitest/test/spec/categories.test.ts
@@ -1,12 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  browserSetupModulePath,
-  reporterModulePath,
-  runVitestInlineTest,
-  setupModulePath,
-} from "../utils.js";
+import { type TestFileAccessor, reporterModulePath, runVitestInlineTest } from "../utils.js";
 
 describe("categories", () => {
   for (const env of ["node", "browser"]) {
@@ -21,7 +15,6 @@ describe("categories", () => {
 
           export default defineConfig({
             test: {
-              setupFiles: ["${setupModulePath}"],
               reporters: [
                 "default",
                 [
@@ -42,13 +35,11 @@ describe("categories", () => {
           }
           return `
           import { defineConfig } from "vitest/config";
-          import { commands } from "allure-vitest/browser";
           import { playwright } from "@vitest/browser-playwright";
 
           export default defineConfig({
             test: {
               openTelemetry: { enabled: false },
-              setupFiles: ["${browserSetupModulePath}"],
               reporters: [
                 "default",
                 [
@@ -68,7 +59,6 @@ describe("categories", () => {
                 enabled: true,
                 headless: true,
                 instances: [{ browser: "chromium" }],
-                commands: { ...commands },
               },
             },
           });

--- a/packages/allure-vitest/test/spec/environmentInfo.test.ts
+++ b/packages/allure-vitest/test/spec/environmentInfo.test.ts
@@ -1,12 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  browserSetupModulePath,
-  reporterModulePath,
-  runVitestInlineTest,
-  setupModulePath,
-} from "../utils.js";
+import { type TestFileAccessor, reporterModulePath, runVitestInlineTest } from "../utils.js";
 
 describe("environment info", () => {
   for (const env of ["node", "browser"]) {
@@ -21,7 +15,6 @@ describe("environment info", () => {
 
         export default defineConfig({
           test: {
-            setupFiles: ["${setupModulePath}"],
             reporters: [
               "default",
               [
@@ -41,13 +34,11 @@ describe("environment info", () => {
           }
           return `
         import { defineConfig } from "vitest/config";
-        import { commands } from "allure-vitest/browser";
         import { playwright } from "@vitest/browser-playwright";
 
         export default defineConfig({
           test: {
             openTelemetry: { enabled: false },
-            setupFiles: ["${browserSetupModulePath}"],
             reporters: [
               "default",
               [
@@ -66,7 +57,6 @@ describe("environment info", () => {
               enabled: true,
               headless: true,
               instances: [{ browser: "chromium" }],
-              commands: { ...commands },
             },
           },
         });

--- a/packages/allure-vitest/test/spec/globalLabels.test.ts
+++ b/packages/allure-vitest/test/spec/globalLabels.test.ts
@@ -1,12 +1,6 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  browserSetupModulePath,
-  reporterModulePath,
-  runVitestInlineTest,
-  setupModulePath,
-} from "../utils.js";
+import { type TestFileAccessor, reporterModulePath, runVitestInlineTest } from "../utils.js";
 
 describe("global labels", () => {
   for (const env of ["node", "browser"]) {
@@ -21,7 +15,6 @@ describe("global labels", () => {
 
         export default defineConfig({
           test: {
-            setupFiles: ["${setupModulePath}"],
             reporters: [
               "default",
               [
@@ -41,13 +34,11 @@ describe("global labels", () => {
           }
           return `
         import { defineConfig } from "vitest/config";
-        import { commands } from "allure-vitest/browser";
         import { playwright } from "@vitest/browser-playwright";
 
         export default defineConfig({
           test: {
             openTelemetry: { enabled: false },
-            setupFiles: ["${browserSetupModulePath}"],
             reporters: [
               "default",
               [
@@ -66,7 +57,6 @@ describe("global labels", () => {
               enabled: true,
               headless: true,
               instances: [{ browser: "chromium" }],
-              commands: { ...commands },
             },
           },
         });

--- a/packages/allure-vitest/test/spec/runtime/modern/steps.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/steps.test.ts
@@ -140,6 +140,127 @@ describe("steps", () => {
         { name: "p4", value: "v4", mode: "hidden" },
       ]);
     });
+
+    it("keeps log steps attached to the correct concurrent test", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": ({ allureResultsPath }) => createVitestConfig(allureResultsPath),
+        "sample.test.ts": `
+  import { describe, test } from "vitest";
+  import { logStep } from "allure-js-commons";
+
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  describe.concurrent("dummy", () => {
+    test("first", async () => {
+      await logStep("First, sync");
+      await delay(200);
+      await logStep("First, async");
+    });
+
+    test("second", async () => {
+      await logStep("Second, sync");
+      await delay(100);
+      await logStep("Second, async");
+    });
+  });
+`,
+      });
+
+      expect(tests).toHaveLength(2);
+      const first = tests.find(({ name }) => name === "first");
+      const second = tests.find(({ name }) => name === "second");
+
+      expect(first?.steps.map(({ name }) => name)).toEqual(["First, sync", "First, async"]);
+      expect(second?.steps.map(({ name }) => name)).toEqual(["Second, sync", "Second, async"]);
+    });
+
+    it("keeps concurrent steps isolated when setup is registered by the reporter", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": ({ allureResultsPath, reporterModulePath }) => `
+  import { defineConfig } from "vitest/config";
+
+  export default defineConfig({
+    test: {
+      openTelemetry: {
+        enabled: false,
+      },
+      reporters: [
+        ["${reporterModulePath}", {
+          resultsDir: "${allureResultsPath}",
+        }]
+      ],
+    },
+  });
+`,
+        "sample.test.ts": `
+  import { describe, test } from "vitest";
+  import { logStep } from "allure-js-commons";
+
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  describe.concurrent("dummy", () => {
+    test("first", async () => {
+      await logStep("First, sync");
+      await delay(200);
+      await logStep("First, async");
+    });
+
+    test("second", async () => {
+      await logStep("Second, sync");
+      await delay(100);
+      await logStep("Second, async");
+    });
+  });
+`,
+      });
+
+      expect(tests).toHaveLength(2);
+      const first = tests.find(({ name }) => name === "first");
+      const second = tests.find(({ name }) => name === "second");
+
+      expect(first?.steps.map(({ name }) => name)).toEqual(["First, sync", "First, async"]);
+      expect(second?.steps.map(({ name }) => name)).toEqual(["Second, sync", "Second, async"]);
+    });
+
+    it("keeps nested steps isolated across concurrent tests", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": ({ allureResultsPath }) => createVitestConfig(allureResultsPath),
+        "sample.test.ts": `
+  import { describe, test } from "vitest";
+  import { step } from "allure-js-commons";
+
+  const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  describe.concurrent("dummy", () => {
+    test("first", async () => {
+      await step("First outer", async () => {
+        await delay(200);
+        await step("First inner", () => {});
+      });
+    });
+
+    test("second", async () => {
+      await step("Second outer", async () => {
+        await delay(100);
+        await step("Second inner", () => {});
+      });
+    });
+  });
+`,
+      });
+
+      expect(tests).toHaveLength(2);
+      const first = tests.find(({ name }) => name === "first");
+      const second = tests.find(({ name }) => name === "second");
+
+      expect(first?.steps).toHaveLength(1);
+      expect(first?.steps[0].name).toBe("First outer");
+      expect(first?.steps[0].steps.map(({ name }) => name)).toEqual(["First inner"]);
+
+      expect(second?.steps).toHaveLength(1);
+      expect(second?.steps[0].name).toBe("Second outer");
+      expect(second?.steps[0].steps.map(({ name }) => name)).toEqual(["Second inner"]);
+    });
   });
 
   describe('for "browser"', () => {

--- a/packages/allure-vitest/test/utils.ts
+++ b/packages/allure-vitest/test/utils.ts
@@ -28,8 +28,6 @@ const fileDirname = dirname(fileURLToPath(import.meta.url));
 
 export const setupModulePath = getPosixPath(require.resolve("allure-vitest/setup"));
 
-export const browserSetupModulePath = getPosixPath(require.resolve("allure-vitest/browser/setup"));
-
 export const reporterModulePath = getPosixPath(require.resolve("allure-vitest/reporter"));
 
 export const createVitestConfig = (allureResultsPath: string) => `
@@ -40,7 +38,6 @@ export const createVitestConfig = (allureResultsPath: string) => `
       openTelemetry: {
         enabled: false,
       },
-      setupFiles: ["${setupModulePath}"],
       reporters: [
         "verbose",
         ["${reporterModulePath}", {
@@ -61,7 +58,6 @@ export const createVitestConfig = (allureResultsPath: string) => `
 
 export const createVitestBrowserConfig = (allureResultsPath: string) => `
   import { defineConfig } from "vitest/config";
-  import { commands } from "allure-vitest/browser"
   import { playwright } from "@vitest/browser-playwright";
 
   export default defineConfig({
@@ -69,7 +65,6 @@ export const createVitestBrowserConfig = (allureResultsPath: string) => `
       openTelemetry: {
         enabled: false,
       },
-      setupFiles: ["${browserSetupModulePath}"],
       reporters: [
         "verbose",
         ["${reporterModulePath}", {
@@ -91,9 +86,6 @@ export const createVitestBrowserConfig = (allureResultsPath: string) => `
         instances: [
           { browser: "chromium" },
         ],
-        commands: {
-          ...commands,
-        }
       },
     },
   });


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->
Fixes #1452

This fixes an issue where Allure runtime calls made inside `describe.concurrent` or concurrent Vitest tests could be recorded under the wrong test after an `await`. Users can keep using the existing Allure APIs such as `logStep`, `step`, and `globalThis.allure`; no test code changes or migration to Vitest annotations are required.

The fix keeps each concurrent test’s Allure messages tied to the correct Vitest test across async boundaries. This means steps and nested steps now appear only in the Allure result for the test that created them, preserving the expected order even when concurrent tests finish at different times.


#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js