### PR TITLE
vitest: add `toMatchInlineSnapshot` and `toMatchSnapshot` fix

### DIFF
--- a/packages/allure-vitest/src/matchers.ts
+++ b/packages/allure-vitest/src/matchers.ts
@@ -81,7 +81,7 @@ const MODIFIER_CHAINS = new Set([
   "rejects",
 ]);
 
-const SKIPPED_ASSERTION_METHODS = new Set(["assert", "constructor", "withContext", "withTest"]);
+const SKIPPED_ASSERTION_METHODS = new Set(["assert", "constructor", "withContext", "withTest",  "toMatchInlineSnapshot", "toMatchSnapshot"]);
 const SKIPPED_ASSERTION_PROPERTIES = new Set(["_obj", "__flags", "__methods", "callable", "iterable", "numeric"]);
 const ASYMMETRIC_MATCHER_FACTORIES = new Map([
   ["ArrayContaining", "arrayContaining"],


### PR DESCRIPTION

`toMatchInlineSnapshot` and `toMatchSnapshot` are matchers that inspect the call stack at runtime to find their own source location — this is how Vitest knows where in the test file to read or write the snapshot string. They also enforce that the same file:line:col is never visited twice per run.

In 3.9.0 we started wrapping all Chai assertion methods to record them as Allure steps. The wrapper routes every call through original.apply(this, args) on a fixed line inside matchers.ts, so both snapshot matchers now report that line as their caller. When two tests in the same file each call `toMatchInlineSnapshot`, Vitest sees the same source position twice and throws `Error: toMatchInlineSnapshot cannot be called multiple times at the same location.`

<!---
Describe the problem or feature in addition to a link to the issues
-->

#### Checklist

- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
