### PR TITLE
fix(cucumberjs): use scenario line in testCaseId to prevent duplicate name collision

### DIFF
--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -246,7 +246,8 @@ export default class AllureCucumberReporter extends Formatter {
     const posixPath = getPosixPathRelativeToProjectRoot(pickle);
     const fullNameBase = projectName ? `${projectName}:${posixPath}` : posixPath;
     const fullName = `${fullNameBase}#${pickle.name}`;
-    const testCaseId = md5(`${fullNameBase}#${scenario?.name ?? pickle.name}`);
+    const scenarioLine = scenario?.location?.line ?? "";
+    const testCaseId = md5(`${fullNameBase}#${scenario?.name ?? pickle.name}#${scenarioLine}`);
     const legacyTestCaseId = md5(`${posixPath}#${scenario?.name ?? pickle.name}`);
     const result: Partial<TestResult> = {
       name: pickle.name,

--- a/packages/allure-cucumberjs/test/samples/features/duplicate-names-rule.feature
+++ b/packages/allure-cucumberjs/test/samples/features/duplicate-names-rule.feature
@@ -1,0 +1,14 @@
+Feature: duplicate scenario names inside rules
+
+  Rule: first rule
+
+    Scenario: same name
+      Given a passed step
+
+    Scenario: same name
+      Given a failed step
+
+  Rule: second rule
+
+    Scenario: same name
+      Given a broken step

--- a/packages/allure-cucumberjs/test/samples/features/duplicate-names.feature
+++ b/packages/allure-cucumberjs/test/samples/features/duplicate-names.feature
@@ -5,3 +5,6 @@ Feature: duplicate scenario names
 
   Scenario: same name
     Given a failed step
+
+  Scenario: same name
+    Given a broken step

--- a/packages/allure-cucumberjs/test/samples/features/duplicate-names.feature
+++ b/packages/allure-cucumberjs/test/samples/features/duplicate-names.feature
@@ -1,0 +1,7 @@
+Feature: duplicate scenario names
+
+  Scenario: same name
+    Given a passed step
+
+  Scenario: same name
+    Given a failed step

--- a/packages/allure-cucumberjs/test/spec/duplicateScenarioNames.test.ts
+++ b/packages/allure-cucumberjs/test/spec/duplicateScenarioNames.test.ts
@@ -1,0 +1,79 @@
+import { Stage, Status } from "allure-js-commons";
+import { md5 } from "allure-js-commons/sdk/reporter";
+import { expect, it } from "vitest";
+
+import { runCucumberInlineTest } from "../utils.js";
+
+it("should report all scenarios when multiple have the same name", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
+
+  expect(tests).toHaveLength(3);
+});
+
+it("should assign unique testCaseIds to scenarios with duplicate names", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
+
+  const ids = tests.map((t) => t.testCaseId);
+  expect(new Set(ids).size).toBe(3);
+});
+
+it("should produce stable testCaseIds for scenarios identified by line number", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
+
+  // duplicate-names.feature lines: Scenario at line 3, 6, 9
+  // testCaseId = md5("dummy:features/duplicate-names.feature#same name#<line>")
+  const expectedIds = [3, 6, 9].map((line) => md5(`dummy:features/duplicate-names.feature#same name#${line}`));
+
+  const actualIds = new Set(tests.map((t) => t.testCaseId));
+  for (const id of expectedIds) {
+    expect(actualIds).toContain(id);
+  }
+});
+
+it("should correctly run each scenario with duplicate name (status check)", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
+
+  const byStatus = (s: Status) => tests.find((t) => t.status === s);
+
+  expect(byStatus(Status.PASSED)).toMatchObject({
+    name: "same name",
+    status: Status.PASSED,
+    stage: Stage.FINISHED,
+  });
+  expect(byStatus(Status.FAILED)).toMatchObject({
+    name: "same name",
+    status: Status.FAILED,
+    stage: Stage.FINISHED,
+  });
+  expect(byStatus(Status.BROKEN)).toMatchObject({
+    name: "same name",
+    status: Status.BROKEN,
+    stage: Stage.FINISHED,
+  });
+});
+
+it("should share fullName for scenarios with duplicate names (known behavior)", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
+
+  // fullName uses pickle.name (not line), so all duplicates share the same fullName.
+  // testCaseId is what makes them unique in the report.
+  const fullNames = new Set(tests.map((t) => t.fullName));
+  expect(fullNames.size).toBe(1);
+  expect([...fullNames][0]).toBe("dummy:features/duplicate-names.feature#same name");
+});
+
+it("should assign unique testCaseIds to scenarios with duplicate names inside Rule blocks", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names-rule"], ["simple"]);
+
+  expect(tests).toHaveLength(3);
+
+  const ids = tests.map((t) => t.testCaseId);
+  expect(new Set(ids).size).toBe(3);
+});
+
+it("should correctly run scenarios with duplicate names inside Rule blocks (status check)", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names-rule"], ["simple"]);
+
+  const statuses = tests.map((t) => t.status).sort();
+  expect(statuses).toEqual([Status.BROKEN, Status.FAILED, Status.PASSED].sort());
+});

