### PR TITLE
Add native Vitest expect matcher reporting

### DIFF
--- a/packages/allure-chai/test/chai.spec.ts
+++ b/packages/allure-chai/test/chai.spec.ts
@@ -189,7 +189,7 @@ describe("allureChai", () => {
     expect(results.stepNames).toEqual(["expect([1,2,3]).to.include.members([2,3])"]);
   });
 
-  it("doesn't record Vitest expect assertions through allureChai", () => {
+  it("doesn't duplicate Vitest expect assertions through allureChai", () => {
     const results = runChai(() => {
       expect(1).toEqual(1);
       expect(undefined).toBeUndefined();
@@ -202,7 +202,14 @@ describe("allureChai", () => {
     });
 
     expect(results.error).toBeUndefined();
-    expect(results.stepNames).toEqual([]);
+    expect(results.stepNames).toEqual([
+      "expect(1).toEqual(1)",
+      "expect(undefined).toBeUndefined()",
+      "expect([1,2]).toHaveLength(2)",
+      "expect([1,2]).toContain(1)",
+      'expect({"name":"Error","message":"email is required"}).toBeInstanceOf([Function Error])',
+      'expect([Function]).toThrow("email is required")',
+    ]);
   });
 
   it("records Chai assertions while ignoring Vitest expects in the same run", () => {
@@ -214,7 +221,12 @@ describe("allureChai", () => {
     });
 
     expect(results.error).toBeUndefined();
-    expect(results.stepNames).toEqual(["expect(2).to.equal(2)", "expect([1,2]).to.include(2)"]);
+    expect(results.stepNames).toEqual([
+      "expect(1).toEqual(1)",
+      "expect(2).to.equal(2)",
+      "expect([1,2]).toHaveLength(2)",
+      "expect([1,2]).to.include(2)",
+    ]);
   });
 
   it("doesn't record assertions from Cypress global Chai", () => {

--- a/packages/allure-vitest/src/browser/setup.ts
+++ b/packages/allure-vitest/src/browser/setup.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeAll, beforeEach } from "vitest";
 import { commands } from "vitest/browser";
 
 import { allureVitestLegacyApi } from "../legacy.js";
+import { registerAllureVitestExpect } from "../matchers.js";
 import { VitestBrowserTestRuntime } from "../VitestBrowserTestRuntime.js";
+
+registerAllureVitestExpect();
 
 beforeAll(() => {
   setGlobalTestRuntime(new VitestBrowserTestRuntime());

--- a/packages/allure-vitest/src/matcherMessages.ts
+++ b/packages/allure-vitest/src/matcherMessages.ts
@@ -1,0 +1,16 @@
+import type { RuntimeMessage } from "allure-js-commons/sdk";
+
+export const ALLURE_VITEST_MATCHER_MESSAGE_KEY = "__allureVitestMatcher";
+
+export type AllureVitestMatcherRuntimeMessage = RuntimeMessage & {
+  [ALLURE_VITEST_MATCHER_MESSAGE_KEY]?: true;
+};
+
+export const markAsMatcherMessage = <T extends RuntimeMessage>(message: T): T & AllureVitestMatcherRuntimeMessage =>
+  ({
+    ...message,
+    [ALLURE_VITEST_MATCHER_MESSAGE_KEY]: true,
+  }) as T & AllureVitestMatcherRuntimeMessage;
+
+export const isMatcherMessage = (message: RuntimeMessage) =>
+  Boolean((message as AllureVitestMatcherRuntimeMessage)[ALLURE_VITEST_MATCHER_MESSAGE_KEY]);

--- a/packages/allure-vitest/src/matchers.ts
+++ b/packages/allure-vitest/src/matchers.ts
@@ -143,7 +143,10 @@ function formatAsymmetricMatcher(value: AsymmetricMatcher): string {
   }
 
   if (constructorName === "CloseTo") {
-    const args = [value.sample, value.precision].filter((arg) => arg !== undefined).map(formatValue).join(", ");
+    const args = [value.sample, value.precision]
+      .filter((arg) => arg !== undefined)
+      .map(formatValue)
+      .join(", ");
 
     return `expect.${inversePrefix}closeTo(${args})`;
   }
@@ -336,8 +339,8 @@ const isPromise = (value: unknown): value is Promise<unknown> => value instanceo
 const isThenable = (value: unknown): value is PromiseLike<unknown> =>
   Boolean(
     value &&
-      (typeof value === "object" || typeof value === "function") &&
-      typeof (value as PromiseLike<unknown>).then === "function",
+    (typeof value === "object" || typeof value === "function") &&
+    typeof (value as PromiseLike<unknown>).then === "function",
   );
 
 const observePromise = <T>(promise: Promise<T>, stop: StepStop) => {

--- a/packages/allure-vitest/src/matchers.ts
+++ b/packages/allure-vitest/src/matchers.ts
@@ -1,0 +1,638 @@
+import { Status } from "allure-js-commons";
+import { type RuntimeMessage, getMessageAndTraceFromError, getStatusFromError } from "allure-js-commons/sdk";
+import { getGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
+import type { TaskMeta } from "vitest";
+import { chai } from "vitest";
+
+import { markAsMatcherMessage } from "./matcherMessages.js";
+import { getCurrentTask } from "./runtime.js";
+
+type ChaiStatic = typeof chai;
+type ChaiUtils = ChaiStatic["util"];
+type Assertion = ReturnType<ChaiStatic["expect"]> & Record<PropertyKey, unknown>;
+type AssertionMethod = (this: Assertion, ...args: unknown[]) => unknown;
+type AssertionPrototype = Record<PropertyKey, unknown>;
+type AnyFunction = ((...args: unknown[]) => unknown) & { name?: string; prototype?: unknown };
+type VitestTask = {
+  meta?: TaskMeta;
+  result?: {
+    errors?: unknown[];
+  };
+};
+type RuntimeMessageSender = {
+  sendMessageSync?: (message: RuntimeMessage) => void;
+  sendMessage?: (message: RuntimeMessage) => PromiseLike<void> | void;
+};
+type AsymmetricMatcher = {
+  $$typeof?: unknown;
+  sample?: unknown;
+  inverse?: boolean;
+  precision?: unknown;
+  constructor?: {
+    name?: string;
+  };
+  toString?: () => string;
+};
+type StepStop = (status: Status, error?: unknown) => void;
+
+const ALLURE_VITEST_EXPECT_PATCHED = Symbol.for("allure.vitest.expectPatched");
+const ALLURE_VITEST_EXPECT_EXTEND_PATCHED = Symbol.for("allure.vitest.expectExtendPatched");
+const ALLURE_VITEST_EXPECT_WRAPPED = Symbol.for("allure.vitest.expectWrapped");
+
+const MAX_VALUE_LENGTH = 160;
+const MAX_VALUE_DEPTH = 2;
+const ACTIVE_MATCHER_STEP_FLAG = "allure-vitest-active-matcher-step";
+const JEST_ASYMMETRIC_MATCHER = Symbol.for("jest.asymmetricMatcher");
+// Vitest doesn't expose a public marker for "this Chai assertion came from Vitest expect".
+// Its expect() implementation marks those assertions through withTest() with this flag;
+// we only read it and let Vitest remain the owner of the flag.
+const VITEST_TEST_FLAG = "vitest-test";
+
+const LANGUAGE_CHAINS = new Set([
+  "to",
+  "be",
+  "been",
+  "is",
+  "and",
+  "has",
+  "have",
+  "with",
+  "that",
+  "which",
+  "at",
+  "of",
+  "same",
+  "but",
+  "does",
+  "still",
+  "also",
+]);
+
+const MODIFIER_CHAINS = new Set([
+  "not",
+  "deep",
+  "nested",
+  "own",
+  "ordered",
+  "any",
+  "all",
+  "itself",
+  "resolves",
+  "rejects",
+]);
+
+const SKIPPED_ASSERTION_METHODS = new Set(["assert", "constructor", "withContext", "withTest"]);
+const SKIPPED_ASSERTION_PROPERTIES = new Set(["_obj", "__flags", "__methods", "callable", "iterable", "numeric"]);
+const ASYMMETRIC_MATCHER_FACTORIES = new Map([
+  ["ArrayContaining", "arrayContaining"],
+  ["ObjectContaining", "objectContaining"],
+  ["SchemaMatching", "schemaMatching"],
+  ["StringContaining", "stringContaining"],
+  ["StringMatching", "stringMatching"],
+]);
+
+const isWrapped = (value: unknown) =>
+  typeof value === "function" &&
+  Boolean((value as unknown as Record<PropertyKey, unknown>)[ALLURE_VITEST_EXPECT_WRAPPED]);
+
+const isAsymmetricMatcher = (value: unknown): value is AsymmetricMatcher =>
+  Boolean(value && typeof value === "object" && (value as AsymmetricMatcher).$$typeof === JEST_ASYMMETRIC_MATCHER);
+
+const markWrapped = <T extends AnyFunction>(value: T): T => {
+  Object.defineProperty(value, ALLURE_VITEST_EXPECT_WRAPPED, {
+    value: true,
+  });
+
+  return value;
+};
+
+const limitString = (value: string, maxLength: number) =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}... <truncated>` : value;
+
+const formatFunction = (value: AnyFunction) => {
+  if (value.prototype instanceof Error) {
+    return value.name || "Error";
+  }
+
+  return value.name ? `[Function ${value.name}]` : "[Function]";
+};
+
+const getAsymmetricMatcherName = (value: AsymmetricMatcher): string | undefined => {
+  try {
+    return value.toString?.();
+  } catch {
+    return undefined;
+  }
+};
+
+const isMatcherPath = (value: string) => /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/.test(value);
+
+function formatAsymmetricMatcher(value: AsymmetricMatcher): string {
+  const constructorName = value.constructor?.name;
+  const inversePrefix = value.inverse ? "not." : "";
+
+  if (constructorName === "Any") {
+    const sample = value.sample;
+    const type = typeof sample === "function" && sample.name ? sample.name : formatValue(sample);
+
+    return `expect.${inversePrefix}any(${type})`;
+  }
+
+  if (constructorName === "Anything") {
+    return `expect.${inversePrefix}anything()`;
+  }
+
+  if (constructorName === "CloseTo") {
+    const args = [value.sample, value.precision].filter((arg) => arg !== undefined).map(formatValue).join(", ");
+
+    return `expect.${inversePrefix}closeTo(${args})`;
+  }
+
+  if (constructorName === "CustomMatcher") {
+    const matcherName = getAsymmetricMatcherName(value);
+
+    if (matcherName && isMatcherPath(matcherName)) {
+      const args = Array.isArray(value.sample) ? value.sample.map(formatValue).join(", ") : "";
+
+      return `expect.${matcherName}(${args})`;
+    }
+  }
+
+  const factoryName = constructorName ? ASYMMETRIC_MATCHER_FACTORIES.get(constructorName) : undefined;
+
+  if (factoryName) {
+    return `expect.${inversePrefix}${factoryName}(${formatValue(value.sample)})`;
+  }
+
+  const matcherName = getAsymmetricMatcherName(value);
+
+  if (matcherName) {
+    return matcherName;
+  }
+
+  return "expect.asymmetricMatcher";
+}
+
+const createJsonReplacer = () => {
+  const parents: unknown[] = [];
+
+  return function (this: unknown, _: string, value: unknown): unknown {
+    if (typeof value === "bigint") {
+      return `${value}n`;
+    }
+
+    if (typeof value === "function") {
+      return formatFunction(value as AnyFunction);
+    }
+
+    if (typeof value === "symbol") {
+      return value.toString();
+    }
+
+    if (value instanceof RegExp) {
+      return value.toString();
+    }
+
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: value.message,
+      };
+    }
+
+    if (isAsymmetricMatcher(value)) {
+      return formatAsymmetricMatcher(value);
+    }
+
+    if (!value || typeof value !== "object") {
+      return value;
+    }
+
+    while (parents.length > 0 && !Object.is(parents[parents.length - 1], this)) {
+      parents.pop();
+    }
+
+    if (parents.includes(value)) {
+      return "[Circular]";
+    }
+
+    if (parents.length >= MAX_VALUE_DEPTH) {
+      return Array.isArray(value) ? "[Array]" : "[Object]";
+    }
+
+    parents.push(value);
+
+    return value;
+  };
+};
+
+const formatValue = (value: unknown): string => {
+  if (typeof value === "string") {
+    return limitString(JSON.stringify(value), MAX_VALUE_LENGTH);
+  }
+
+  if (typeof value === "number" || typeof value === "boolean" || value === null || value === undefined) {
+    return String(value);
+  }
+
+  if (typeof value === "bigint") {
+    return `${value}n`;
+  }
+
+  if (typeof value === "symbol") {
+    return value.toString();
+  }
+
+  if (typeof value === "function") {
+    return formatFunction(value as AnyFunction);
+  }
+
+  if (isAsymmetricMatcher(value)) {
+    return limitString(formatAsymmetricMatcher(value), MAX_VALUE_LENGTH);
+  }
+
+  try {
+    return limitString(JSON.stringify(value, createJsonReplacer()) ?? String(value), MAX_VALUE_LENGTH);
+  } catch {
+    return limitString(String(value), MAX_VALUE_LENGTH);
+  }
+};
+
+const formatArguments = (args: unknown[]) => args.map(formatValue).join(", ");
+
+const getCurrentVitestTask = (): VitestTask | undefined => {
+  const task = getCurrentTask() as VitestTask | undefined;
+
+  return task?.meta ? task : undefined;
+};
+
+// In concurrent tests, Vitest's process-global getCurrentTest() can be reset after an awaited gap,
+// so expect() may skip withTest() even though the assertion is still running inside a known test task.
+// Keep that recovery narrow to Vitest/Jest-style matcher names so raw Chai methods like equal()
+// remain ignored.
+const canRecoverVitestTaskFromAsyncContext = (assertionName: string) => assertionName.startsWith("to");
+
+const getVitestTask = (utils: ChaiUtils, assertion: Assertion, assertionName: string): VitestTask | undefined => {
+  const flaggedTask = utils.flag(assertion, VITEST_TEST_FLAG) as VitestTask | undefined;
+  const currentTask = getCurrentVitestTask();
+
+  if (!flaggedTask?.meta) {
+    return canRecoverVitestTaskFromAsyncContext(assertionName) ? currentTask : undefined;
+  }
+
+  return currentTask ?? flaggedTask;
+};
+
+const countErrors = (task: VitestTask | undefined) => task?.result?.errors?.length ?? 0;
+
+const getNewSoftAssertionError = (task: VitestTask | undefined, beforeErrors: number) => {
+  const errors = task?.result?.errors;
+
+  return errors && errors.length > beforeErrors ? errors[errors.length - 1] : undefined;
+};
+
+const sendMatcherMessage = (message: RuntimeMessage) => {
+  const runtime = getGlobalTestRuntime() as RuntimeMessageSender;
+  const matcherMessage = markAsMatcherMessage(message);
+
+  if (runtime.sendMessageSync) {
+    runtime.sendMessageSync(matcherMessage);
+    return;
+  }
+
+  void runtime.sendMessage?.(matcherMessage);
+};
+
+const startMatcherStep = (name: string): StepStop => {
+  sendMatcherMessage({
+    type: "step_start",
+    data: {
+      name,
+      start: Date.now(),
+    },
+  });
+
+  let stopped = false;
+
+  return (status, error) => {
+    if (stopped) {
+      return;
+    }
+
+    stopped = true;
+    sendMatcherMessage({
+      type: "step_stop",
+      data: {
+        status,
+        stop: Date.now(),
+        statusDetails: error ? getMessageAndTraceFromError(error as Error) : undefined,
+      },
+    });
+  };
+};
+
+const isPromise = (value: unknown): value is Promise<unknown> => value instanceof Promise;
+
+const isThenable = (value: unknown): value is PromiseLike<unknown> =>
+  Boolean(
+    value &&
+      (typeof value === "object" || typeof value === "function") &&
+      typeof (value as PromiseLike<unknown>).then === "function",
+  );
+
+const observePromise = <T>(promise: Promise<T>, stop: StepStop) => {
+  void promise.then(
+    () => stop(Status.PASSED),
+    (error) => {
+      stop(getStatusFromError(error as Error), error);
+    },
+  );
+
+  return promise;
+};
+
+const observeThenable = <T>(thenable: PromiseLike<T>, stop: StepStop) => {
+  try {
+    void thenable.then(
+      () => stop(Status.PASSED),
+      (error) => {
+        stop(getStatusFromError(error as Error), error);
+      },
+    );
+  } catch (error) {
+    stop(getStatusFromError(error as Error), error);
+  }
+
+  return thenable;
+};
+
+const restoreActiveMatcherFlag = (utils: ChaiUtils, assertion: Assertion, previousValue: unknown) => {
+  utils.flag(assertion, ACTIVE_MATCHER_STEP_FLAG, previousValue);
+};
+
+const isMatcherStepActive = (utils: ChaiUtils, assertion: Assertion) =>
+  Boolean(utils.flag(assertion, ACTIVE_MATCHER_STEP_FLAG));
+
+const runWithNestedMatcherStepsSuppressed = <T>(utils: ChaiUtils, assertion: Assertion, body: () => T): T => {
+  const previousValue = utils.flag(assertion, ACTIVE_MATCHER_STEP_FLAG);
+
+  utils.flag(assertion, ACTIVE_MATCHER_STEP_FLAG, true);
+
+  try {
+    const result = body();
+
+    if (isPromise(result)) {
+      void result.then(
+        () => restoreActiveMatcherFlag(utils, assertion, previousValue),
+        () => restoreActiveMatcherFlag(utils, assertion, previousValue),
+      );
+      return result;
+    }
+
+    if (isThenable(result)) {
+      try {
+        void result.then(
+          () => restoreActiveMatcherFlag(utils, assertion, previousValue),
+          () => restoreActiveMatcherFlag(utils, assertion, previousValue),
+        );
+      } catch {
+        restoreActiveMatcherFlag(utils, assertion, previousValue);
+      }
+
+      return result;
+    }
+
+    restoreActiveMatcherFlag(utils, assertion, previousValue);
+    return result;
+  } catch (error) {
+    restoreActiveMatcherFlag(utils, assertion, previousValue);
+    throw error;
+  }
+};
+
+const buildMatcherStepName = (
+  utils: ChaiUtils,
+  assertion: Assertion,
+  assertionName: string,
+  args: unknown[],
+  isProperty: boolean,
+) => {
+  const actual = formatValue(utils.flag(assertion, "object"));
+  const promise = utils.flag(assertion, "promise") as string | undefined;
+  const parts = [];
+
+  if (promise) {
+    parts.push(promise);
+  }
+
+  if (utils.flag(assertion, "negate")) {
+    parts.push("not");
+  }
+
+  parts.push(assertionName);
+
+  const argsSuffix = isProperty ? "" : `(${formatArguments(args)})`;
+
+  return `expect(${actual}).${parts.join(".")}${argsSuffix}`;
+};
+
+const runMatcherStep = <T>(
+  task: VitestTask,
+  name: string,
+  body: () => T,
+): T | PromiseLike<Awaited<T>> | Promise<Awaited<T>> => {
+  const stop = startMatcherStep(name);
+  const beforeErrors = countErrors(task);
+
+  try {
+    const result = body();
+
+    if (isPromise(result)) {
+      return observePromise(result, stop) as Promise<Awaited<T>>;
+    }
+
+    if (isThenable(result)) {
+      return observeThenable(result as PromiseLike<Awaited<T>>, stop);
+    }
+
+    const softAssertionError = getNewSoftAssertionError(task, beforeErrors);
+
+    if (softAssertionError) {
+      stop(getStatusFromError(softAssertionError as Error), softAssertionError);
+    } else {
+      stop(Status.PASSED);
+    }
+
+    return result;
+  } catch (error) {
+    stop(getStatusFromError(error as Error), error);
+    throw error;
+  }
+};
+
+const wrapAssertionMethod = (
+  utils: ChaiUtils,
+  prototype: AssertionPrototype,
+  assertionName: string,
+  descriptor: PropertyDescriptor,
+) => {
+  const original = descriptor.value as AssertionMethod;
+
+  if (isWrapped(original)) {
+    return;
+  }
+
+  const wrapped = markWrapped(function (this: Assertion, ...args: unknown[]) {
+    if (isMatcherStepActive(utils, this)) {
+      return original.apply(this, args);
+    }
+
+    const task = getVitestTask(utils, this, assertionName);
+
+    if (!task || utils.flag(this, "poll")) {
+      return original.apply(this, args);
+    }
+
+    return runMatcherStep(task, buildMatcherStepName(utils, this, assertionName, args, false), () =>
+      runWithNestedMatcherStepsSuppressed(utils, this, () => original.apply(this, args)),
+    );
+  });
+
+  Object.defineProperty(prototype, assertionName, {
+    ...descriptor,
+    value: wrapped,
+  });
+};
+
+const wrapAssertionProperty = (
+  utils: ChaiUtils,
+  prototype: AssertionPrototype,
+  assertionName: string,
+  descriptor: PropertyDescriptor,
+) => {
+  const originalGet = descriptor.get;
+
+  if (!originalGet || isWrapped(originalGet)) {
+    return;
+  }
+
+  const wrappedGet = markWrapped(function (this: Assertion) {
+    if (isMatcherStepActive(utils, this)) {
+      return originalGet.call(this);
+    }
+
+    const task = getVitestTask(utils, this, assertionName);
+
+    if (!task || utils.flag(this, "poll")) {
+      return originalGet.call(this);
+    }
+
+    return runMatcherStep(task, buildMatcherStepName(utils, this, assertionName, [], true), () =>
+      runWithNestedMatcherStepsSuppressed(utils, this, () => originalGet.call(this)),
+    );
+  });
+
+  Object.defineProperty(prototype, assertionName, {
+    ...descriptor,
+    get: wrappedGet,
+  });
+};
+
+const wrapDescriptor = (utils: ChaiUtils, prototype: AssertionPrototype, assertionName: string) => {
+  if (SKIPPED_ASSERTION_METHODS.has(assertionName) || SKIPPED_ASSERTION_PROPERTIES.has(assertionName)) {
+    return;
+  }
+
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, assertionName);
+
+  if (!descriptor) {
+    return;
+  }
+
+  if (typeof descriptor.value === "function") {
+    wrapAssertionMethod(utils, prototype, assertionName, descriptor);
+    return;
+  }
+
+  if (!descriptor.get || LANGUAGE_CHAINS.has(assertionName) || MODIFIER_CHAINS.has(assertionName)) {
+    return;
+  }
+
+  wrapAssertionProperty(utils, prototype, assertionName, descriptor);
+};
+
+const instrumentWithTest = (prototype: AssertionPrototype) => {
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, "withTest");
+  const original = descriptor?.value as AssertionMethod | undefined;
+
+  if (!descriptor || typeof original !== "function" || isWrapped(original)) {
+    return;
+  }
+
+  const wrapped = markWrapped(function (this: Assertion, task?: unknown, ...args: unknown[]) {
+    return original.call(this, getCurrentVitestTask() ?? task, ...args);
+  });
+
+  Object.defineProperty(prototype, "withTest", {
+    ...descriptor,
+    value: wrapped,
+  });
+};
+
+const instrumentExistingAssertions = (utils: ChaiUtils, prototype: AssertionPrototype) => {
+  if (prototype[ALLURE_VITEST_EXPECT_PATCHED]) {
+    return;
+  }
+
+  Object.defineProperty(prototype, ALLURE_VITEST_EXPECT_PATCHED, {
+    value: true,
+  });
+
+  for (const assertionName of Object.getOwnPropertyNames(prototype)) {
+    wrapDescriptor(utils, prototype, assertionName);
+  }
+};
+
+const instrumentExpectExtend = (utils: ChaiUtils, prototype: AssertionPrototype) => {
+  const expectStatic = chai.expect as unknown as Record<PropertyKey, unknown>;
+
+  if (expectStatic[ALLURE_VITEST_EXPECT_EXTEND_PATCHED]) {
+    return;
+  }
+
+  Object.defineProperty(expectStatic, ALLURE_VITEST_EXPECT_EXTEND_PATCHED, {
+    value: true,
+  });
+
+  const descriptor = Object.getOwnPropertyDescriptor(expectStatic, "extend");
+  const original = descriptor?.value;
+
+  if (!descriptor || typeof original !== "function" || isWrapped(original)) {
+    return;
+  }
+
+  const wrapped = markWrapped(function (this: unknown, ...args: unknown[]) {
+    const result = original.apply(this, args);
+
+    for (const matchers of args) {
+      if (matchers && typeof matchers === "object") {
+        Object.keys(matchers).forEach((assertionName) => wrapDescriptor(utils, prototype, assertionName));
+      }
+    }
+
+    return result;
+  });
+
+  Object.defineProperty(expectStatic, "extend", {
+    ...descriptor,
+    value: wrapped,
+  });
+};
+
+export const registerAllureVitestExpect = () => {
+  const prototype = chai.Assertion.prototype as unknown as AssertionPrototype;
+
+  instrumentWithTest(prototype);
+  instrumentExistingAssertions(chai.util, prototype);
+  instrumentExpectExtend(chai.util, prototype);
+};

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -23,10 +23,15 @@ import type { TestModule, Vitest } from "vitest/node";
 import type { Reporter } from "vitest/reporters";
 
 import { commands as allureBrowserCommands } from "./browser/index.js";
+import { isMatcherMessage } from "./matcherMessages.js";
 import { takeGlobalRuntimeMessages } from "./runtime.js";
 import { getTestMetadata } from "./utils.js";
 
 const localRequire = createRequire(import.meta.url);
+
+export type AllureVitestReporterConfig = ReporterConfig & {
+  reportMatchers?: boolean;
+};
 
 const setupModulePath = fileURLToPath(new URL("./setup.js", import.meta.url));
 
@@ -37,10 +42,10 @@ const normalizeSetupFilePath = (setupFilePath: string) =>
 
 export default class AllureVitestReporter implements Reporter {
   private allureReporterRuntime?: ReporterRuntime;
-  private config: ReporterConfig;
+  private config: AllureVitestReporterConfig;
   private globalRuntimeMessages: RuntimeMessage[] = [];
 
-  constructor(config: ReporterConfig) {
+  constructor(config: AllureVitestReporterConfig) {
     this.config = config;
   }
 
@@ -48,7 +53,7 @@ export default class AllureVitestReporter implements Reporter {
     this.registerSetupFile(vitest);
     this.enableConcurrencySupport(vitest);
 
-    const { listeners, resultsDir, ...config } = this.config;
+    const { listeners, resultsDir, reportMatchers: _reportMatchers, ...config } = this.config;
 
     this.allureReporterRuntime = new ReporterRuntime({
       ...config,
@@ -187,8 +192,13 @@ export default class AllureVitestReporter implements Reporter {
         result.labels.push(getPackageLabel(task.file.filepath));
       }
 
-      if (allureRuntimeMessages.length) {
-        this.allureReporterRuntime!.applyRuntimeMessages(testUuid, allureRuntimeMessages);
+      const runtimeMessages =
+        this.config.reportMatchers ?? true
+          ? allureRuntimeMessages
+          : allureRuntimeMessages.filter((m) => !isMatcherMessage(m));
+
+      if (runtimeMessages.length) {
+        this.allureReporterRuntime!.applyRuntimeMessages(testUuid, runtimeMessages);
       }
 
       switch (task.result?.state) {

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -193,7 +193,7 @@ export default class AllureVitestReporter implements Reporter {
       }
 
       const runtimeMessages =
-        this.config.reportMatchers ?? true
+        (this.config.reportMatchers ?? true)
           ? allureRuntimeMessages
           : allureRuntimeMessages.filter((m) => !isMatcherMessage(m));
 

--- a/packages/allure-vitest/src/runtime.ts
+++ b/packages/allure-vitest/src/runtime.ts
@@ -30,6 +30,8 @@ export type RuntimeMessageTaskMeta = TaskMeta & {
   [ALLURE_VITEST_RUNTIME_MESSAGES_META_KEY]?: RuntimeMessage[];
 };
 
+export const getCurrentTask = (): Task | undefined => getCurrentTest();
+
 export const addGlobalMessage = (message: RuntimeMessage) => {
   const holder = globalThis as unknown as Record<string, RuntimeMessage[] | undefined>;
   const messages = (holder[ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_KEY] ??= []);

--- a/packages/allure-vitest/src/setup.ts
+++ b/packages/allure-vitest/src/setup.ts
@@ -4,11 +4,13 @@ import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
 
 import { getCurrentTest } from "./concurrentState.js";
 import { allureVitestLegacyApi } from "./legacy.js";
+import { registerAllureVitestExpect } from "./matchers.js";
 import { setGetCurrentTest } from "./runtime.js";
 import { existsInTestPlan } from "./utils.js";
 import { VitestTestRuntime } from "./VitestTestRuntime.js";
 
 setGetCurrentTest(getCurrentTest);
+registerAllureVitestExpect();
 
 beforeAll(() => {
   globalThis.allureTestPlan = parseTestPlan();

--- a/packages/allure-vitest/test/spec/expect-extend.test.ts
+++ b/packages/allure-vitest/test/spec/expect-extend.test.ts
@@ -32,6 +32,12 @@ describe("expect.extend", () => {
           expect.objectContaining({
             name: "fail test",
             status: "failed",
+            steps: [
+              expect.objectContaining({
+                name: "expect({}).toFail()",
+                status: "failed",
+              }),
+            ],
             statusDetails: expect.objectContaining({
               message: "some message",
             }),

--- a/packages/allure-vitest/test/spec/expect.test.ts
+++ b/packages/allure-vitest/test/spec/expect.test.ts
@@ -12,6 +12,97 @@ describe("expect", () => {
           env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
       });
 
+      it("should report vitest expect matchers as steps by default", async () => {
+        const { tests } = await runVitestInlineTest({
+          "vitest.config.ts": configFileAccessor,
+          "sample.test.ts": `
+    import { test, expect } from "vitest";
+
+    test("pass test", async () => {
+      expect(1).toBe(1);
+      expect(1).not.toBe(2);
+      expect([1]).toHaveLength(1);
+      await expect(Promise.resolve(1)).resolves.toBe(1);
+      await expect(Promise.reject("boom")).rejects.toBe("boom");
+    });
+
+  `,
+        });
+
+        expect(tests).toHaveLength(1);
+        expect(tests[0].steps.map((s) => s.name)).toEqual([
+          "expect(1).toBe(1)",
+          "expect(1).not.toBe(2)",
+          "expect([1]).toHaveLength(1)",
+          "expect(1).resolves.toBe(1)",
+          'expect("boom").rejects.toBe("boom")',
+        ]);
+        expect(tests[0].steps.find((s) => s.name === "expect([1]).toHaveLength(1)")?.steps).toEqual([]);
+        expect(tests[0].steps.every((s) => s.status === "passed")).toBe(true);
+      });
+
+      if (env === "node") {
+        it("should keep matcher steps attached to the correct concurrent test", async () => {
+          const { tests } = await runVitestInlineTest({
+            "vitest.config.ts": configFileAccessor,
+            "sample.test.ts": `
+    import { describe, test, expect } from "vitest";
+
+    const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+    describe.concurrent("dummy", () => {
+      test("first", async () => {
+        expect("first sync").toBe("first sync");
+        await delay(200);
+        expect("first async").toBe("first async");
+      });
+
+      test("second", async () => {
+        expect("second sync").toBe("second sync");
+        await delay(100);
+        expect("second async").toBe("second async");
+      });
+    });
+
+  `,
+          });
+
+          expect(tests).toHaveLength(2);
+          const first = tests.find(({ name }) => name === "first");
+          const second = tests.find(({ name }) => name === "second");
+
+          expect(first?.steps.map(({ name }) => name)).toEqual([
+            'expect("first sync").toBe("first sync")',
+            'expect("first async").toBe("first async")',
+          ]);
+          expect(second?.steps.map(({ name }) => name)).toEqual([
+            'expect("second sync").toBe("second sync")',
+            'expect("second async").toBe("second async")',
+          ]);
+        });
+      }
+
+      it("should format asymmetric matcher arguments", async () => {
+        const { tests } = await runVitestInlineTest({
+          "vitest.config.ts": configFileAccessor,
+          "sample.test.ts": `
+    import { test, expect } from "vitest";
+
+    test("pass test", () => {
+      expect([{ name: "foo", value: "bar", extra: "baz" }]).toContainEqual(
+        expect.objectContaining({ name: "foo", value: "bar" }),
+      );
+    });
+
+  `,
+        });
+
+        expect(tests).toHaveLength(1);
+        expect(tests[0].steps.map((s) => s.name)).toEqual([
+          'expect([{"name":"foo","value":"bar","extra":"baz"}]).toContainEqual(expect.objectContaining({"name":"foo","value":"bar"}))',
+        ]);
+      });
+
       it("should add actual and expected values when using expect", async () => {
         const { tests } = await runVitestInlineTest({
           "vitest.config.ts": configFileAccessor,
@@ -35,6 +126,16 @@ describe("expect", () => {
               expected: "the other one",
               actual: "a value",
             },
+            steps: [
+              {
+                name: 'expect("a value").toEqual("the other one")',
+                status: "failed",
+                statusDetails: {
+                  expected: "the other one",
+                  actual: "a value",
+                },
+              },
+            ],
           },
         ]);
       });
@@ -95,6 +196,47 @@ describe("expect", () => {
         expect(statusDetails.trace).toContain("Error: fail!");
         expect(statusDetails.expected).toBeUndefined();
         expect(statusDetails.actual).toBeUndefined();
+      });
+
+      it("should disable matcher reporting when reportMatchers is false", async () => {
+        const { tests } = await runVitestInlineTest({
+          "vitest.config.ts": ({ allureResultsPath }) =>
+            env === "node"
+              ? createVitestConfig(allureResultsPath, { reportMatchers: false })
+              : createVitestBrowserConfig(allureResultsPath, { reportMatchers: false }),
+          "sample.test.ts": `
+    import { test, expect } from "vitest";
+    import * as allure from "allure-js-commons";
+
+    test("pass test", async () => {
+      expect(1).toBe(1);
+      await allure.step("manual step", async () => {
+        expect(2).toBe(2);
+      });
+    });
+
+  `,
+        });
+
+        expect(tests).toHaveLength(1);
+        expect(tests[0].steps.map((s) => s.name)).toEqual(["manual step"]);
+      });
+
+      it("should not report raw chai assertions as vitest matcher steps", async () => {
+        const { tests } = await runVitestInlineTest({
+          "vitest.config.ts": configFileAccessor,
+          "sample.test.ts": `
+    import { chai, test } from "vitest";
+
+    test("pass test", () => {
+      chai.expect(1).to.equal(1);
+    });
+
+  `,
+        });
+
+        expect(tests).toHaveLength(1);
+        expect(tests[0].steps).toEqual([]);
       });
     });
   }

--- a/packages/allure-vitest/test/utils.ts
+++ b/packages/allure-vitest/test/utils.ts
@@ -19,6 +19,10 @@ export type TestFileAccessor = (opts: {
 
 export type TestFiles = Record<string, string | TestFileAccessor>;
 
+type VitestConfigOptions = {
+  reportMatchers?: boolean;
+};
+
 type Opts = {
   env?: (testDir: string) => Record<string, string>;
   cwd?: string;
@@ -30,7 +34,20 @@ export const setupModulePath = getPosixPath(require.resolve("allure-vitest/setup
 
 export const reporterModulePath = getPosixPath(require.resolve("allure-vitest/reporter"));
 
-export const createVitestConfig = (allureResultsPath: string) => `
+const createReporterOptions = (allureResultsPath: string, options: VitestConfigOptions = {}) => `
+          links: {
+            issue: {
+              urlTemplate: "https://example.org/issue/%s",
+            },
+            tms: {
+              urlTemplate: "https://example.org/tms/%s",
+            },
+          },
+          resultsDir: "${allureResultsPath}",
+          ${options.reportMatchers === undefined ? "" : `reportMatchers: ${options.reportMatchers},`}
+`;
+
+export const createVitestConfig = (allureResultsPath: string, options: VitestConfigOptions = {}) => `
   import { defineConfig } from "vitest/config";
 
   export default defineConfig({
@@ -41,22 +58,14 @@ export const createVitestConfig = (allureResultsPath: string) => `
       reporters: [
         "verbose",
         ["${reporterModulePath}", {
-          links: {
-            issue: {
-              urlTemplate: "https://example.org/issue/%s",
-            },
-            tms: {
-              urlTemplate: "https://example.org/tms/%s",
-            },
-          },
-          resultsDir: "${allureResultsPath}",
+${createReporterOptions(allureResultsPath, options)}
         }]
       ],
     },
   });
 `;
 
-export const createVitestBrowserConfig = (allureResultsPath: string) => `
+export const createVitestBrowserConfig = (allureResultsPath: string, options: VitestConfigOptions = {}) => `
   import { defineConfig } from "vitest/config";
   import { playwright } from "@vitest/browser-playwright";
 
@@ -68,15 +77,7 @@ export const createVitestBrowserConfig = (allureResultsPath: string) => `
       reporters: [
         "verbose",
         ["${reporterModulePath}", {
-          links: {
-            issue: {
-              urlTemplate: "https://example.org/issue/%s",
-            },
-            tms: {
-              urlTemplate: "https://example.org/tms/%s",
-            },
-          },
-          resultsDir: "${allureResultsPath}",
+${createReporterOptions(allureResultsPath, options)}
         }]
       ],
       browser: {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

This adds native `expect` matcher reporting to `allure-vitest`. Vitest assertions such as `expect(1).toBe(1)`, `expect(value).not.toEqual(...)`, `resolves`, `rejects`, and custom `expect.extend(...)` matchers are now shown as Allure steps by default. Failed matchers are reported as failed steps while preserving the normal test failure details.

Matcher reporting can be disabled with `reportMatchers: false` without affecting user-created Allure steps or failed-test `actual` / `expected` details:

```ts
["allure-vitest/reporter", {
  resultsDir: "./allure-results",
  reportMatchers: false,
}]
```

The implementation is Vitest-native and only reports Vitest `expect` assertions, so separately imported raw Chai assertions are not shown as matcher steps. Step names also render common Vitest asymmetric matchers in a readable form, for example `expect.objectContaining(...)` instead of Vitest’s internal matcher object.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js