### PR TITLE
chore: add allure-js-commons bugs metadata

### DIFF
--- a/packages/allure-js-commons/package.json
+++ b/packages/allure-js-commons/package.json
@@ -21,6 +21,9 @@
     "vitest"
   ],
   "homepage": "https://allurereport.org/",
+  "bugs": {
+    "url": "https://github.com/allure-framework/allure-js/issues"
+  },
   "license": "Apache-2.0",
   "author": {
     "name": "Qameta Software",


### PR DESCRIPTION
## Summary
- add npm `bugs.url` metadata for `allure-js-commons`
- point users and registry tooling to the repository issue tracker
- leave runtime code, dependencies, package versioning, entry points, and files unchanged

## Validation
- node package metadata assertion
- corepack yarn install --immutable --mode=skip-build
- corepack yarn workspace allure-js-commons compile
- corepack yarn workspace allure-js-commons test
- corepack yarn oxlint --import-plugin packages/allure-js-commons/src packages/allure-js-commons/test
- npm pack --dry-run --json ./packages/allure-js-commons
- git diff --check