### PR TITLE
chore(allure-vitest): extend skipped matchers, add tests

### DIFF
--- a/packages/allure-vitest/src/matchers.ts
+++ b/packages/allure-vitest/src/matchers.ts
@@ -88,6 +88,9 @@ const SKIPPED_ASSERTION_METHODS = new Set([
   "withTest",
   "toMatchInlineSnapshot",
   "toMatchSnapshot",
+  "toMatchFileSnapshot",
+  "toThrowErrorMatchingInlineSnapshot",
+  "toThrowErrorMatchingSnapshot",
 ]);
 const SKIPPED_ASSERTION_PROPERTIES = new Set(["_obj", "__flags", "__methods", "callable", "iterable", "numeric"]);
 const ASYMMETRIC_MATCHER_FACTORIES = new Map([

--- a/packages/allure-vitest/test/spec/expect.test.ts
+++ b/packages/allure-vitest/test/spec/expect.test.ts
@@ -222,6 +222,36 @@ describe("expect", () => {
         expect(tests[0].steps.map((s) => s.name)).toEqual(["manual step"]);
       });
 
+      if (env === "node") {
+        it("should allow multiple toMatchInlineSnapshot calls in one file with setup enabled", async () => {
+          const { tests } = await runVitestInlineTest({
+            "vitest.config.ts": configFileAccessor,
+            "sample.test.ts": `
+    import { describe, test, expect } from "vitest";
+
+    describe("inline snapshots", () => {
+      test("first", () => {
+        expect("hello").toMatchInlineSnapshot('"hello"');
+      });
+
+      test("second", () => {
+        expect("hello").toMatchInlineSnapshot('"hello"');
+      });
+
+      test("third", () => {
+        expect("hello").toMatchInlineSnapshot('"hello"');
+      });
+    });
+
+  `,
+          });
+
+          expect(tests).toHaveLength(3);
+          expect(tests.every((t) => t.status === "passed")).toBe(true);
+          expect(tests.every((t) => t.steps.length === 0)).toBe(true);
+        });
+      }
+
       it("should not report raw chai assertions as vitest matcher steps", async () => {
         const { tests } = await runVitestInlineTest({
           "vitest.config.ts": configFileAccessor,


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Builds on https://github.com/allure-framework/allure-js/pull/1500.
Extends the skip list (`toMatchFileSnapshot`, `toThrowErrorMatchingInlineSnapshot`, `toThrowErrorMatchingSnapshot`).
Adds a regression test - multiple toMatchInlineSnapshot calls in one file with setup enabled.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
