### PR TITLE
Add bugs metadata for allure-playwright

### DIFF
--- a/packages/allure-playwright/package.json
+++ b/packages/allure-playwright/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/allure-framework/allure-js.git",
     "directory": "packages/allure-playwright"
   },
+  "bugs": {
+    "url": "https://github.com/allure-framework/allure-js/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary
- add package-level `bugs.url` metadata for `allure-playwright`
- point npm consumers to the existing Allure JS issue tracker
- leave runtime code, dependencies, entrypoints, and generated output unchanged

## Verification
- `node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('packages/allure-playwright/package.json','utf8')); if (p.name !== 'allure-playwright' || p.bugs?.url !== 'https://github.com/allure-framework/allure-js/issues') process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,bugs:p.bugs}))"`
- `npm pack --dry-run --json --ignore-scripts` from `packages/allure-playwright`
- `git diff --check`