### PR TITLE
Make skipped adapter tests explicit

### DIFF
--- a/packages/allure-bun/test/spec/bun.test.ts
+++ b/packages/allure-bun/test/spec/bun.test.ts
@@ -6,7 +6,7 @@ import { expect, it } from "vitest";
 import { finishFileContext } from "../../src/lifecycle.js";
 import { createFileContext, createRunState } from "../../src/state.js";
 import { runBunInlineTest } from "../utils.js";
-import { bunIt, getTestByName, getTestsByName, hasFixtureStep } from "./helpers.js";
+import { getTestByName, getTestsByName, hasFixtureStep } from "./helpers.js";
 
 it("writes Bun global metadata once across multiple file contexts", () => {
   const runState = createRunState();
@@ -45,7 +45,7 @@ it("writes Bun global metadata once across multiple file contexts", () => {
   expect(categoriesWrites).toBe(1);
 });
 
-bunIt("writes configured environment info and categories", async () => {
+it("writes configured environment info and categories", async () => {
   const { envInfo, categories, exitCode } = await runBunInlineTest(
     {
       "sample.test.ts": `
@@ -69,7 +69,7 @@ bunIt("writes configured environment info and categories", async () => {
   expect(categories).toEqual([expect.objectContaining({ name: "known", messageRegex: "known problem" })]);
 });
 
-bunIt("reports Bun tests, hooks, serial tests, skips and todos", async () => {
+it("reports Bun tests, hooks, serial tests, skips and todos", async () => {
   const { tests, groups, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, test } from "bun:test";
@@ -211,7 +211,7 @@ bunIt("reports Bun tests, hooks, serial tests, skips and todos", async () => {
   expect(hasFixtureStep(groups, "afters", "root after all")).toBe(true);
 });
 
-bunIt("reports afterAll registered after top-level await", async () => {
+it("reports afterAll registered after top-level await", async () => {
   const { tests, groups, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { afterAll, expect, test } from "bun:test";
@@ -239,7 +239,7 @@ bunIt("reports afterAll registered after top-level await", async () => {
   expect(hasFixtureStep(groups, "afters", "late after all")).toBe(true);
 });
 
-bunIt("reports Bun retry attempts as separate Allure results", async () => {
+it("reports Bun retry attempts as separate Allure results", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { expect, test } from "bun:test";
@@ -277,7 +277,7 @@ bunIt("reports Bun retry attempts as separate Allure results", async () => {
   expect(passedAttempt?.historyId).toBe(failedAttempt?.historyId);
 });
 
-bunIt("keeps hook context isolated across multiple Bun files", async () => {
+it("keeps hook context isolated across multiple Bun files", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "hook-context-a.test.ts": `
       import { beforeAll, expect, it } from "bun:test";
@@ -320,7 +320,7 @@ bunIt("keeps hook context isolated across multiple Bun files", async () => {
   );
 });
 
-bunIt("reports tests from sibling top-level suites", async () => {
+it("reports tests from sibling top-level suites", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { describe, expect, it } from "bun:test";
@@ -345,7 +345,7 @@ bunIt("reports tests from sibling top-level suites", async () => {
   expect(getTestByName(tests, "test B").fullName).toBe("sample.test.ts#suite B test B");
 });
 
-bunIt("keeps Bun file paths with parentheses in the reported package name", async () => {
+it("keeps Bun file paths with parentheses in the reported package name", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "paren(dir)/file(name).test.ts": `
       import { expect, test } from "bun:test";
@@ -370,7 +370,7 @@ bunIt("keeps Bun file paths with parentheses in the reported package name", asyn
   );
 });
 
-bunIt("reports Bun hook failures consistently", async () => {
+it("reports Bun hook failures consistently", async () => {
   const { tests, groups, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
@@ -488,7 +488,7 @@ bunIt("reports Bun hook failures consistently", async () => {
   );
 });
 
-bunIt("respects the Allure test plan at registration time", async () => {
+it("respects the Allure test plan at registration time", async () => {
   const testPlanFilename = "testplan.json";
   const { tests, groups, exitCode } = await runBunInlineTest(
     {
@@ -537,7 +537,7 @@ bunIt("respects the Allure test plan at registration time", async () => {
   expect(groups).toHaveLength(0);
 });
 
-bunIt("respects Allure test plan ids from title metadata", async () => {
+it("respects Allure test plan ids from title metadata", async () => {
   const testPlanFilename = "testplan.json";
   const { tests, exitCode } = await runBunInlineTest(
     {
@@ -581,7 +581,7 @@ bunIt("respects Allure test plan ids from title metadata", async () => {
   );
 });
 
-bunIt("matches Bun --todo mode for expected todo failures", async () => {
+it("matches Bun --todo mode for expected todo failures", async () => {
   const { tests, exitCode } = await runBunInlineTest(
     {
       "sample.test.ts": `
@@ -612,7 +612,7 @@ bunIt("matches Bun --todo mode for expected todo failures", async () => {
   );
 });
 
-bunIt("matches Bun --todo mode for unexpected todo passes", async () => {
+it("matches Bun --todo mode for unexpected todo passes", async () => {
   const { tests, exitCode, stdout, stderr } = await runBunInlineTest(
     {
       "sample.test.ts": `

--- a/packages/allure-bun/test/spec/bunApi.test.ts
+++ b/packages/allure-bun/test/spec/bunApi.test.ts
@@ -5,7 +5,7 @@ import { createFileContext, createRunState } from "../../src/state.js";
 import type { BunWrappedFn } from "../../src/types.js";
 import { createWrappedTest } from "../../src/wrappers.js";
 import { runBunInlineTest } from "../utils.js";
-import { bunIt, getTestByName, getTestsByName } from "./helpers.js";
+import { getTestByName, getTestsByName } from "./helpers.js";
 
 it("resolves native test modifiers lazily from aliases", () => {
   const registered: string[] = [];
@@ -35,7 +35,7 @@ it("resolves native test modifiers lazily from aliases", () => {
   expect(registered).toEqual(["only alpha", "only beta"]);
 });
 
-bunIt("supports conditional and failing Bun modifier factories", async () => {
+it("supports conditional and failing Bun modifier factories", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { describe, expect, test } from "bun:test";
@@ -163,7 +163,7 @@ bunIt("supports conditional and failing Bun modifier factories", async () => {
   );
 });
 
-bunIt("fails fast for Bun concurrent mode before tests execute", async () => {
+it("fails fast for Bun concurrent mode before tests execute", async () => {
   const { tests, exitCode, stdout, stderr } = await runBunInlineTest(
     {
       "sample.test.ts": `
@@ -191,7 +191,7 @@ bunIt("fails fast for Bun concurrent mode before tests execute", async () => {
   expect(`${stdout.join("\n")}\n${stderr.join("\n")}`).not.toContain("(pass)");
 });
 
-bunIt("fails fast for randomized Bun order before tests execute", async () => {
+it("fails fast for randomized Bun order before tests execute", async () => {
   const { tests, exitCode, stdout, stderr } = await runBunInlineTest(
     {
       "sample.test.ts": `
@@ -217,7 +217,7 @@ bunIt("fails fast for randomized Bun order before tests execute", async () => {
   expect(`${stdout.join("\n")}\n${stderr.join("\n")}`).not.toContain("(pass)");
 });
 
-bunIt("does not report static skipped tests excluded by Bun name pattern", async () => {
+it("does not report static skipped tests excluded by Bun name pattern", async () => {
   const { tests, exitCode } = await runBunInlineTest(
     {
       "sample.test.ts": `
@@ -247,7 +247,7 @@ bunIt("does not report static skipped tests excluded by Bun name pattern", async
   );
 });
 
-bunIt("supports parameterized Bun test factories", async () => {
+it("supports parameterized Bun test factories", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { expect, test } from "bun:test";
@@ -355,7 +355,7 @@ bunIt("supports parameterized Bun test factories", async () => {
   );
 });
 
-bunIt("supports parameterized Bun describe factories", async () => {
+it("supports parameterized Bun describe factories", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { describe, expect, test } from "bun:test";
@@ -429,7 +429,7 @@ bunIt("supports parameterized Bun describe factories", async () => {
 });
 
 // FIXME: pass locally, but fails every time on CI
-bunIt.skip("supports Bun only.each variants", async () => {
+it.skip("supports Bun only.each variants", async () => {
   const testOnly = await runBunInlineTest(
     {
       "sample.test.ts": `
@@ -482,7 +482,7 @@ bunIt.skip("supports Bun only.each variants", async () => {
   );
 });
 
-bunIt("matches Bun's current each title formatting", async () => {
+it("matches Bun's current each title formatting", async () => {
   const { tests, exitCode } = await runBunInlineTest({
     "sample.test.ts": `
       import { expect, test } from "bun:test";

--- a/packages/allure-bun/test/spec/helpers.ts
+++ b/packages/allure-bun/test/spec/helpers.ts
@@ -1,9 +1,5 @@
 import type { TestResult, TestResultContainer } from "allure-js-commons";
-import { expect, it } from "vitest";
-
-import { isBunAvailable } from "../utils.js";
-
-export const bunIt = isBunAvailable ? it : it.skip;
+import { expect } from "vitest";
 
 export const getTestByName = (tests: TestResult[], name: string) => {
   const test = tests.find((entry) => entry.name === name);

--- a/packages/allure-bun/test/spec/runtime/attachments.test.ts
+++ b/packages/allure-bun/test/spec/runtime/attachments.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt, readAttachment } from "../helpers.js";
+import { readAttachment } from "../helpers.js";
 
 describe("attachments", () => {
-  bunIt("adds inline attachments", async () => {
+  it("adds inline attachments", async () => {
     const { tests, attachments, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -33,7 +33,7 @@ describe("attachments", () => {
     expect(readAttachment(attachments, attachment.source)).toBe("bar");
   });
 
-  bunIt("adds attachments from paths", async () => {
+  it("adds attachments from paths", async () => {
     const { tests, attachments, exitCode } = await runBunInlineTest({
       "payload.txt": "payload from path",
       "sample.test.ts": `
@@ -62,7 +62,7 @@ describe("attachments", () => {
     expect(readAttachment(attachments, attachment.source)).toBe("payload from path");
   });
 
-  bunIt("adds trace attachments from paths", async () => {
+  it("adds trace attachments from paths", async () => {
     const { tests, attachments, exitCode } = await runBunInlineTest({
       "trace.zip": "trace payload",
       "sample.test.ts": `
@@ -91,7 +91,7 @@ describe("attachments", () => {
     expect(readAttachment(attachments, attachment.source)).toBe("trace payload");
   });
 
-  bunIt("adds attachments inside steps", async () => {
+  it("adds attachments inside steps", async () => {
     const { tests, attachments, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/description.test.ts
+++ b/packages/allure-bun/test/spec/runtime/description.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt } from "../helpers.js";
 
 describe("description", () => {
-  bunIt("sets markdown description", async () => {
+  it("sets markdown description", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -21,7 +20,7 @@ describe("description", () => {
     expect(tests[0].description).toBe("markdown description");
   });
 
-  bunIt("sets html description", async () => {
+  it("sets html description", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -38,7 +37,7 @@ describe("description", () => {
     expect(tests[0].descriptionHtml).toBe("<b>html description</b>");
   });
 
-  bunIt("adds descriptions from before fixtures to linked tests", async () => {
+  it("adds descriptions from before fixtures to linked tests", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeAll, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/displayName.test.ts
+++ b/packages/allure-bun/test/spec/runtime/displayName.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt, hasFixtureStep } from "../helpers.js";
+import { hasFixtureStep } from "../helpers.js";
 
 describe("displayName", () => {
-  bunIt("sets test display name", async () => {
+  it("sets test display name", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -22,7 +22,7 @@ describe("displayName", () => {
     expect(tests[0].fullName).toBe("sample.test.ts#display name");
   });
 
-  bunIt("renames fixtures without renaming tests", async () => {
+  it("renames fixtures without renaming tests", async () => {
     const { tests, groups, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeAll, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/globals.test.ts
+++ b/packages/allure-bun/test/spec/runtime/globals.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt, readAttachment } from "../helpers.js";
+import { readAttachment } from "../helpers.js";
 
 describe("globals", () => {
-  bunIt("writes globals from rootless runtime API calls", async () => {
+  it("writes globals from rootless runtime API calls", async () => {
     const { globals, attachments, exitCode } = await runBunInlineTest({
       "payload.txt": "from path",
       "sample.test.ts": `
@@ -56,7 +56,7 @@ describe("globals", () => {
     expect(readAttachment(attachments, pathAttachment!.source)).toBe("from path");
   });
 
-  bunIt("writes globals from fixture runtime API calls", async () => {
+  it("writes globals from fixture runtime API calls", async () => {
     const { globals, attachments, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeAll, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/historyId.test.ts
+++ b/packages/allure-bun/test/spec/runtime/historyId.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt } from "../helpers.js";
 
 describe("historyId", () => {
-  bunIt("sets test history id", async () => {
+  it("sets test history id", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/labels.test.ts
+++ b/packages/allure-bun/test/spec/runtime/labels.test.ts
@@ -1,8 +1,8 @@
 import { LabelName } from "allure-js-commons";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt, getTestByName } from "../helpers.js";
+import { getTestByName } from "../helpers.js";
 
 describe("labels", () => {
   const labelCases = [
@@ -81,7 +81,7 @@ describe("labels", () => {
   ];
 
   for (const labelCase of labelCases) {
-    bunIt(labelCase.title, async () => {
+    it(labelCase.title, async () => {
       const { tests, exitCode } = await runBunInlineTest({
         "sample.test.ts": `
           import { test } from "bun:test";
@@ -99,7 +99,7 @@ describe("labels", () => {
     });
   }
 
-  bunIt("labels", async () => {
+  it("labels", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -121,7 +121,7 @@ describe("labels", () => {
     );
   });
 
-  bunIt("tags", async () => {
+  it("tags", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -143,7 +143,7 @@ describe("labels", () => {
     );
   });
 
-  bunIt("adds labels from before fixtures to linked tests", async () => {
+  it("adds labels from before fixtures to linked tests", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeAll, test } from "bun:test";
@@ -164,7 +164,7 @@ describe("labels", () => {
     });
   });
 
-  bunIt("adds configured global labels to every test", async () => {
+  it("adds configured global labels to every test", async () => {
     const { tests, exitCode } = await runBunInlineTest(
       {
         "sample.test.ts": `
@@ -193,7 +193,7 @@ describe("labels", () => {
     );
   });
 
-  bunIt("user suite labels override generated suite labels", async () => {
+  it("user suite labels override generated suite labels", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { describe, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/links.test.ts
+++ b/packages/allure-bun/test/spec/runtime/links.test.ts
@@ -1,11 +1,10 @@
 import { LinkType } from "allure-js-commons";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt } from "../helpers.js";
 
 describe("links", () => {
-  bunIt("adds generic links", async () => {
+  it("adds generic links", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -26,7 +25,7 @@ describe("links", () => {
     });
   });
 
-  bunIt("adds multiple links", async () => {
+  it("adds multiple links", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -51,7 +50,7 @@ describe("links", () => {
     );
   });
 
-  bunIt("adds issue and tms links with templates", async () => {
+  it("adds issue and tms links with templates", async () => {
     const { tests, exitCode } = await runBunInlineTest(
       {
         "sample.test.ts": `
@@ -90,7 +89,7 @@ describe("links", () => {
     );
   });
 
-  bunIt("adds links from before fixtures to linked tests", async () => {
+  it("adds links from before fixtures to linked tests", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeAll, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/parameters.test.ts
+++ b/packages/allure-bun/test/spec/runtime/parameters.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt, getTestByName } from "../helpers.js";
+import { getTestByName } from "../helpers.js";
 
 describe("parameters", () => {
-  bunIt("sets test parameters", async () => {
+  it("sets test parameters", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -31,7 +31,7 @@ describe("parameters", () => {
     );
   });
 
-  bunIt("adds parameters from hooks to the current test", async () => {
+  it("adds parameters from hooks to the current test", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeEach, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/steps.test.ts
+++ b/packages/allure-bun/test/spec/runtime/steps.test.ts
@@ -1,11 +1,10 @@
 import { Stage, Status } from "allure-js-commons";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt } from "../helpers.js";
 
 describe("steps", () => {
-  bunIt("handles single lambda steps", async () => {
+  it("handles single lambda steps", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -28,7 +27,7 @@ describe("steps", () => {
     );
   });
 
-  bunIt("preserves nested lambda steps", async () => {
+  it("preserves nested lambda steps", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -62,7 +61,7 @@ describe("steps", () => {
     });
   });
 
-  bunIt("supports step display names and parameters", async () => {
+  it("supports step display names and parameters", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -96,7 +95,7 @@ describe("steps", () => {
     );
   });
 
-  bunIt("returns step callback values", async () => {
+  it("returns step callback values", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { expect, test } from "bun:test";
@@ -115,7 +114,7 @@ describe("steps", () => {
     expect(tests[0].steps).toContainEqual(expect.objectContaining({ name: "get value", status: Status.PASSED }));
   });
 
-  bunIt("records failed lambda steps and rethrows errors", async () => {
+  it("records failed lambda steps and rethrows errors", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";
@@ -141,7 +140,7 @@ describe("steps", () => {
     );
   });
 
-  bunIt("adds instant log steps", async () => {
+  it("adds instant log steps", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/sync/globals.test.ts
+++ b/packages/allure-bun/test/spec/runtime/sync/globals.test.ts
@@ -1,10 +1,10 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../../utils.js";
-import { bunIt, getTestByName, readAttachment } from "../../helpers.js";
+import { getTestByName, readAttachment } from "../../helpers.js";
 
 describe("sync globals", () => {
-  bunIt("writes globals from rootless sync runtime API calls", async () => {
+  it("writes globals from rootless sync runtime API calls", async () => {
     const { globals, attachments, exitCode } = await runBunInlineTest({
       "payload.txt": "from path",
       "sample.test.ts": `
@@ -50,7 +50,7 @@ describe("sync globals", () => {
     expect(readAttachment(attachments, pathAttachment!.source)).toBe("from path");
   });
 
-  bunIt("adds sync metadata from before fixtures to linked tests", async () => {
+  it("adds sync metadata from before fixtures to linked tests", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { beforeAll, test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/sync/steps.test.ts
+++ b/packages/allure-bun/test/spec/runtime/sync/steps.test.ts
@@ -1,11 +1,11 @@
 import { Stage, Status } from "allure-js-commons";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../../utils.js";
-import { bunIt, readAttachment } from "../../helpers.js";
+import { readAttachment } from "../../helpers.js";
 
 describe("sync steps", () => {
-  bunIt("handles sync runtime api", async () => {
+  it("handles sync runtime api", async () => {
     const { tests, attachments, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { expect, test } from "bun:test";
@@ -55,7 +55,7 @@ describe("sync steps", () => {
     expect(readAttachment(attachments, attachmentRef.source)).toBe("bar");
   });
 
-  bunIt("rejects promise-returning sync steps", async () => {
+  it("rejects promise-returning sync steps", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";

--- a/packages/allure-bun/test/spec/runtime/testCaseId.test.ts
+++ b/packages/allure-bun/test/spec/runtime/testCaseId.test.ts
@@ -1,10 +1,9 @@
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { runBunInlineTest } from "../../utils.js";
-import { bunIt } from "../helpers.js";
 
 describe("testCaseId", () => {
-  bunIt("sets test case id", async () => {
+  it("sets test case id", async () => {
     const { tests, exitCode } = await runBunInlineTest({
       "sample.test.ts": `
         import { test } from "bun:test";

--- a/packages/allure-bun/test/utils.ts
+++ b/packages/allure-bun/test/utils.ts
@@ -26,13 +26,17 @@ export type BunInlineTestResult = AllureResults & {
 
 const bunBinary = process.env.BUN_BINARY ?? "bun";
 
-export const isBunAvailable = (() => {
+const assertBunBinaryAvailable = () => {
   const result = spawnSync(bunBinary, ["--version"], {
     stdio: "ignore",
   });
 
-  return !result.error && result.status === 0;
-})();
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `Bun binary "${bunBinary}" is not available. Install Bun or set BUN_BINARY to run Bun integration tests.`,
+    );
+  }
+};
 
 const attachProcessOutput = async (stdout: string[], stderr: string[]) => {
   if (stdout.length) {
@@ -114,9 +118,7 @@ export const runBunInlineTest = async (
   testFiles: BunTestFiles,
   { env, args = [], cwd }: BunRunOptions = {},
 ): Promise<BunInlineTestResult> => {
-  if (!isBunAvailable) {
-    throw new Error("Bun is not available in PATH. Install Bun or set BUN_BINARY to run Bun integration tests.");
-  }
+  assertBunBinaryAvailable();
 
   const testDir = join(__dirname, "fixtures", randomUUID());
   const resultsDir = join(testDir, "allure-results");

--- a/packages/allure-codeceptjs/test/spec/runtime/modern/helperHooks.test.ts
+++ b/packages/allure-codeceptjs/test/spec/runtime/modern/helperHooks.test.ts
@@ -61,7 +61,8 @@ it("should support runtime API in helper _beforeStep & _afterStep hooks", async 
   );
 });
 
-// it's doesn't reported in time, don't know why
+// Runtime messages from helper _passed are not reported before the test result
+// is finalized in this harness; keep the gap visible until lifecycle handling is fixed.
 it.skip("should support runtime API in helper _passed", async () => {
   const { tests } = await runCodeceptJsInlineTest({
     "nested/login.test.js": `

--- a/packages/allure-cucumberjs/test/samples/support/stepArguments.cjs
+++ b/packages/allure-cucumberjs/test/samples/support/stepArguments.cjs
@@ -4,6 +4,6 @@ Given(/^a is (\d+)$/, (_) => {});
 
 Given(/^b is (\d+)$/, (_) => {});
 
-When(/^I add a to b$/, () => {});
+When(/^I plus a and b$/, () => {});
 
-Then(/^result is (\d+)$/, (_) => {});
+Then(/^the result is (\d+)$/, (_) => {});

--- a/packages/allure-cucumberjs/test/spec/stepArguments.test.ts
+++ b/packages/allure-cucumberjs/test/spec/stepArguments.test.ts
@@ -1,3 +1,4 @@
+import { Status } from "allure-js-commons";
 import { expect, it } from "vitest";
 
 import { runCucumberInlineTest } from "../utils.js";
@@ -8,6 +9,7 @@ it("reports steps with their arguments", async () => {
   expect(tests).toHaveLength(1);
   expect(tests).toContainEqual(
     expect.objectContaining({
+      status: Status.PASSED,
       steps: expect.arrayContaining([
         expect.objectContaining({
           name: "Given a is 5",

--- a/packages/allure-node-test/test/spec/node.test.ts
+++ b/packages/allure-node-test/test/spec/node.test.ts
@@ -8,8 +8,6 @@ import { describe, expect, it } from "vitest";
 import { runNodeInlineTest, supportsNodeTestRuntimeApi } from "../utils.js";
 import { getTestByName, readAttachment } from "./helpers.js";
 
-const runtimeIt = supportsNodeTestRuntimeApi ? it : it.skip;
-
 describe("node --test integration", () => {
   it("writes reporter-only results with unchanged node:test imports", async () => {
     const { exitCode, tests } = await runNodeInlineTest({
@@ -210,8 +208,11 @@ describe("node --test integration", () => {
     );
   });
 
-  if (!supportsNodeTestRuntimeApi) {
-    it("fails fast when setup is used on a Node version without getTestContext", async () => {
+  // The setup failure is only meaningful before node:test exposes getTestContext;
+  // keep the unsupported-runtime case visible on Node versions where it cannot fail.
+  it.skipIf(supportsNodeTestRuntimeApi)(
+    "fails fast when setup is used on a Node version without getTestContext",
+    async () => {
       const { exitCode } = await runNodeInlineTest(
         {
           "unsupported-runtime.test.mjs": `
@@ -224,8 +225,8 @@ describe("node --test integration", () => {
       );
 
       expect(exitCode).not.toBe(0);
-    });
-  }
+    },
+  );
 
   it("does not execute tests outside ALLURE_TESTPLAN_PATH when setup is preloaded", async () => {
     const executionDir = mkdtempSync(join(tmpdir(), "allure-node-testplan-execution-"));
@@ -360,10 +361,13 @@ describe("node --test integration", () => {
     }
   });
 
-  runtimeIt("writes runtime API data with unchanged node:test imports on Node >= 26.1", async () => {
-    const { attachments, exitCode, tests } = await runNodeInlineTest(
-      {
-        "runtime.test.mjs": `
+  // Runtime API calls require node:test getTestContext, which is available in Node >= 26.1.
+  it.skipIf(!supportsNodeTestRuntimeApi)(
+    "writes runtime API data with unchanged node:test imports on Node >= 26.1",
+    async () => {
+      const { attachments, exitCode, tests } = await runNodeInlineTest(
+        {
+          "runtime.test.mjs": `
           import test from "node:test";
           import assert from "node:assert/strict";
           import { attachment, label, step } from "allure-js-commons";
@@ -376,23 +380,24 @@ describe("node --test integration", () => {
             assert.equal(1 + 1, 2);
           });
         `,
-      },
-      { setup: true },
-    );
+        },
+        { setup: true },
+      );
 
-    expect(exitCode).toBe(0);
+      expect(exitCode).toBe(0);
 
-    const result = getTestByName(tests, "uses runtime API");
+      const result = getTestByName(tests, "uses runtime API");
 
-    expect(result.labels).toEqual(expect.arrayContaining([{ name: LabelName.FEATURE, value: "native-runtime" }]));
-    expect(result.steps).toEqual(expect.arrayContaining([expect.objectContaining({ name: "runtime step" })]));
+      expect(result.labels).toEqual(expect.arrayContaining([{ name: LabelName.FEATURE, value: "native-runtime" }]));
+      expect(result.steps).toEqual(expect.arrayContaining([expect.objectContaining({ name: "runtime step" })]));
 
-    const runtimeStep = result.steps.find((entry) => entry.name === "runtime step");
-    const runtimeAttachment = runtimeStep?.steps
-      .flatMap((entry) => entry.attachments)
-      .find((entry) => entry.name === "runtime attachment");
+      const runtimeStep = result.steps.find((entry) => entry.name === "runtime step");
+      const runtimeAttachment = runtimeStep?.steps
+        .flatMap((entry) => entry.attachments)
+        .find((entry) => entry.name === "runtime attachment");
 
-    expect(runtimeAttachment).toBeDefined();
-    expect(readAttachment(attachments, runtimeAttachment!.source)).toBe("hello node");
-  });
+      expect(runtimeAttachment).toBeDefined();
+      expect(readAttachment(attachments, runtimeAttachment!.source)).toBe("hello node");
+    },
+  );
 });

--- a/packages/allure-playwright/test/spec/steps.spec.ts
+++ b/packages/allure-playwright/test/spec/steps.spec.ts
@@ -340,13 +340,28 @@ it("should support steps with names longer then 50 chars", async () => {
 it("should ignore route.continue() steps", async () => {
   const { tests } = await runPlaywrightInlineTest({
     "a.test.js": `
+      import { createServer } from 'node:http';
       import { test, expect } from '@playwright/test';
 
       test('a test', async ({ page }) => {
+        const server = createServer((_, response) => {
+          response.writeHead(200, { "content-type": "text/html" });
+          response.end("<html><body>ok</body></html>");
+        });
+        const port = await new Promise((resolve) => {
+          server.listen(0, "127.0.0.1", () => {
+            resolve(server.address().port);
+          });
+        });
+
         await page.route('**/*', (route) => {
           route.continue();
         });
-        await page.goto("https://allurereport.org");
+        try {
+          await page.goto(\`http://127.0.0.1:\${port}/\`);
+        } finally {
+          await new Promise((resolve) => server.close(resolve));
+        }
       });
     `,
   });

--- a/packages/allure-vitest/test/spec/categories.test.ts
+++ b/packages/allure-vitest/test/spec/categories.test.ts
@@ -1,84 +1,80 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { type TestFileAccessor, reporterModulePath, runVitestInlineTest } from "../utils.js";
 
-describe("categories", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+const nodeConfig: TestFileAccessor = ({ allureResultsPath }) => `
+  import { defineConfig } from "vitest/config";
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) => {
-          if (env === "node") {
-            return `
-          import { defineConfig } from "vitest/config";
-
-          export default defineConfig({
-            test: {
-              reporters: [
-                "default",
-                [
-                  "${reporterModulePath}",
-                  {
-                    resultsDir: "${allureResultsPath}",
-                    categories: [{
-                      name: "first"
-                    },{
-                      name: "second"
-                    }]
-                  }
-                ],
-              ],
-            },
-          });
-        `;
+  export default defineConfig({
+    test: {
+      reporters: [
+        "default",
+        [
+          "${reporterModulePath}",
+          {
+            resultsDir: "${allureResultsPath}",
+            categories: [{
+              name: "first"
+            },{
+              name: "second"
+            }]
           }
-          return `
-          import { defineConfig } from "vitest/config";
-          import { playwright } from "@vitest/browser-playwright";
+        ],
+      ],
+    },
+  });
+`;
 
-          export default defineConfig({
-            test: {
-              openTelemetry: { enabled: false },
-              reporters: [
-                "default",
-                [
-                  "${reporterModulePath}",
-                  {
-                    resultsDir: "${allureResultsPath}",
-                    categories: [{
-                      name: "first"
-                    },{
-                      name: "second"
-                    }]
-                  }
-                ],
-              ],
-              browser: {
-                provider: playwright(),
-                enabled: true,
-                headless: true,
-                instances: [{ browser: "chromium" }],
-              },
-            },
-          });
-        `;
-        };
-      });
+const browserConfig: TestFileAccessor = ({ allureResultsPath }) => `
+  import { defineConfig } from "vitest/config";
+  import { playwright } from "@vitest/browser-playwright";
 
-      it("should support categories", async () => {
-        const { categories } = await runVitestInlineTest({
-          "sample.test.ts": `
+  export default defineConfig({
+    test: {
+      openTelemetry: { enabled: false },
+      reporters: [
+        "default",
+        [
+          "${reporterModulePath}",
+          {
+            resultsDir: "${allureResultsPath}",
+            categories: [{
+              name: "first"
+            },{
+              name: "second"
+            }]
+          }
+        ],
+      ],
+      browser: {
+        provider: playwright(),
+        enabled: true,
+        headless: true,
+        instances: [{ browser: "chromium" }],
+      },
+    },
+  });
+`;
+
+const testEnvironments = [
+  ["node", nodeConfig],
+  ["browser", browserConfig],
+] as const;
+
+describe("categories", () => {
+  describe.each(testEnvironments)('for "%s"', (_env, configFileAccessor) => {
+    it("should support categories", async () => {
+      const { categories } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { test } from "vitest";
 
         test("sample test", async () => {
         });
       `,
-          "vitest.config.ts": configFileAccessor,
-        });
-
-        expect(categories).toEqual(expect.arrayContaining([{ name: "first" }, { name: "second" }]));
+        "vitest.config.ts": configFileAccessor,
       });
+
+      expect(categories).toEqual(expect.arrayContaining([{ name: "first" }, { name: "second" }]));
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/dataTable.test.ts
+++ b/packages/allure-vitest/test/spec/dataTable.test.ts
@@ -1,21 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("data tables", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should support tests with data table", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should support tests with data table", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
     import { label } from "allure-js-commons";
 
@@ -27,13 +25,12 @@ describe("data tables", () => {
       await label("foo", "bar");
     })
   `,
-        });
-
-        expect(tests).toHaveLength(3);
-        expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
-        expect(tests[1].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
-        expect(tests[2].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
       });
+
+      expect(tests).toHaveLength(3);
+      expect(tests[0].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
+      expect(tests[1].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
+      expect(tests[2].labels).toContainEqual(expect.objectContaining({ name: "foo", value: "bar" }));
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/duration.test.ts
+++ b/packages/allure-vitest/test/spec/duration.test.ts
@@ -1,57 +1,54 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("test timings", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should set correct timings for tests", async () => {
-        const before = new Date().getTime();
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should set correct timings for tests", async () => {
+      const before = new Date().getTime();
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("sample test", async () => {
       expect(1).toBe(1);
     });
   `,
-        });
-        const after = new Date().getTime();
-
-        expect(tests).toHaveLength(1);
-        const [tr] = tests;
-
-        expect(tr.start).toBeGreaterThanOrEqual(before);
-        expect(tr.start).toBeLessThanOrEqual(after);
-        expect(tr.stop).toBeGreaterThanOrEqual(tr.start!);
       });
+      const after = new Date().getTime();
 
-      it("should set integer timings for tests", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      const [tr] = tests;
+
+      expect(tr.start).toBeGreaterThanOrEqual(before);
+      expect(tr.start).toBeLessThanOrEqual(after);
+      expect(tr.stop).toBeGreaterThanOrEqual(tr.start!);
+    });
+
+    it("should set integer timings for tests", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("sample test", async () => {
       expect(1).toBe(1);
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        const [tr] = tests;
-
-        expect(tr.start).toStrictEqual(Math.trunc(tr.start!));
-        expect(tr.stop).toStrictEqual(Math.trunc(tr.stop!));
       });
+
+      expect(tests).toHaveLength(1);
+      const [tr] = tests;
+
+      expect(tr.start).toStrictEqual(Math.trunc(tr.start!));
+      expect(tr.stop).toStrictEqual(Math.trunc(tr.stop!));
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/environmentInfo.test.ts
+++ b/packages/allure-vitest/test/spec/environmentInfo.test.ts
@@ -1,82 +1,78 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { type TestFileAccessor, reporterModulePath, runVitestInlineTest } from "../utils.js";
 
-describe("environment info", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+const nodeConfig: TestFileAccessor = ({ allureResultsPath }) => `
+  import { defineConfig } from "vitest/config";
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) => {
-          if (env === "node") {
-            return `
-        import { defineConfig } from "vitest/config";
-
-        export default defineConfig({
-          test: {
-            reporters: [
-              "default",
-              [
-                "${reporterModulePath}",
-                {
-                  resultsDir: "${allureResultsPath}",
-                  environmentInfo: {
-                    "app version": "123.0.1",
-                    "some other key": "some other value"
-                  }
-                }
-              ],
-            ],
-          },
-        });
-      `;
+  export default defineConfig({
+    test: {
+      reporters: [
+        "default",
+        [
+          "${reporterModulePath}",
+          {
+            resultsDir: "${allureResultsPath}",
+            environmentInfo: {
+              "app version": "123.0.1",
+              "some other key": "some other value"
+            }
           }
-          return `
-        import { defineConfig } from "vitest/config";
-        import { playwright } from "@vitest/browser-playwright";
+        ],
+      ],
+    },
+  });
+`;
 
-        export default defineConfig({
-          test: {
-            openTelemetry: { enabled: false },
-            reporters: [
-              "default",
-              [
-                "${reporterModulePath}",
-                {
-                  resultsDir: "${allureResultsPath}",
-                  environmentInfo: {
-                    "app version": "123.0.1",
-                    "some other key": "some other value"
-                  }
-                }
-              ],
-            ],
-            browser: {
-              provider: playwright(),
-              enabled: true,
-              headless: true,
-              instances: [{ browser: "chromium" }],
-            },
-          },
-        });
-      `;
-        };
-      });
+const browserConfig: TestFileAccessor = ({ allureResultsPath }) => `
+  import { defineConfig } from "vitest/config";
+  import { playwright } from "@vitest/browser-playwright";
 
-      it("should add environmentInfo", async () => {
-        const { envInfo } = await runVitestInlineTest({
-          "sample.test.ts": `
+  export default defineConfig({
+    test: {
+      openTelemetry: { enabled: false },
+      reporters: [
+        "default",
+        [
+          "${reporterModulePath}",
+          {
+            resultsDir: "${allureResultsPath}",
+            environmentInfo: {
+              "app version": "123.0.1",
+              "some other key": "some other value"
+            }
+          }
+        ],
+      ],
+      browser: {
+        provider: playwright(),
+        enabled: true,
+        headless: true,
+        instances: [{ browser: "chromium" }],
+      },
+    },
+  });
+`;
+
+const testEnvironments = [
+  ["node", nodeConfig],
+  ["browser", browserConfig],
+] as const;
+
+describe("environment info", () => {
+  describe.each(testEnvironments)('for "%s"', (_env, configFileAccessor) => {
+    it("should add environmentInfo", async () => {
+      const { envInfo } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { test } from "vitest";
 
         test("sample test", async () => {
         });
       `,
-          "vitest.config.ts": configFileAccessor,
-        });
-
-        expect(envInfo).toEqual({ "app version": "123.0.1", "some other key": "some other value" });
+        "vitest.config.ts": configFileAccessor,
       });
+
+      expect(envInfo).toEqual({ "app version": "123.0.1", "some other key": "some other value" });
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/expect-extend.test.ts
+++ b/packages/allure-vitest/test/spec/expect-extend.test.ts
@@ -1,21 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("expect.extend", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should support expect.extend", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should support expect.extend", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     expect.extend({ toFail() { return { pass: false, message: () => "some message" }; } });
@@ -25,25 +23,24 @@ describe("expect.extend", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests).toEqual([
-          expect.objectContaining({
-            name: "fail test",
-            status: "failed",
-            steps: [
-              expect.objectContaining({
-                name: "expect({}).toFail()",
-                status: "failed",
-              }),
-            ],
-            statusDetails: expect.objectContaining({
-              message: "some message",
-            }),
-          }),
-        ]);
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests).toEqual([
+        expect.objectContaining({
+          name: "fail test",
+          status: "failed",
+          steps: [
+            expect.objectContaining({
+              name: "expect({}).toFail()",
+              status: "failed",
+            }),
+          ],
+          statusDetails: expect.objectContaining({
+            message: "some message",
+          }),
+        }),
+      ]);
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/expect.test.ts
+++ b/packages/allure-vitest/test/spec/expect.test.ts
@@ -2,20 +2,23 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
 
+const testEnvironments = [
+  ["node", createVitestConfig, true],
+  ["browser", createVitestBrowserConfig, false],
+] as const;
+
 describe("expect", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(testEnvironments)('for "%s"', (_env, createConfig, supportsConcurrentMatcherSteps) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should report vitest expect matchers as steps by default", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should report vitest expect matchers as steps by default", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("pass test", async () => {
@@ -27,25 +30,29 @@ describe("expect", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].steps.map((s) => s.name)).toEqual([
-          "expect(1).toBe(1)",
-          "expect(1).not.toBe(2)",
-          "expect([1]).toHaveLength(1)",
-          "expect(1).resolves.toBe(1)",
-          'expect("boom").rejects.toBe("boom")',
-        ]);
-        expect(tests[0].steps.find((s) => s.name === "expect([1]).toHaveLength(1)")?.steps).toEqual([]);
-        expect(tests[0].steps.every((s) => s.status === "passed")).toBe(true);
       });
 
-      if (env === "node") {
-        it("should keep matcher steps attached to the correct concurrent test", async () => {
-          const { tests } = await runVitestInlineTest({
-            "vitest.config.ts": configFileAccessor,
-            "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].steps.map((s) => s.name)).toEqual([
+        "expect(1).toBe(1)",
+        "expect(1).not.toBe(2)",
+        "expect([1]).toHaveLength(1)",
+        "expect(1).resolves.toBe(1)",
+        'expect("boom").rejects.toBe("boom")',
+      ]);
+      expect(tests[0].steps.find((s) => s.name === "expect([1]).toHaveLength(1)")?.steps).toEqual([]);
+      expect(tests[0].steps.every((s) => s.status === "passed")).toBe(true);
+    });
+
+    // Browser projects don't install the concurrency-aware runner/current-test
+    // recovery used by Node yet, so matcher steps are not attached correctly
+    // across awaited gaps in concurrent browser tests.
+    it.skipIf(!supportsConcurrentMatcherSteps)(
+      "should keep matcher steps attached to the correct concurrent test",
+      async () => {
+        const { tests } = await runVitestInlineTest({
+          "vitest.config.ts": configFileAccessor,
+          "sample.test.ts": `
     import { describe, test, expect } from "vitest";
 
     const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -65,27 +72,27 @@ describe("expect", () => {
     });
 
   `,
-          });
-
-          expect(tests).toHaveLength(2);
-          const first = tests.find(({ name }) => name === "first");
-          const second = tests.find(({ name }) => name === "second");
-
-          expect(first?.steps.map(({ name }) => name)).toEqual([
-            'expect("first sync").toBe("first sync")',
-            'expect("first async").toBe("first async")',
-          ]);
-          expect(second?.steps.map(({ name }) => name)).toEqual([
-            'expect("second sync").toBe("second sync")',
-            'expect("second async").toBe("second async")',
-          ]);
         });
-      }
 
-      it("should format asymmetric matcher arguments", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+        expect(tests).toHaveLength(2);
+        const first = tests.find(({ name }) => name === "first");
+        const second = tests.find(({ name }) => name === "second");
+
+        expect(first?.steps.map(({ name }) => name)).toEqual([
+          'expect("first sync").toBe("first sync")',
+          'expect("first async").toBe("first async")',
+        ]);
+        expect(second?.steps.map(({ name }) => name)).toEqual([
+          'expect("second sync").toBe("second sync")',
+          'expect("second async").toBe("second async")',
+        ]);
+      },
+    );
+
+    it("should format asymmetric matcher arguments", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("pass test", () => {
@@ -95,18 +102,18 @@ describe("expect", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].steps.map((s) => s.name)).toEqual([
-          'expect([{"name":"foo","value":"bar","extra":"baz"}]).toContainEqual(expect.objectContaining({"name":"foo","value":"bar"}))',
-        ]);
       });
 
-      it("should add actual and expected values when using expect", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].steps.map((s) => s.name)).toEqual([
+        'expect([{"name":"foo","value":"bar","extra":"baz"}]).toContainEqual(expect.objectContaining({"name":"foo","value":"bar"}))',
+      ]);
+    });
+
+    it("should add actual and expected values when using expect", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("fail test", () => {
@@ -114,36 +121,36 @@ describe("expect", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests).toMatchObject([
-          {
-            name: "fail test",
-            status: "failed",
-            statusDetails: {
-              message: "expected 'a value' to deeply equal 'the other one'",
-              expected: "the other one",
-              actual: "a value",
-            },
-            steps: [
-              {
-                name: 'expect("a value").toEqual("the other one")',
-                status: "failed",
-                statusDetails: {
-                  expected: "the other one",
-                  actual: "a value",
-                },
-              },
-            ],
-          },
-        ]);
       });
 
-      it("should add actual and expected values when using expect with match object", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests).toMatchObject([
+        {
+          name: "fail test",
+          status: "failed",
+          statusDetails: {
+            message: "expected 'a value' to deeply equal 'the other one'",
+            expected: "the other one",
+            actual: "a value",
+          },
+          steps: [
+            {
+              name: 'expect("a value").toEqual("the other one")',
+              status: "failed",
+              statusDetails: {
+                expected: "the other one",
+                actual: "a value",
+              },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("should add actual and expected values when using expect with match object", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("fail test", () => {
@@ -151,60 +158,57 @@ describe("expect", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests).toMatchObject([
-          {
-            name: "fail test",
-            status: "failed",
-            statusDetails: {
-              expected: expect.toBeOneOf([
-                // Vitest < 4.1
-                "Object {\n" + '  "nested": Object {\n' + '    "obj": "some",\n' + "  },\n" + "}",
-                // Vitest 4.1+
-                "{\n" + '  "nested": {\n' + '    "obj": "some",\n' + "  },\n" + "}",
-              ]),
-              actual: expect.toBeOneOf([
-                "Object {\n" + '  "nested": Object {\n' + '    "obj": "value",\n' + "  },\n" + "}",
-                "{\n" + '  "nested": {\n' + '    "obj": "value",\n' + "  },\n" + "}",
-              ]),
-            },
-          },
-        ]);
       });
 
-      it("should add actual and expected values when regular exception is thrown", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests).toMatchObject([
+        {
+          name: "fail test",
+          status: "failed",
+          statusDetails: {
+            expected: expect.toBeOneOf([
+              // Vitest < 4.1
+              "Object {\n" + '  "nested": Object {\n' + '    "obj": "some",\n' + "  },\n" + "}",
+              // Vitest 4.1+
+              "{\n" + '  "nested": {\n' + '    "obj": "some",\n' + "  },\n" + "}",
+            ]),
+            actual: expect.toBeOneOf([
+              "Object {\n" + '  "nested": Object {\n' + '    "obj": "value",\n' + "  },\n" + "}",
+              "{\n" + '  "nested": {\n' + '    "obj": "value",\n' + "  },\n" + "}",
+            ]),
+          },
+        },
+      ]);
+    });
+
+    it("should add actual and expected values when regular exception is thrown", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("fail test", () => {
       throw new Error("fail!")
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-
-        const [{ name, status, statusDetails }] = tests;
-
-        expect(name).toBe("fail test");
-        expect(status).toBe("broken");
-        expect(statusDetails.message).toBe("fail!");
-        expect(statusDetails.trace).toContain("Error: fail!");
-        expect(statusDetails.expected).toBeUndefined();
-        expect(statusDetails.actual).toBeUndefined();
       });
 
-      it("should disable matcher reporting when reportMatchers is false", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": ({ allureResultsPath }) =>
-            env === "node"
-              ? createVitestConfig(allureResultsPath, { reportMatchers: false })
-              : createVitestBrowserConfig(allureResultsPath, { reportMatchers: false }),
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+
+      const [{ name, status, statusDetails }] = tests;
+
+      expect(name).toBe("fail test");
+      expect(status).toBe("broken");
+      expect(statusDetails.message).toBe("fail!");
+      expect(statusDetails.trace).toContain("Error: fail!");
+      expect(statusDetails.expected).toBeUndefined();
+      expect(statusDetails.actual).toBeUndefined();
+    });
+
+    it("should disable matcher reporting when reportMatchers is false", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": ({ allureResultsPath }) => createConfig(allureResultsPath, { reportMatchers: false }),
+        "sample.test.ts": `
     import { test, expect } from "vitest";
     import * as allure from "allure-js-commons";
 
@@ -216,17 +220,16 @@ describe("expect", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].steps.map((s) => s.name)).toEqual(["manual step"]);
       });
 
-      if (env === "node") {
-        it("should allow multiple toMatchInlineSnapshot calls in one file with setup enabled", async () => {
-          const { tests } = await runVitestInlineTest({
-            "vitest.config.ts": configFileAccessor,
-            "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].steps.map((s) => s.name)).toEqual(["manual step"]);
+    });
+
+    it("should allow multiple toMatchInlineSnapshot calls in one file with setup enabled", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { describe, test, expect } from "vitest";
 
     describe("inline snapshots", () => {
@@ -244,18 +247,17 @@ describe("expect", () => {
     });
 
   `,
-          });
+      });
 
-          expect(tests).toHaveLength(3);
-          expect(tests.every((t) => t.status === "passed")).toBe(true);
-          expect(tests.every((t) => t.steps.length === 0)).toBe(true);
-        });
-      }
+      expect(tests).toHaveLength(3);
+      expect(tests.every((t) => t.status === "passed")).toBe(true);
+      expect(tests.every((t) => t.steps.length === 0)).toBe(true);
+    });
 
-      it("should not report raw chai assertions as vitest matcher steps", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should not report raw chai assertions as vitest matcher steps", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { chai, test } from "vitest";
 
     test("pass test", () => {
@@ -263,11 +265,10 @@ describe("expect", () => {
     });
 
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].steps).toEqual([]);
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].steps).toEqual([]);
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/fixtures.test.ts
+++ b/packages/allure-vitest/test/spec/fixtures.test.ts
@@ -1,21 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("fixtures", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should report fixtures", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should report fixtures", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { afterAll, afterEach, beforeAll, beforeEach, test } from "vitest";
     import { step } from "allure-js-commons";
 
@@ -39,28 +37,27 @@ describe("fixtures", () => {
       await step("test step", () => {});
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        const [testResult] = tests;
-        expect(testResult.steps).toEqual([
-          expect.objectContaining({
-            name: "before all step",
-          }),
-          expect.objectContaining({
-            name: "before each step",
-          }),
-          expect.objectContaining({
-            name: "test step",
-          }),
-          expect.objectContaining({
-            name: "after each step",
-          }),
-          expect.objectContaining({
-            name: "after all step",
-          }),
-        ]);
       });
+
+      expect(tests).toHaveLength(1);
+      const [testResult] = tests;
+      expect(testResult.steps).toEqual([
+        expect.objectContaining({
+          name: "before all step",
+        }),
+        expect.objectContaining({
+          name: "before each step",
+        }),
+        expect.objectContaining({
+          name: "test step",
+        }),
+        expect.objectContaining({
+          name: "after each step",
+        }),
+        expect.objectContaining({
+          name: "after all step",
+        }),
+      ]);
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/fullName.test.ts
+++ b/packages/allure-vitest/test/spec/fullName.test.ts
@@ -1,22 +1,20 @@
 import { md5 } from "allure-js-commons/sdk/reporter";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("full name", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should set full name", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should set full name", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test, describe } from "vitest";
 
       describe("foo", () => {
@@ -25,52 +23,51 @@ describe("full name", () => {
         })
       })
     `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].fullName).toBe("dummy:sample.test.ts#foo bar baz");
-        expect(tests[0].labels).toEqual(
-          expect.arrayContaining([
-            {
-              name: "_fallbackTestCaseId",
-              value: md5("sample.test.ts#foo bar baz"),
-            },
-          ]),
-        );
       });
 
-      it("should use POSIX path to the spec file", async () => {
-        const { tests } = await runVitestInlineTest({
+      expect(tests).toHaveLength(1);
+      expect(tests[0].fullName).toBe("dummy:sample.test.ts#foo bar baz");
+      expect(tests[0].labels).toEqual(
+        expect.arrayContaining([
+          {
+            name: "_fallbackTestCaseId",
+            value: md5("sample.test.ts#foo bar baz"),
+          },
+        ]),
+      );
+    });
+
+    it("should use POSIX path to the spec file", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "foo/bar/baz.test.ts": `
+      import { test } from "vitest";
+
+      test("qux", () => {});
+    `,
+      });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].fullName).toBe("dummy:foo/bar/baz.test.ts#qux");
+    });
+
+    it("should not depend on CWD", async () => {
+      const { tests } = await runVitestInlineTest(
+        {
           "vitest.config.ts": configFileAccessor,
           "foo/bar/baz.test.ts": `
       import { test } from "vitest";
 
       test("qux", () => {});
     `,
-        });
+        },
+        {
+          cwd: "foo",
+        },
+      );
 
-        expect(tests).toHaveLength(1);
-        expect(tests[0].fullName).toBe("dummy:foo/bar/baz.test.ts#qux");
-      });
-
-      it("should not depend on CWD", async () => {
-        const { tests } = await runVitestInlineTest(
-          {
-            "vitest.config.ts": configFileAccessor,
-            "foo/bar/baz.test.ts": `
-      import { test } from "vitest";
-
-      test("qux", () => {});
-    `,
-          },
-          {
-            cwd: "foo",
-          },
-        );
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].fullName).toBe("dummy:foo/bar/baz.test.ts#qux");
-      });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].fullName).toBe("dummy:foo/bar/baz.test.ts#qux");
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/globalLabels.test.ts
+++ b/packages/allure-vitest/test/spec/globalLabels.test.ts
@@ -1,98 +1,94 @@
-import { beforeAll, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 
 import { type TestFileAccessor, reporterModulePath, runVitestInlineTest } from "../utils.js";
 
-describe("global labels", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+const nodeConfig: TestFileAccessor = ({ allureResultsPath }) => `
+  import { defineConfig } from "vitest/config";
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) => {
-          if (env === "node") {
-            return `
-        import { defineConfig } from "vitest/config";
-
-        export default defineConfig({
-          test: {
-            reporters: [
-              "default",
-              [
-                "${reporterModulePath}",
-                {
-                  resultsDir: "${allureResultsPath}",
-                    globalLabels: {
-                      foo: "bar",
-                      bar: ["beep", "boop"],
-                    }
-                }
-              ],
-            ],
-          },
-        });
-      `;
+  export default defineConfig({
+    test: {
+      reporters: [
+        "default",
+        [
+          "${reporterModulePath}",
+          {
+            resultsDir: "${allureResultsPath}",
+            globalLabels: {
+              foo: "bar",
+              bar: ["beep", "boop"],
+            }
           }
-          return `
-        import { defineConfig } from "vitest/config";
-        import { playwright } from "@vitest/browser-playwright";
+        ],
+      ],
+    },
+  });
+`;
 
-        export default defineConfig({
-          test: {
-            openTelemetry: { enabled: false },
-            reporters: [
-              "default",
-              [
-                "${reporterModulePath}",
-                {
-                  resultsDir: "${allureResultsPath}",
-                    globalLabels: {
-                      foo: "bar",
-                      bar: ["beep", "boop"],
-                    }
-                }
-              ],
-            ],
-            browser: {
-              provider: playwright(),
-              enabled: true,
-              headless: true,
-              instances: [{ browser: "chromium" }],
-            },
-          },
-        });
-      `;
-        };
-      });
+const browserConfig: TestFileAccessor = ({ allureResultsPath }) => `
+  import { defineConfig } from "vitest/config";
+  import { playwright } from "@vitest/browser-playwright";
 
-      it("should handle global labels", async () => {
-        const { tests } = await runVitestInlineTest({
-          "sample.test.ts": `
+  export default defineConfig({
+    test: {
+      openTelemetry: { enabled: false },
+      reporters: [
+        "default",
+        [
+          "${reporterModulePath}",
+          {
+            resultsDir: "${allureResultsPath}",
+            globalLabels: {
+              foo: "bar",
+              bar: ["beep", "boop"],
+            }
+          }
+        ],
+      ],
+      browser: {
+        provider: playwright(),
+        enabled: true,
+        headless: true,
+        instances: [{ browser: "chromium" }],
+      },
+    },
+  });
+`;
+
+const testEnvironments = [
+  ["node", nodeConfig],
+  ["browser", browserConfig],
+] as const;
+
+describe("global labels", () => {
+  describe.each(testEnvironments)('for "%s"', (_env, configFileAccessor) => {
+    it("should handle global labels", async () => {
+      const { tests } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { test } from "vitest";
 
         test("sample test", async () => {
         });
       `,
-          "vitest.config.ts": configFileAccessor,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toEqual(
-          expect.arrayContaining([
-            {
-              name: "foo",
-              value: "bar",
-            },
-            {
-              name: "bar",
-              value: "beep",
-            },
-            {
-              name: "bar",
-              value: "boop",
-            },
-          ]),
-        );
+        "vitest.config.ts": configFileAccessor,
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toEqual(
+        expect.arrayContaining([
+          {
+            name: "foo",
+            value: "bar",
+          },
+          {
+            name: "bar",
+            value: "beep",
+          },
+          {
+            name: "bar",
+            value: "boop",
+          },
+        ]),
+      );
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/labels.test.ts
+++ b/packages/allure-vitest/test/spec/labels.test.ts
@@ -1,115 +1,112 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("labels", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should add host & thread labels", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should add host & thread labels", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("sample test", async () => {
       expect(1).toBe(1);
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toEqual(
-          expect.arrayContaining([
-            {
-              name: "host",
-              value: expect.any(String),
-            },
-            {
-              name: "thread",
-              value: expect.any(String),
-            },
-          ]),
-        );
       });
 
-      it("should add package label", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toEqual(
+        expect.arrayContaining([
+          {
+            name: "host",
+            value: expect.any(String),
+          },
+          {
+            name: "thread",
+            value: expect.any(String),
+          },
+        ]),
+      );
+    });
+
+    it("should add package label", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test, expect } from "vitest";
 
     test("sample test", async () => {
       expect(1).toBe(1);
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toEqual(
-          expect.arrayContaining([
-            {
-              name: "package",
-              value: "dummy.sample.test.ts",
-            },
-          ]),
-        );
       });
 
-      it("should add package label for tests in directories", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "foo/bar/baz.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toEqual(
+        expect.arrayContaining([
+          {
+            name: "package",
+            value: "dummy.sample.test.ts",
+          },
+        ]),
+      );
+    });
+
+    it("should add package label for tests in directories", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "foo/bar/baz.test.ts": `
       import { test } from "vitest";
 
       test("qux", async () => {});
     `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toEqual(
-          expect.arrayContaining([
-            {
-              name: "package",
-              value: "dummy.foo.bar.baz.test.ts",
-            },
-          ]),
-        );
       });
 
-      it("should add labels from env variables", async () => {
-        const { tests } = await runVitestInlineTest(
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toEqual(
+        expect.arrayContaining([
           {
-            "vitest.config.ts": configFileAccessor,
-            "sample.test.ts": `
+            name: "package",
+            value: "dummy.foo.bar.baz.test.ts",
+          },
+        ]),
+      );
+    });
+
+    it("should add labels from env variables", async () => {
+      const { tests } = await runVitestInlineTest(
+        {
+          "vitest.config.ts": configFileAccessor,
+          "sample.test.ts": `
       import { test } from "vitest";
 
       test("foo", () => {});
       test("bar", () => {});
     `,
-          },
-          {
-            env: () => ({
-              ALLURE_LABEL_: "-",
-              ALLURE_LABEL_A: "",
-              ALLURE_LABEL_B: "foo",
-              ALLURE_LABEL_workerId: "baz",
-            }),
-          },
-        );
+        },
+        {
+          env: () => ({
+            ALLURE_LABEL_: "-",
+            ALLURE_LABEL_A: "",
+            ALLURE_LABEL_B: "foo",
+            ALLURE_LABEL_workerId: "baz",
+          }),
+        },
+      );
 
-        tests.forEach((testResult) => {
-          expect(testResult.labels).toContainEqual(expect.objectContaining({ name: "A", value: "" }));
-          expect(testResult.labels).toContainEqual(expect.objectContaining({ name: "B", value: "foo" }));
-          expect(testResult.labels).toContainEqual(expect.objectContaining({ name: "workerId", value: "baz" }));
-        });
+      tests.forEach((testResult) => {
+        expect(testResult.labels).toContainEqual(expect.objectContaining({ name: "A", value: "" }));
+        expect(testResult.labels).toContainEqual(expect.objectContaining({ name: "B", value: "foo" }));
+        expect(testResult.labels).toContainEqual(expect.objectContaining({ name: "workerId", value: "baz" }));
       });
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/description.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/description.test.ts
@@ -1,26 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("description", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("sets description", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("sets description", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test } from "vitest";
     import { description } from "allure-js-commons";
 
@@ -28,16 +21,16 @@ describe("description", () => {
       await description("foo");
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].description).toBe("foo");
       });
 
-      it("sets html description", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].description).toBe("foo");
+    });
+
+    it("sets html description", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test } from "vitest";
     import { descriptionHtml } from "allure-js-commons";
 
@@ -45,11 +38,10 @@ describe("description", () => {
       await descriptionHtml("foo");
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].descriptionHtml).toBe("foo");
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].descriptionHtml).toBe("foo");
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/displayName.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/displayName.test.ts
@@ -1,26 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("displayName", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("sets test display name", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("sets test display name", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test } from "vitest";
     import { displayName } from "allure-js-commons";
 
@@ -28,11 +21,10 @@ describe("displayName", () => {
       await displayName("foo");
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].name).toBe("foo");
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].name).toBe("foo");
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/historyId.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/historyId.test.ts
@@ -1,26 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("historyId", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("sets test history id", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("sets test history id", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test } from "vitest";
     import { historyId } from "allure-js-commons";
 
@@ -28,11 +21,10 @@ describe("historyId", () => {
       await historyId("foo");
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].historyId).toBe("foo");
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].historyId).toBe("foo");
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/labels.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/labels.test.ts
@@ -1,27 +1,20 @@
 import { LabelName } from "allure-js-commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("labels", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("label", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("label", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { label } from "allure-js-commons";
 
@@ -29,15 +22,15 @@ describe("labels", () => {
         await label("foo", "bar");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: "foo", value: "bar" });
+    });
 
-      it("epic", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("epic", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { epic } from "allure-js-commons";
 
@@ -45,15 +38,15 @@ describe("labels", () => {
         await epic("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.EPIC, value: "foo" });
+    });
 
-      it("feature", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("feature", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { feature } from "allure-js-commons";
 
@@ -61,15 +54,15 @@ describe("labels", () => {
         await feature("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.FEATURE, value: "foo" });
+    });
 
-      it("story", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("story", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { story } from "allure-js-commons";
 
@@ -77,15 +70,15 @@ describe("labels", () => {
         await story("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.STORY, value: "foo" });
+    });
 
-      it("suite", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("suite", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { suite } from "allure-js-commons";
 
@@ -93,15 +86,15 @@ describe("labels", () => {
         await suite("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.SUITE, value: "foo" });
+    });
 
-      it("parentSuite", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("parentSuite", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { parentSuite } from "allure-js-commons";
 
@@ -109,15 +102,15 @@ describe("labels", () => {
         await parentSuite("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.PARENT_SUITE, value: "foo" });
+    });
 
-      it("subSuite", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("subSuite", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { subSuite } from "allure-js-commons";
 
@@ -125,15 +118,15 @@ describe("labels", () => {
         await subSuite("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.SUB_SUITE, value: "foo" });
+    });
 
-      it("owner", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("owner", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { owner } from "allure-js-commons";
 
@@ -141,15 +134,15 @@ describe("labels", () => {
         await owner("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.OWNER, value: "foo" });
+    });
 
-      it("severity", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("severity", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { severity } from "allure-js-commons";
 
@@ -157,15 +150,15 @@ describe("labels", () => {
         await severity("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.SEVERITY, value: "foo" });
+    });
 
-      it("layer", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("layer", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { layer } from "allure-js-commons";
 
@@ -173,15 +166,15 @@ describe("labels", () => {
         await layer("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.LAYER, value: "foo" });
+    });
 
-      it("id", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("id", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { allureId } from "allure-js-commons";
 
@@ -189,15 +182,15 @@ describe("labels", () => {
         await allureId("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.ALLURE_ID, value: "foo" });
+    });
 
-      it("tag", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("tag", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { tag } from "allure-js-commons";
 
@@ -205,10 +198,9 @@ describe("labels", () => {
         await tag("foo");
       });
       `,
-        });
-        expect(tests).toHaveLength(1);
-        expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
       });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].labels).toContainEqual({ name: LabelName.TAG, value: "foo" });
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/links.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/links.test.ts
@@ -1,27 +1,20 @@
 import { LinkType } from "allure-js-commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("links", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("link", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("link", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { link } from "allure-js-commons";
 
@@ -29,20 +22,20 @@ describe("links", () => {
         await link("https://example.org", "foo", "bar");
       });
       `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].links).toContainEqual({
-          name: "foo",
-          type: "bar",
-          url: "https://example.org",
-        });
       });
 
-      it("issue", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].links).toContainEqual({
+        name: "foo",
+        type: "bar",
+        url: "https://example.org",
+      });
+    });
+
+    it("issue", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { issue } from "allure-js-commons";
 
@@ -51,25 +44,25 @@ describe("links", () => {
         await issue("2", "bar");
       });
       `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].links).toContainEqual({
-          name: "foo",
-          type: LinkType.ISSUE,
-          url: "https://example.org/issue/1",
-        });
-        expect(tests[0].links).toContainEqual({
-          name: "bar",
-          type: LinkType.ISSUE,
-          url: "https://example.org/issue/2",
-        });
       });
 
-      it("tms", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].links).toContainEqual({
+        name: "foo",
+        type: LinkType.ISSUE,
+        url: "https://example.org/issue/1",
+      });
+      expect(tests[0].links).toContainEqual({
+        name: "bar",
+        type: LinkType.ISSUE,
+        url: "https://example.org/issue/2",
+      });
+    });
+
+    it("tms", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
       import { test } from "vitest";
       import { tms } from "allure-js-commons";
 
@@ -78,20 +71,19 @@ describe("links", () => {
         await tms("2", "bar");
       });
       `,
-        });
+      });
 
-        expect(tests).toHaveLength(1);
-        expect(tests[0].links).toContainEqual({
-          name: "foo",
-          type: LinkType.TMS,
-          url: "https://example.org/tms/1",
-        });
-        expect(tests[0].links).toContainEqual({
-          name: "bar",
-          type: LinkType.TMS,
-          url: "https://example.org/tms/2",
-        });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].links).toContainEqual({
+        name: "foo",
+        type: LinkType.TMS,
+        url: "https://example.org/tms/1",
+      });
+      expect(tests[0].links).toContainEqual({
+        name: "bar",
+        type: LinkType.TMS,
+        url: "https://example.org/tms/2",
       });
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/parameters.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/parameters.test.ts
@@ -1,26 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("parameters", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("sets parameters", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("sets parameters", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test } from "vitest";
     import { parameter } from "allure-js-commons";
 
@@ -28,16 +21,15 @@ describe("parameters", () => {
       await parameter("foo", "bar", { mode: "hidden", excluded: true });
     });
   `,
-        });
+      });
 
-        expect(tests).toHaveLength(1);
-        expect(tests[0].parameters).toContainEqual({
-          name: "foo",
-          value: "bar",
-          mode: "hidden",
-          excluded: true,
-        });
+      expect(tests).toHaveLength(1);
+      expect(tests[0].parameters).toContainEqual({
+        name: "foo",
+        value: "bar",
+        mode: "hidden",
+        excluded: true,
       });
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/runtime/modern/testCaseId.test.ts
+++ b/packages/allure-vitest/test/spec/runtime/modern/testCaseId.test.ts
@@ -1,26 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  type TestFileAccessor,
-  createVitestBrowserConfig,
-  createVitestConfig,
-  runVitestInlineTest,
-} from "../../../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../../../utils.js";
 
 describe("testCaseId", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("sets test case id", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("sets test case id", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test } from "vitest";
     import { testCaseId } from "allure-js-commons";
 
@@ -28,11 +21,10 @@ describe("testCaseId", () => {
       await testCaseId("foo");
     });
   `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].testCaseId).toBe("foo");
       });
+
+      expect(tests).toHaveLength(1);
+      expect(tests[0].testCaseId).toBe("foo");
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/simple.test.ts
+++ b/packages/allure-vitest/test/spec/simple.test.ts
@@ -1,83 +1,81 @@
 import { Stage, Status } from "allure-js-commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("simple", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`test status for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('test status for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should report passed test", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should report passed test", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
         import { test, expect } from "vitest";
 
         test("sample test", async () => {
           expect(1).toBe(1);
         });
       `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].status).toBe(Status.PASSED);
       });
 
-      it("should report failed test", async () => {
-        const { tests } = await runVitestInlineTest({
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].status).toBe(Status.PASSED);
+    });
+
+    it("should report failed test", async () => {
+      const { tests } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { test, expect } from "vitest";
 
         test("sample test", async () => {
           expect(1).toBe(2);
         });
       `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].status).toBe(Status.FAILED);
       });
 
-      it("should report broken test", async () => {
-        const { tests } = await runVitestInlineTest({
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].status).toBe(Status.FAILED);
+    });
+
+    it("should report broken test", async () => {
+      const { tests } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { test, expect } from "vitest";
 
         test("sample test", async () => {
           throw new Error("broken");
         });
       `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].status).toBe(Status.BROKEN);
       });
 
-      it("should report manually skipped tests", async () => {
-        const { tests } = await runVitestInlineTest({
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].status).toBe(Status.BROKEN);
+    });
+
+    it("should report manually skipped tests", async () => {
+      const { tests } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { test } from "vitest";
 
         test("skipped", (ctx) => {
           ctx.skip();
         })
         `,
-        });
-
-        expect(tests).toHaveLength(1);
-        expect(tests[0].status).toBe(Status.SKIPPED);
-        expect(tests[0].stage).toBe(Stage.PENDING);
       });
 
-      it("shouldn't report skipped tests and suites", async () => {
-        const { tests } = await runVitestInlineTest({
-          "sample.test.ts": `
+      expect(tests).toHaveLength(1);
+      expect(tests[0].status).toBe(Status.SKIPPED);
+      expect(tests[0].stage).toBe(Stage.PENDING);
+    });
+
+    it("shouldn't report skipped tests and suites", async () => {
+      const { tests } = await runVitestInlineTest({
+        "sample.test.ts": `
         import { describe, test } from "vitest";
 
         test.skip("skipped", () => {})
@@ -86,10 +84,9 @@ describe("simple", () => {
           test("not skipped", () => {})
         })
         `,
-        });
-
-        expect(tests).toHaveLength(0);
       });
+
+      expect(tests).toHaveLength(0);
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/test-extend.test.ts
+++ b/packages/allure-vitest/test/spec/test-extend.test.ts
@@ -1,21 +1,19 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("test.extend", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should support test.extend", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should support test.extend", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
     import { test as baseTest, expect } from "vitest";
     import { logStep } from "allure-js-commons";
 
@@ -32,26 +30,25 @@ describe("test.extend", () => {
       await logStep(dummy);
     });
   `,
-        });
-
-        expect(tests).toHaveLength(2);
-        expect(tests).toEqual([
-          expect.objectContaining({
-            name: "base test",
-            status: "passed",
-          }),
-          expect.objectContaining({
-            name: "fixture test",
-            status: "passed",
-            steps: expect.arrayContaining([
-              expect.objectContaining({
-                name: "fixture data",
-                status: "passed",
-              }),
-            ]),
-          }),
-        ]);
       });
+
+      expect(tests).toHaveLength(2);
+      expect(tests).toEqual([
+        expect.objectContaining({
+          name: "base test",
+          status: "passed",
+        }),
+        expect.objectContaining({
+          name: "fixture test",
+          status: "passed",
+          steps: expect.arrayContaining([
+            expect.objectContaining({
+              name: "fixture data",
+              status: "passed",
+            }),
+          ]),
+        }),
+      ]);
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/testPlan.test.ts
+++ b/packages/allure-vitest/test/spec/testPlan.test.ts
@@ -2,23 +2,21 @@ import { join } from "node:path";
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("test plan", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should support test plan", async () => {
-        const { tests } = await runVitestInlineTest(
-          {
-            "vitest.config.ts": configFileAccessor,
-            "foo/sample.test.ts": `
+    it("should support test plan", async () => {
+      const { tests } = await runVitestInlineTest(
+        {
+          "vitest.config.ts": configFileAccessor,
+          "foo/sample.test.ts": `
           import { test, describe } from "vitest";
 
           test("foo", () => {});
@@ -45,37 +43,34 @@ describe("test plan", () => {
             await logStep(dummy);
           });
         `,
-            "testplan.json": JSON.stringify(
-              {
-                version: "1.0",
-                tests: [
-                  { selector: "dummy:foo/sample.test.ts#baz" },
-                  { id: 3 },
-                  { selector: "dummy:foo/sample.test.ts#foo bar boop" },
-                ],
-              },
-              null,
-              2,
-            ),
-          },
-          {
-            env: (testDir) => ({
-              ALLURE_TESTPLAN_PATH: join(testDir, "testplan.json"),
-            }),
-          },
-        );
+          "testplan.json": JSON.stringify(
+            {
+              version: "1.0",
+              tests: [
+                { selector: "dummy:foo/sample.test.ts#baz" },
+                { id: 3 },
+                { selector: "dummy:foo/sample.test.ts#foo bar boop" },
+              ],
+            },
+            null,
+            2,
+          ),
+        },
+        {
+          env: (testDir) => ({
+            ALLURE_TESTPLAN_PATH: join(testDir, "testplan.json"),
+          }),
+        },
+      );
 
-        expect(tests).toHaveLength(3);
-        expect(tests).toContainEqual(
-          expect.objectContaining({ name: "baz", fullName: "dummy:foo/sample.test.ts#baz" }),
-        );
-        expect(tests).toContainEqual(
-          expect.objectContaining({ name: "beep", fullName: "dummy:foo/sample.test.ts#beep" }),
-        );
-        expect(tests).toContainEqual(
-          expect.objectContaining({ name: "boop", fullName: "dummy:foo/sample.test.ts#foo bar boop" }),
-        );
-      });
+      expect(tests).toHaveLength(3);
+      expect(tests).toContainEqual(expect.objectContaining({ name: "baz", fullName: "dummy:foo/sample.test.ts#baz" }));
+      expect(tests).toContainEqual(
+        expect.objectContaining({ name: "beep", fullName: "dummy:foo/sample.test.ts#beep" }),
+      );
+      expect(tests).toContainEqual(
+        expect.objectContaining({ name: "boop", fullName: "dummy:foo/sample.test.ts#foo bar boop" }),
+      );
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/titleMetadata.test.ts
+++ b/packages/allure-vitest/test/spec/titleMetadata.test.ts
@@ -1,39 +1,36 @@
 import { LabelName } from "allure-js-commons";
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("title metadata", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should add metadata from the test name", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "sample.test.ts": `
+    it("should add metadata from the test name", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "sample.test.ts": `
         import { test } from "vitest";
 
         test("foo @allure.id=1 @allure.label.bar=2 @allure.link.my_link=https://allurereport.org", () => {});
       `,
-        });
+      });
 
-        expect(tests).toHaveLength(1);
-        expect(tests[0]).toMatchObject({
-          name: "foo",
-          fullName: "dummy:sample.test.ts#foo",
-          labels: expect.arrayContaining([
-            { name: LabelName.ALLURE_ID, value: "1" },
-            { name: "bar", value: "2" },
-          ]),
-          links: expect.arrayContaining([{ type: "my_link", url: "https://allurereport.org" }]),
-        });
+      expect(tests).toHaveLength(1);
+      expect(tests[0]).toMatchObject({
+        name: "foo",
+        fullName: "dummy:sample.test.ts#foo",
+        labels: expect.arrayContaining([
+          { name: LabelName.ALLURE_ID, value: "1" },
+          { name: "bar", value: "2" },
+        ]),
+        links: expect.arrayContaining([{ type: "my_link", url: "https://allurereport.org" }]),
       });
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/spec/titlePath.test.ts
+++ b/packages/allure-vitest/test/spec/titlePath.test.ts
@@ -1,40 +1,38 @@
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { type TestFileAccessor, createVitestBrowserConfig, createVitestConfig, runVitestInlineTest } from "../utils.js";
+import { type TestFileAccessor, runVitestInlineTest, vitestTestEnvironments } from "../utils.js";
 
 describe("title path", () => {
-  for (const env of ["node", "browser"]) {
-    describe(`for "${env}"`, () => {
-      let configFileAccessor: TestFileAccessor;
+  describe.each(vitestTestEnvironments)('for "%s"', (_env, createConfig) => {
+    let configFileAccessor: TestFileAccessor;
 
-      beforeAll(() => {
-        configFileAccessor = ({ allureResultsPath }) =>
-          env === "node" ? createVitestConfig(allureResultsPath) : createVitestBrowserConfig(allureResultsPath);
-      });
+    beforeAll(() => {
+      configFileAccessor = ({ allureResultsPath }) => createConfig(allureResultsPath);
+    });
 
-      it("should assign titlePath property to the test result", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "foo/bar/sample.test.ts": `
+    it("should assign titlePath property to the test result", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "foo/bar/sample.test.ts": `
         import { expect, it } from "vitest";
 
         it("should pass", () => {
           expect(true).toBe(true);
         });
      `,
-        });
-
-        expect(tests).toHaveLength(1);
-
-        const [tr] = tests;
-
-        expect(tr.titlePath).toEqual(["dummy", "foo", "bar", "sample.test.ts"]);
       });
 
-      it("should assign titlePath property to the test result with suites", async () => {
-        const { tests } = await runVitestInlineTest({
-          "vitest.config.ts": configFileAccessor,
-          "foo/bar/sample.test.ts": `
+      expect(tests).toHaveLength(1);
+
+      const [tr] = tests;
+
+      expect(tr.titlePath).toEqual(["dummy", "foo", "bar", "sample.test.ts"]);
+    });
+
+    it("should assign titlePath property to the test result with suites", async () => {
+      const { tests } = await runVitestInlineTest({
+        "vitest.config.ts": configFileAccessor,
+        "foo/bar/sample.test.ts": `
         import { describe, expect, it } from "vitest";
 
         describe("foo", () => {
@@ -45,14 +43,13 @@ describe("title path", () => {
           });
         });
       `,
-        });
-
-        expect(tests).toHaveLength(1);
-
-        const [tr] = tests;
-
-        expect(tr.titlePath).toEqual(["dummy", "foo", "bar", "sample.test.ts", "foo", "bar"]);
       });
+
+      expect(tests).toHaveLength(1);
+
+      const [tr] = tests;
+
+      expect(tr.titlePath).toEqual(["dummy", "foo", "bar", "sample.test.ts", "foo", "bar"]);
     });
-  }
+  });
 });

--- a/packages/allure-vitest/test/utils.ts
+++ b/packages/allure-vitest/test/utils.ts
@@ -92,6 +92,11 @@ ${createReporterOptions(allureResultsPath, options)}
   });
 `;
 
+export const vitestTestEnvironments = [
+  ["node", createVitestConfig],
+  ["browser", createVitestBrowserConfig],
+] as const;
+
 export const runVitestInlineTest = async (
   testFiles: TestFiles,
   { env = () => ({}), cwd }: Opts = {},


### PR DESCRIPTION
<!---
Thank you so much for sending us a pull request!

Make sure you have a clear name for your pull request.
The name should start with a capital letter and no dot is required in the end of the sentence.
To link the request with issues use the following notation: (fixes #123, fixes #321\)

An example of good pull request names:
* Add Cucumber integration (fixes #123\)
* Add an ability to disable default plugins
* Support emoji in test descriptions
-->

### Context

<!---
Describe the problem or feature in addition to a link to the issues
-->
This removes hidden conditional test registration from the adapter test suites.

Vitest tests now use an explicit node/browser matrix instead of looping with runtime `if` checks. The one browser-only gap for concurrent matcher steps is declared with `it.skipIf(...)` and a comment explaining why it is skipped. The inline snapshot matcher test now runs in both node and browser.

Bun tests no longer skip when Bun is missing. The old `bunIt` helper was removed, and missing Bun now fails the test run with a clear setup error instead of silently skipping Bun integration coverage.

Node version-specific tests now use explicit `it.skipIf(...)` declarations instead of custom aliases, and the existing CodeceptJS skipped test has a clearer comment explaining the known lifecycle gap.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js