### PR TITLE
Fix concurrency support for Vitest 4.1 and custom runners

### DIFF
--- a/packages/allure-vitest/src/concurrentState.ts
+++ b/packages/allure-vitest/src/concurrentState.ts
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import { type Test, getCurrentTest as getCurrentTestGlobal } from "@vitest/runner";
+
+type AllureAwareGlobalThis = { __allureVitestAsyncContext?: AllureVitestAsyncContext };
+
+type AllureVitestAsyncContext = {
+  currentTaskStorage: AsyncLocalStorage<Test>;
+  activeTasks: WeakSet<Test>;
+};
+
+export const getAsyncContext = () => {
+  const holder = globalThis as unknown as AllureAwareGlobalThis;
+
+  return (holder.__allureVitestAsyncContext ??= {
+    currentTaskStorage: new AsyncLocalStorage<Test>(),
+    activeTasks: new WeakSet<Test>(),
+  });
+};
+
+export const getCurrentTest = () => {
+  const holder = globalThis as unknown as AllureAwareGlobalThis;
+  const asyncContext = holder.__allureVitestAsyncContext;
+  const task = asyncContext?.currentTaskStorage.getStore();
+
+  if (task) {
+    return (asyncContext?.activeTasks?.has(task) ?? true) ? task : undefined;
+  }
+
+  return getCurrentTestGlobal();
+};

--- a/packages/allure-vitest/src/index.ts
+++ b/packages/allure-vitest/src/index.ts
@@ -1,17 +1,5 @@
-/* eslint no-var: "off" */
-import { type TestPlanV1 } from "allure-js-commons/sdk";
-
 import type { AllureVitestLegacyApi } from "./legacy.js";
 
 declare global {
   var allure: AllureVitestLegacyApi;
-  var allureTestPlan: TestPlanV1 | undefined;
-}
-
-declare module "vitest" {
-  interface TaskMeta {
-    vitestWorker?: string;
-    browser?: string;
-    allureSkip?: boolean;
-  }
 }

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -1,3 +1,4 @@
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 import { Stage, Status } from "allure-js-commons";
@@ -25,6 +26,8 @@ import { commands as allureBrowserCommands } from "./browser/index.js";
 import { takeGlobalRuntimeMessages } from "./runtime.js";
 import { getTestMetadata } from "./utils.js";
 
+const localRequire = createRequire(import.meta.url);
+
 const setupModulePath = fileURLToPath(new URL("./setup.js", import.meta.url));
 
 const browserSetupModulePath = fileURLToPath(new URL("./browser/setup.js", import.meta.url));
@@ -43,6 +46,7 @@ export default class AllureVitestReporter implements Reporter {
 
   onInit(vitest: Vitest) {
     this.registerSetupFile(vitest);
+    this.enableConcurrencySupport(vitest);
 
     const { listeners, resultsDir, ...config } = this.config;
 
@@ -75,6 +79,16 @@ export default class AllureVitestReporter implements Reporter {
         for (const [name, command] of Object.entries(allureBrowserCommands)) {
           project.config.browser.commands[name] ??= command;
         }
+      }
+    }
+  }
+
+  private enableConcurrencySupport(vitest: Vitest) {
+    for (const project of vitest.projects) {
+      if (!project.config.browser.enabled) {
+        // @ts-ignore
+        project.provide("__allure_vitest_custom_runner_module__", project.config.runner);
+        project.config.runner = localRequire.resolve("./runner.js");
       }
     }
   }

