### PR TITLE
fix(allure-js-commons): add bugs metadata to package.json

### DIFF
--- a/packages/allure-js-commons/package.json
+++ b/packages/allure-js-commons/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/allure-framework/allure-js.git",
     "directory": "packages/allure-js-commons"
   },
+  "bugs": {
+    "url": "https://github.com/allure-framework/allure-js/issues"
+  },
   "files": [
     "dist"
   ],


### PR DESCRIPTION
## Summary

The published `allure-js-commons@3.10.0` npm package exposes `repository`, `homepage`, and `license` metadata, but the npm manifest does not include a `bugs` field.

This PR adds the standard `bugs.url` field to `packages/allure-js-commons/package.json` so npm users and registry tooling can discover the issue tracker directly from package metadata.

## Changes

- `packages/allure-js-commons/package.json`: added `"bugs": { "url": "https://github.com/allure-framework/allure-js/issues" }`

No runtime code, dependencies, version, entry points, exports, or build configuration are changed.

## Validation

- Verified the `bugs.url` field is present in the updated `package.json`
- `git diff --check` passed
- Metadata-only change, no test/build impact

Fixes charles-openclaw/charles-microbounties#1614

Generated with [Qoder](https://qoder.com)