--- a/packages/allure-cucumberjs/test/spec/examples.test.ts
+++ b/packages/allure-cucumberjs/test/spec/examples.test.ts
@@ -204,3 +204,11 @@ it("should create same test case id for scenario outline tests with template nam
   const [tr1, tr2] = tests;
   expect(tr1.testCaseId).toEqual(tr2.testCaseId);
 });
+
+it("should create different test case ids for scenarios with duplicate names in the same feature", async () => {
+  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
+
+  expect(tests).toHaveLength(2);
+  const [tr1, tr2] = tests;
+  expect(tr1.testCaseId).not.toEqual(tr2.testCaseId);
+});

--- a/packages/allure-cucumberjs/test/spec/examples.test.ts
+++ b/packages/allure-cucumberjs/test/spec/examples.test.ts
@@ -204,11 +204,3 @@ it("should create same test case id for scenario outline tests with template nam
   const [tr1, tr2] = tests;
   expect(tr1.testCaseId).toEqual(tr2.testCaseId);
 });
-
-it("should create different test case ids for scenarios with duplicate names in the same feature", async () => {
-  const { tests } = await runCucumberInlineTest(["duplicate-names"], ["simple"]);
-
-  expect(tests).toHaveLength(2);
-  const [tr1, tr2] = tests;
-  expect(tr1.testCaseId).not.toEqual(tr2.testCaseId);
-});


### PR DESCRIPTION
## Problem

Fixes #1387.

When two `Scenario` blocks in the same feature file share an identical name (but have different steps), the reporter computed the same `testCaseId` for both:

```ts
// before
const testCaseId = md5(`${fullNameBase}#${scenario?.name ?? pickle.name}`);
```

`allure-report` (the Java/HTML generator) deduplicates test results by `testCaseId`, so one of the two tests was silently dropped from the report — users saw **N-1 tests** instead of N. All other reporters (JSON, JUnit XML, HTML) were unaffected because they don't deduplicate.

## Fix

Include `scenario.location.line` in the `testCaseId` hash. Two scenarios with the same name but on different lines now get distinct ids:

```ts
// after
const scenarioLine = scenario?.location?.line ?? "";
const testCaseId = md5(`${fullNameBase}#${scenario?.name ?? pickle.name}#${scenarioLine}`);
```

**Scenario Outline rows are unaffected** — all rows of one outline share the same `Scenario Outline:` line number, so they keep the same `testCaseId`. This is required for cross-run history tracking (you want to see the history of "row 1 of this outline" across multiple runs, not treat each run as a fresh test).

## Breaking Change

`testCaseId` changes for **every** test in every feature file, because the hash input gains a `#<line>` suffix. Existing allure history tied to the old hash will be lost after upgrading — the first run after the upgrade will appear as a new test with no history.

`_fallbackTestCaseId` (the `legacyTestCaseId` used for allure2 → allure3 history migration) is **unchanged**, so the migration path from older allure versions is preserved.

## Testing

Added `duplicate-names.feature` with two `Scenario: same name` blocks and a new test asserting they produce different `testCaseId` values. The existing test for Scenario Outline (`should create same test case id for scenario outline tests with template name`) continues to pass.