--- a/packages/allure-vitest/src/reporter.ts
+++ b/packages/allure-vitest/src/reporter.ts
@@ -86,7 +86,6 @@ export default class AllureVitestReporter implements Reporter {
   private enableConcurrencySupport(vitest: Vitest) {
     for (const project of vitest.projects) {
       if (!project.config.browser.enabled) {
-        // @ts-ignore
         project.provide("__allure_vitest_custom_runner_module__", project.config.runner);
         project.config.runner = localRequire.resolve("./runner.js");
       }
@@ -133,13 +132,7 @@ export default class AllureVitestReporter implements Reporter {
       vitestWorker,
       browser,
       allureSkip = false,
-    } = task.meta as {
-      allureRuntimeMessages: RuntimeMessage[];
-      allureGlobalRuntimeMessages: RuntimeMessage[];
-      vitestWorker: string;
-      allureSkip?: boolean;
-      browser?: string;
-    };
+    } = task.meta;
 
     // do not report tests skipped by test plan
     if (allureSkip) {

--- a/packages/allure-vitest/src/runner.ts
+++ b/packages/allure-vitest/src/runner.ts
@@ -1,0 +1,86 @@
+import type { VitestRunner, Test } from "@vitest/runner";
+import type { SerializedConfig } from "vitest";
+import * as vitest from "vitest";
+
+import { getAsyncContext } from "./concurrentState.js";
+
+type VitestRunnerCtor = new (config: SerializedConfig) => VitestRunner;
+
+const resolveRunnerBaseClass = async (): Promise<VitestRunnerCtor> => {
+  //@ts-ignore
+  const customRunnerModulePath = vitest.inject("__allure_vitest_custom_runner_module__");
+  if (customRunnerModulePath) {
+    // The value comes from config.runner, which is always resolved to an absolute
+    // or bare specifier
+    const customRunnerCtor = (await import(customRunnerModulePath)).default;
+    if (!customRunnerCtor && typeof customRunnerCtor !== "function") {
+      throw new Error(
+        `Runner must export a default function, but got ${typeof customRunnerCtor} imported from ${customRunnerModulePath}`,
+      );
+    }
+    return customRunnerCtor;
+  }
+
+  if ("TestRunner" in vitest) {
+    // Vitest 4.1+
+    return vitest.TestRunner as VitestRunnerCtor;
+  }
+
+  // Vitest <=4.0
+  const { VitestTestRunner } = await import("vitest/runners");
+  return VitestTestRunner;
+};
+
+export default class ConcurrencyAwareAllureVitestRunner
+  extends (await resolveRunnerBaseClass())
+  implements VitestRunner
+{
+  constructor(config: SerializedConfig) {
+    super(config);
+
+    this.onBeforeRunTask = async (test: Test) => {
+      const asyncContext = getAsyncContext();
+
+      asyncContext.activeTasks.add(test as Test);
+      asyncContext.currentTaskStorage.enterWith(test as Test);
+
+      await super.onBeforeRunTask?.(test);
+
+      this.#releaseNonRunnableTask(test);
+    };
+
+    this.onAfterRetryTask = (test: Test, options: { retry: number; repeats: number }) => {
+      try {
+        return super.onAfterRetryTask?.(test, options);
+      } finally {
+        this.#releaseDynamicallySkippedTask(test);
+      }
+    };
+
+    this.onAfterRunTask = async (test: Test) => {
+      try {
+        return await super.onAfterRunTask?.(test);
+      } finally {
+        this.#releaseTask(test);
+      }
+    };
+  }
+
+  #releaseNonRunnableTask = (test: Test) => {
+    if (test.mode !== "run" && test.mode !== "queued") {
+      this.#releaseTask(test);
+    }
+  };
+
+  #releaseTask = (test: Test) => {
+    getAsyncContext().activeTasks.delete(test as Test);
+  };
+
+  #releaseDynamicallySkippedTask = (test: Test) => {
+    const result = (test as Test).result as { pending?: boolean; state?: string } | undefined;
+
+    if (result?.pending || result?.state === "skip") {
+      this.#releaseTask(test);
+    }
+  };
+}

