### PR TITLE
Keep test reruns from deleting Allure results

### DIFF
--- a/packages/allure-ava/package.json
+++ b/packages/allure-ava/package.json
@@ -53,7 +53,7 @@
     "generate-report": "allure generate ./out/allure-results -o ./out/allure-report --clean --single-file",
     "lint": "oxlint --import-plugin src test",
     "lint:fix": "oxlint --import-plugin --fix src test",
-    "test": "yarn workspace allure-js-commons compile && run-s clean compile && vitest run"
+    "test": "yarn workspace allure-js-commons compile && yarn run compile && vitest run"
   },
   "dependencies": {
     "allure-js-commons": "workspace:*"

--- a/packages/allure-playwright/package.json
+++ b/packages/allure-playwright/package.json
@@ -57,7 +57,7 @@
     "generate-report": "allure generate ./out/allure-results -o ./out/allure-report --clean",
     "lint": "yarn run -T oxlint --import-plugin src test",
     "lint:fix": "yarn run -T oxlint --import-plugin --fix src test",
-    "pretest": "run-p clean compile",
+    "pretest": "run-p compile",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/allure-vitest/package.json
+++ b/packages/allure-vitest/package.json
@@ -58,7 +58,7 @@
     "generate-report": "allure generate ./out/allure-results -o ./out/allure-report --clean --single-file",
     "lint": "oxlint --import-plugin src test",
     "lint:fix": "oxlint --import-plugin --fix src test",
-    "pretest": "run-p clean compile",
+    "pretest": "run-p compile",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/testcafe-reporter-allure-official/package.json
+++ b/packages/testcafe-reporter-allure-official/package.json
@@ -54,7 +54,7 @@
     "generate-report": "allure generate ./out/allure-results -o ./out/allure-report --clean",
     "lint": "oxlint --import-plugin src test",
     "lint:fix": "oxlint --import-plugin --fix src test",
-    "pretest": "run-s clean compile",
+    "pretest": "run-s compile",
     "test": "vitest run"
   },
   "dependencies": {


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->

Test scripts no longer clean package output directories as part of normal execution. This keeps Allure result files and attachments from earlier retry attempts available when `allure run --rerun` packages the final dump.

This prevents noisy “Skipping attachment while writing dump” warnings caused by rerun attempts deleting `out/allure-results` before the dump writer can include those files.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js