### PR TITLE
fix build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,6 @@ jobs:
     env:
       ALLURE_MATRIX_ENV: ${{ matrix.os }}-node-${{ matrix.node-version }}
       ALLURE_DUMP_NAME: allure-results-${{ matrix.os }}-node${{ matrix.node-version }}-${{ matrix.suite.id }}
-      TESTCAFE_BROWSER: ${{ matrix.os == 'ubuntu-latest' && 'chromium:headless --guest --no-sandbox' || 'chromium:headless --guest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,6 @@ jobs:
       ALLURE_MATRIX_ENV: ${{ matrix.os }}-node-${{ matrix.node-version }}
       ALLURE_DUMP_NAME: allure-results-${{ matrix.os }}-node${{ matrix.node-version }}-${{ matrix.suite.id }}
       TESTCAFE_BROWSER: ${{ matrix.os == 'ubuntu-latest' && 'chromium:headless --guest --no-sandbox' || 'chromium:headless --guest' }}
-      PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
     strategy:
       fail-fast: false
       matrix:
@@ -149,11 +148,14 @@ jobs:
       - name: Install Playwright Chromium
         id: pw-chromium
         if: ${{ matrix.suite.requirePwChromium }}
+        env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
         run: |
           node ./scripts/ci/install-playwright-chromium.mjs ${{ matrix.os == 'ubuntu-latest' && '--with-deps' || '' }}
 
       - name: Run suite tests
         env:
+          PLAYWRIGHT_BROWSERS_PATH: ${{ runner.temp }}/pw-browsers
           PW_CHROMIUM_PATH: ${{ steps.pw-chromium.outputs.path }}
         run: |
           yarn allure run --config ./allurerc.mjs --environment="${{ env.ALLURE_MATRIX_ENV }}" --dump="${{ env.ALLURE_DUMP_NAME }}" --rerun 2 -- node ./scripts/ci/run-suite.mjs test ${{ matrix.suite.id }}

--- a/packages/allure-vitest/src/matchers.ts
+++ b/packages/allure-vitest/src/matchers.ts
@@ -81,7 +81,14 @@ const MODIFIER_CHAINS = new Set([
   "rejects",
 ]);
 
-const SKIPPED_ASSERTION_METHODS = new Set(["assert", "constructor", "withContext", "withTest",  "toMatchInlineSnapshot", "toMatchSnapshot"]);
+const SKIPPED_ASSERTION_METHODS = new Set([
+  "assert",
+  "constructor",
+  "withContext",
+  "withTest",
+  "toMatchInlineSnapshot",
+  "toMatchSnapshot",
+]);
 const SKIPPED_ASSERTION_PROPERTIES = new Set(["_obj", "__flags", "__methods", "callable", "iterable", "numeric"]);
 const ASYMMETRIC_MATCHER_FACTORIES = new Map([
   ["ArrayContaining", "arrayContaining"],

--- a/packages/testcafe-reporter-allure-official/test/utils.ts
+++ b/packages/testcafe-reporter-allure-official/test/utils.ts
@@ -62,20 +62,21 @@ type AllureResultsWithTimestamps = AllureResults & {
 };
 
 const ALLURE_TEST_RUNTIME_KEY = "allureTestRuntime";
-const DEFAULT_BROWSER_CMD = process.platform === "linux" ? "--headless --guest --no-sandbox" : "--headless --guest";
+const DEFAULT_BROWSER_ARGS = process.platform === "linux" ? "--guest --no-sandbox" : "--guest";
+const createChromiumBrowserAlias = (browserPath?: string) =>
+  browserPath
+    ? `chromium:${browserPath}:headless ${DEFAULT_BROWSER_ARGS}`
+    : `chromium:headless ${DEFAULT_BROWSER_ARGS}`;
 const DEFAULT_BROWSER = (() => {
   if (process.env.TESTCAFE_BROWSER) {
     return process.env.TESTCAFE_BROWSER;
   }
 
   if (process.env.PW_CHROMIUM_PATH) {
-    return {
-      path: process.env.PW_CHROMIUM_PATH,
-      cmd: DEFAULT_BROWSER_CMD,
-    } satisfies TestCafeBrowserOption;
+    return createChromiumBrowserAlias(process.env.PW_CHROMIUM_PATH);
   }
 
-  return process.platform === "linux" ? "chromium:headless --guest --no-sandbox" : "chromium:headless --guest";
+  return createChromiumBrowserAlias();
 })();
 
 const CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
@@ -508,11 +509,21 @@ export const runTestCafeInlineTest = async (
   }
 };
 
+const toRequirePath = (fromDir: string, resolvedPath: string) => {
+  const relativePath = relative(fromDir, resolvedPath);
+  const normalizedPath = relativePath.replaceAll("\\", "/");
+
+  if (isAbsolute(relativePath)) {
+    return normalizedPath;
+  }
+
+  return normalizedPath.startsWith(".") ? normalizedPath : `./${normalizedPath}`;
+};
+
 export const getPackageRequirePath = (request: string, fromDir: string) => {
   const resolvedPath = isAbsolute(request) ? request : require.resolve(request);
-  const relativePath = relative(fromDir, resolvedPath).replaceAll("\\", "/");
 
-  return relativePath.startsWith(".") ? relativePath : `./${relativePath}`;
+  return toRequirePath(fromDir, resolvedPath);
 };
 
 export const check = async <T>(name: string, body: () => T | Promise<T>) => {

--- a/scripts/ci/install-playwright-chromium.mjs
+++ b/scripts/ci/install-playwright-chromium.mjs
@@ -12,7 +12,8 @@ if (flags.includes("--with-deps")) {
 }
 
 const runYarn = (args, options = {}) => {
-  const result = spawnSync(YARN_BIN, args, {
+  const yarnInvocation = createYarnInvocation(args);
+  const result = spawnSync(yarnInvocation.command, yarnInvocation.args, {
     stdio: options.captureOutput ? ["ignore", "pipe", "inherit"] : "inherit",
     encoding: "utf8",
     env: process.env,
@@ -28,6 +29,20 @@ const runYarn = (args, options = {}) => {
 
   return result.stdout?.trim() ?? "";
 };
+
+function createYarnInvocation(args) {
+  if (process.platform === "win32") {
+    return {
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", YARN_BIN, ...args],
+    };
+  }
+
+  return {
+    command: YARN_BIN,
+    args,
+  };
+}
 
 runYarn(installArgs);
 


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Fixes the GitHub Actions workflow so test suite builds can start again instead of failing during workflow validation with an unrecognized `runner.temp` expression. The Playwright browser cache path is still applied to the Chromium install and test execution steps, preserving the intended browser setup while avoiding invalid job-level context usage.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js