--- a/packages/allure-vitest/src/runner.ts
+++ b/packages/allure-vitest/src/runner.ts
@@ -7,7 +7,6 @@ import { getAsyncContext } from "./concurrentState.js";
 type VitestRunnerCtor = new (config: SerializedConfig) => VitestRunner;
 
 const resolveRunnerBaseClass = async (): Promise<VitestRunnerCtor> => {
-  //@ts-ignore
   const customRunnerModulePath = vitest.inject("__allure_vitest_custom_runner_module__");
   if (customRunnerModulePath) {
     // The value comes from config.runner, which is always resolved to an absolute

--- a/packages/allure-vitest/src/runtime.ts
+++ b/packages/allure-vitest/src/runtime.ts
@@ -1,15 +1,25 @@
-import { type SuiteCollector, type Task, getCurrentSuite, getCurrentTest } from "@vitest/runner";
+import {
+  type SuiteCollector,
+  type Task,
+  type Test,
+  getCurrentSuite,
+  getCurrentTest as getCurrentTestGlobal,
+} from "@vitest/runner";
 import { type RuntimeMessage, isGlobalRuntimeMessage } from "allure-js-commons/sdk";
 import { BaseMessageTestRuntime } from "allure-js-commons/sdk/runtime";
 import type { TaskMeta } from "vitest";
+
+let getCurrentTest: () => Test | undefined = getCurrentTestGlobal;
+
+export const setGetCurrentTest = (fn: () => Test | undefined) => {
+  getCurrentTest = fn;
+};
 
 export const ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_KEY = "__allureVitestGlobalRuntimeMessages";
 
 export const ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_META_KEY = "allureGlobalRuntimeMessages";
 
 export const ALLURE_VITEST_RUNTIME_MESSAGES_META_KEY = "allureRuntimeMessages";
-
-export const ALLURE_VITEST_ASYNC_CONTEXT_KEY = "__allureVitestAsyncContext";
 
 export type RuntimeMessageMetaKey =
   | typeof ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_META_KEY
@@ -18,27 +28,6 @@ export type RuntimeMessageMetaKey =
 export type RuntimeMessageTaskMeta = TaskMeta & {
   [ALLURE_VITEST_GLOBAL_RUNTIME_MESSAGES_META_KEY]?: RuntimeMessage[];
   [ALLURE_VITEST_RUNTIME_MESSAGES_META_KEY]?: RuntimeMessage[];
-};
-
-type AllureVitestAsyncContext = {
-  currentTaskStorage: {
-    getStore: () => Task | undefined;
-  };
-  activeTasks?: {
-    has: (task: Task) => boolean;
-  };
-};
-
-const getCurrentTask = (): Task | undefined => {
-  const holder = globalThis as unknown as Record<string, AllureVitestAsyncContext | undefined>;
-  const asyncContext = holder[ALLURE_VITEST_ASYNC_CONTEXT_KEY];
-  const task = asyncContext?.currentTaskStorage.getStore();
-
-  if (task) {
-    return (asyncContext?.activeTasks?.has(task) ?? true) ? task : undefined;
-  }
-
-  return getCurrentTest();
 };
 
 export const addGlobalMessage = (message: RuntimeMessage) => {
@@ -124,7 +113,7 @@ export class BaseVitestTestRuntime extends BaseMessageTestRuntime {
   }
 
   protected processMessage(message: RuntimeMessage): boolean {
-    const currentTest = getCurrentTask();
+    const currentTest = getCurrentTest();
 
     if (isGlobalRuntimeMessage(message)) {
       if (currentTest) {

--- a/packages/allure-vitest/src/setup.ts
+++ b/packages/allure-vitest/src/setup.ts
@@ -1,97 +1,14 @@
-import { AsyncLocalStorage } from "node:async_hooks";
-
-import type { Task, Test } from "@vitest/runner";
 import { parseTestPlan } from "allure-js-commons/sdk/reporter";
 import { setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
-import { VitestTestRunner } from "vitest/runners";
 
+import { getCurrentTest } from "./concurrentState.js";
 import { allureVitestLegacyApi } from "./legacy.js";
-import { ALLURE_VITEST_ASYNC_CONTEXT_KEY } from "./runtime.js";
+import { setGetCurrentTest } from "./runtime.js";
 import { existsInTestPlan } from "./utils.js";
 import { VitestTestRuntime } from "./VitestTestRuntime.js";
 
-const ALLURE_VITEST_RUNNER_PATCHED_KEY = Symbol.for("allure-vitest.runnerPatched");
-
-type AllureVitestAsyncContext = {
-  currentTaskStorage: AsyncLocalStorage<Test>;
-  activeTasks: WeakSet<Test>;
-};
-
-type PatchedRunner = typeof VitestTestRunner.prototype & {
-  [ALLURE_VITEST_RUNNER_PATCHED_KEY]?: true;
-  onAfterRetryTask?: (test: Task, retryInfo: { retry: number; repeats: number }) => unknown;
-};
-
-const getAsyncContext = (): AllureVitestAsyncContext => {
-  const holder = globalThis as unknown as Record<string, AllureVitestAsyncContext | undefined>;
-
-  return (holder[ALLURE_VITEST_ASYNC_CONTEXT_KEY] ??= {
-    currentTaskStorage: new AsyncLocalStorage<Test>(),
-    activeTasks: new WeakSet<Test>(),
-  });
-};
-
-const patchVitestRunner = () => {
-  const prototype = VitestTestRunner.prototype as PatchedRunner;
-
-  if (prototype[ALLURE_VITEST_RUNNER_PATCHED_KEY]) {
-    return;
-  }
-
-  const originalOnBeforeRunTask = prototype.onBeforeRunTask;
-  const originalOnAfterRetryTask = prototype.onAfterRetryTask;
-  const originalOnAfterRunTask = prototype.onAfterRunTask;
-
-  const releaseTask = (test: Task) => {
-    getAsyncContext().activeTasks.delete(test as Test);
-  };
-
-  const releaseNonRunnableTask = (test: Task) => {
-    if (test.mode !== "run" && test.mode !== "queued") {
-      releaseTask(test);
-    }
-  };
-
-  const releaseDynamicallySkippedTask = (test: Task) => {
-    const result = (test as Test).result as { pending?: boolean; state?: string } | undefined;
-
-    if (result?.pending || result?.state === "skip") {
-      releaseTask(test);
-    }
-  };
-
-  prototype.onBeforeRunTask = async function allureOnBeforeRunTask(test: Task) {
-    const asyncContext = getAsyncContext();
-
-    asyncContext.activeTasks.add(test as Test);
-    asyncContext.currentTaskStorage.enterWith(test as Test);
-
-    await originalOnBeforeRunTask.call(this, test);
-
-    releaseNonRunnableTask(test);
-  };
-
-  prototype.onAfterRetryTask = function allureOnAfterRetryTask(test: Task, retryInfo) {
-    try {
-      return originalOnAfterRetryTask?.call(this, test, retryInfo);
-    } finally {
-      releaseDynamicallySkippedTask(test);
-    }
-  };
-
-  prototype.onAfterRunTask = async function allureOnAfterRunTask(test: Task) {
-    try {
-      return await originalOnAfterRunTask.call(this, test);
-    } finally {
-      releaseTask(test);
-    }
-  };
-
-  prototype[ALLURE_VITEST_RUNNER_PATCHED_KEY] = true;
-};
-
-patchVitestRunner();
+setGetCurrentTest(getCurrentTest);
 
 beforeAll(() => {
   globalThis.allureTestPlan = parseTestPlan();

--- a/packages/allure-vitest/src/vitest-internal.d.ts
+++ b/packages/allure-vitest/src/vitest-internal.d.ts
@@ -1,0 +1,20 @@
+import "vitest";
+import type { RuntimeMessage, TestPlanV1 } from "allure-js-commons/sdk";
+
+declare global {
+  var allureTestPlan: TestPlanV1 | undefined;
+}
+
+declare module "vitest" {
+  interface ProvidedContext {
+    __allure_vitest_custom_runner_module__?: string;
+  }
+
+  interface TaskMeta {
+    vitestWorker?: string;
+    browser?: string;
+    allureSkip?: boolean;
+    allureRuntimeMessages?: RuntimeMessage[];
+    allureGlobalRuntimeMessages?: RuntimeMessage[];
+  }
+}

--- a/packages/allure-vitest/test/spec/expect.test.ts
+++ b/packages/allure-vitest/test/spec/expect.test.ts
@@ -58,8 +58,16 @@ describe("expect", () => {
             name: "fail test",
             status: "failed",
             statusDetails: {
-              expected: "Object {\n" + '  "nested": Object {\n' + '    "obj": "some",\n' + "  },\n" + "}",
-              actual: "Object {\n" + '  "nested": Object {\n' + '    "obj": "value",\n' + "  },\n" + "}",
+              expected: expect.toBeOneOf([
+                // Vitest < 4.1
+                "Object {\n" + '  "nested": Object {\n' + '    "obj": "some",\n' + "  },\n" + "}",
+                // Vitest 4.1+
+                "{\n" + '  "nested": {\n' + '    "obj": "some",\n' + "  },\n" + "}",
+              ]),
+              actual: expect.toBeOneOf([
+                "Object {\n" + '  "nested": Object {\n' + '    "obj": "value",\n' + "  },\n" + "}",
+                "{\n" + '  "nested": {\n' + '    "obj": "value",\n' + "  },\n" + "}",
+              ]),
             },
           },
         ]);

--- a/packages/allure-vitest/test/spec/runtime/modern/steps.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/steps.test.ts
@@ -261,6 +261,73 @@ describe("steps", () => {
       expect(second?.steps[0].name).toBe("Second outer");
       expect(second?.steps[0].steps.map(({ name }) => name)).toEqual(["Second inner"]);
     });
+
+    it("supports custom runners in a concurrent environment", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": ({ allureResultsPath, reporterModulePath }) => `
+          import { defineConfig } from "vitest/config";
+
+          export default defineConfig({
+            test: {
+              runner: "./runner.mjs",
+              openTelemetry: {
+                enabled: false,
+              },
+              reporters: [
+                "verbose",
+                ["${reporterModulePath}", {
+                  resultsDir: "${allureResultsPath}",
+                }]
+              ],
+            },
+          });
+        `,
+        "runner.mjs": `
+          export default class CustomRunner {
+            constructor(config) {
+              this.config = config;
+            }
+            async importFile(filepath, source) {
+              await this.moduleRunner.import(filepath);
+            }
+          };
+        `,
+        "sample.test.ts": `
+          import { describe, test } from "vitest";
+          import { step } from "allure-js-commons";
+
+          const passControl = () => new Promise(setImmediate);
+
+          describe.concurrent("dummy", () => {
+            test("first", async () => {
+              await step("First outer", async () => {
+                await passControl();
+                await step("First inner", () => {});
+              });
+            });
+
+            test("second", async () => {
+              await step("Second outer", async () => {
+                await passControl();
+                await step("Second inner", () => {});
+              });
+            });
+          });
+        `,
+      });
+
+      expect(tests).toHaveLength(2);
+      const first = tests.find(({ name }) => name === "first");
+      const second = tests.find(({ name }) => name === "second");
+
+      expect(first?.steps).toHaveLength(1);
+      expect(first?.steps[0].name).toBe("First outer");
+      expect(first?.steps[0].steps.map(({ name }) => name)).toEqual(["First inner"]);
+
+      expect(second?.steps).toHaveLength(1);
+      expect(second?.steps[0].name).toBe("Second outer");
+      expect(second?.steps[0].steps.map(({ name }) => name)).toEqual(["Second inner"]);
+    });
   });
 
   describe('for "browser"', () => {


### PR DESCRIPTION
### Context

#1471 introduces support for concurrent test execution to `allure-vitest`. This PR updates the concurrency support, so it also works when a project provides a custom runner. It does so by introducing an Allure runner wrapper that extends the built-in or custom runner with async state management.

The async context management logic was moved to this wrapper. The reporter forces all non-browser projects to use this runner. A custom runner module specifier is communicated to the wrapper via `provide/inject`. If no custom runner is configured, the wrapper will use the default one.

Additionally, Vitest deprecates `vitest/runners` export in 4.1 and is going to remove it in a future major version (it's already removed in `main`). Newer versions of Vitest provide the runner as `import { TestRunner } from "vitest";`. The PR adapts the way the default runner is imported for wrapping, so it attempts using the new path, falling back to `vitest/runners` if `TestRunner` is not defined.

#### Extra changes

  - Make an actual/expected test Vitest 4.1 friendly to make a future Vitest bump less painful.
  - Move internal Vitest type declarations to `vitest-internal.d.ts`. This prevents these internal declarations from leaking to consumers' code.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
