### PR TITLE
fix allure-node-test runtime API inside native hooks

### DIFF
--- a/packages/allure-node-test/src/loader.ts
+++ b/packages/allure-node-test/src/loader.ts
@@ -26,9 +26,9 @@ export const load = async (url: string, context: unknown, nextLoad: Function) =>
       shortCircuit: true,
       source: `
         import * as actual from ${JSON.stringify(NODE_TEST_ACTUAL_SPECIFIER)};
-        import { applyNodeTestPlanFilter } from ${JSON.stringify(new URL("./testplan.js", import.meta.url).href)};
+        import { applyNodeTestWrappers } from ${JSON.stringify(new URL("./testplan.js", import.meta.url).href)};
 
-        const wrappers = applyNodeTestPlanFilter(actual);
+        const wrappers = applyNodeTestWrappers(actual);
 
         export default wrappers.test;
         export const test = wrappers.test;

--- a/packages/allure-node-test/src/model.ts
+++ b/packages/allure-node-test/src/model.ts
@@ -5,6 +5,7 @@ import type { ReporterConfig, Writer } from "allure-js-commons/sdk/reporter";
 export const ALLURE_NODE_TEST_CONFIG_ENV = "ALLURE_NODE_TEST_CONFIG";
 export const ALLURE_NODE_TEST_RUN_DIR_ENV = "ALLURE_NODE_TEST_RUN_DIR";
 export const ALLURE_NODE_TEST_TESTPLAN_FILTER_ENV = "ALLURE_NODE_TEST_TESTPLAN_FILTER";
+export const ROOT_SUITE_FULL_NAME = "<root>";
 
 export type NodeTestReporterConfig = ReporterConfig & {
   readonly writer?: Writer;

--- a/packages/allure-node-test/src/reporter.ts
+++ b/packages/allure-node-test/src/reporter.ts
@@ -32,15 +32,16 @@ import {
 } from "allure-js-commons/sdk/reporter";
 
 import { getNodeTestReporterConfig } from "./config.js";
-import type {
-  NodeTestEvent,
-  NodeTestEventData,
-  NodeTestError,
-  NodeTestReporterConfig,
-  NodeTestResultEvent,
-  RuntimeMessageRecord,
-  StatusResolution,
-  TestMetadata,
+import {
+  ROOT_SUITE_FULL_NAME,
+  type NodeTestEvent,
+  type NodeTestEventData,
+  type NodeTestError,
+  type NodeTestReporterConfig,
+  type NodeTestResultEvent,
+  type RuntimeMessageRecord,
+  type StatusResolution,
+  type TestMetadata,
 } from "./model.js";
 import {
   ensureRunDir,
@@ -48,6 +49,7 @@ import {
   getFallbackNodeFullName,
   getRelativeFilePath,
   normalizeFilePath,
+  splitNodeFullName,
 } from "./utils.js";
 
 const getEventType = (data: NodeTestEventData) => data.details?.type ?? data.type;
@@ -333,7 +335,10 @@ export class AllureNodeTestReporter {
     });
 
     for (const [index, record] of runtimeRecords.entries()) {
-      if (matchedRecordIndexes.has(index) || !matchesRuntimeRecord(record, resultEvent.data, metadata)) {
+      if (
+        (!isReusableRuntimeRecord(record) && matchedRecordIndexes.has(index)) ||
+        !matchesRuntimeRecord(record, resultEvent.data, metadata)
+      ) {
         continue;
       }
 
@@ -827,6 +832,10 @@ const matchesRuntimeRecord = (record: RuntimeMessageRecord, data: NodeTestEventD
     return record.testId === data.testId && normalizeFilePath(record.file) === normalizeFilePath(data.file);
   }
 
+  if (record.type === "suite" && matchesRuntimeSuiteRecord(record, data, metadata)) {
+    return true;
+  }
+
   if (record.allureFullName && record.allureFullName === metadata.fullName) {
     return true;
   }
@@ -836,6 +845,20 @@ const matchesRuntimeRecord = (record: RuntimeMessageRecord, data: NodeTestEventD
     !!record.nodeFullName &&
     record.nodeFullName === metadata.nodeFullName
   );
+};
+
+const isReusableRuntimeRecord = (record: RuntimeMessageRecord) => record.type === "suite";
+
+const matchesRuntimeSuiteRecord = (record: RuntimeMessageRecord, data: NodeTestEventData, metadata: TestMetadata) => {
+  if (normalizeFilePath(record.file) !== normalizeFilePath(data.file) || !record.nodeFullName) {
+    return false;
+  }
+
+  if (record.nodeFullName === ROOT_SUITE_FULL_NAME) {
+    return true;
+  }
+
+  return isSuitePathPrefix(splitNodeFullName(record.nodeFullName), metadata.suitePath);
 };
 
 export default async function* allureNodeTestReporter(source: AsyncIterable<NodeTestEvent>) {

--- a/packages/allure-node-test/src/runtime.ts
+++ b/packages/allure-node-test/src/runtime.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import * as nodeTest from "node:test";
@@ -13,6 +14,7 @@ type NodeTestModule = {
 };
 
 let getTracingStore: (() => NodeTestTracingStore | undefined) | undefined;
+const hookContextStorage = new AsyncLocalStorage<{ context: NodeTestContext; type: "suite" | "test" }>();
 
 const nodeTestModule = nodeTest as unknown as NodeTestModule;
 
@@ -21,6 +23,9 @@ export const hasNodeTestContextApi = () => typeof nodeTestModule.getTestContext 
 export const setNodeTestTracingStoreProvider = (provider: () => NodeTestTracingStore | undefined) => {
   getTracingStore = provider;
 };
+
+export const runWithNodeTestHookContext = <T>(context: NodeTestContext, type: "suite" | "test", callback: () => T) =>
+  hookContextStorage.run({ context, type }, callback);
 
 export class NodeTestRuntime extends MessageTestRuntime {
   constructor(private readonly runDir = ensureRunDir()) {
@@ -39,7 +44,8 @@ export class NodeTestRuntime extends MessageTestRuntime {
 }
 
 export const createRuntimeMessageRecord = (message: RuntimeMessage): RuntimeMessageRecord => {
-  const context = nodeTestModule.getTestContext?.();
+  const hookContext = hookContextStorage.getStore();
+  const context = hookContext?.context ?? getNodeTestContext();
   const tracingStore = getTracingStore?.();
   const file = normalizeFilePath(context?.filePath ?? tracingStore?.file);
   const nodeFullName = context?.fullName ?? tracingStore?.fullName ?? tracingStore?.name;
@@ -55,10 +61,18 @@ export const createRuntimeMessageRecord = (message: RuntimeMessage): RuntimeMess
     name: context?.name ?? tracingStore?.name,
     nodeFullName,
     allureFullName: getAllureFullName(file, nodeFullName),
-    type: context?.type ?? tracingStore?.type,
+    type: hookContext?.type ?? context?.type ?? tracingStore?.type,
     timestamp: Date.now(),
     message,
   };
+};
+
+const getNodeTestContext = () => {
+  try {
+    return nodeTestModule.getTestContext?.();
+  } catch {
+    return undefined;
+  }
 };
 
 export const writeRuntimeMessage = (runDir: string, record: RuntimeMessageRecord) => {

--- a/packages/allure-node-test/src/setup.ts
+++ b/packages/allure-node-test/src/setup.ts
@@ -7,7 +7,7 @@ import { setGlobalTestRuntime } from "allure-js-commons/sdk/runtime";
 
 import type { NodeTestTracingStore } from "./model.js";
 import { NodeTestRuntime, hasNodeTestContextApi, setNodeTestTracingStoreProvider } from "./runtime.js";
-import { hasExecutableTestPlan, installCommonJsTestPlanFilter } from "./testplan.js";
+import { hasExecutableTestPlan, installCommonJsNodeTestWrappers } from "./testplan.js";
 import { ensureRunDir, normalizeFilePath } from "./utils.js";
 
 const SETUP_KEY = "__allure_node_test_setup__";
@@ -33,23 +33,19 @@ const installTracingStore = () => {
   setNodeTestTracingStoreProvider(() => storage.getStore());
 };
 
-const installTestPlanFilter = () => {
-  if (!hasExecutableTestPlan()) {
-    return false;
-  }
-
-  installCommonJsTestPlanFilter();
+const installNodeTestWrappers = () => {
+  installCommonJsNodeTestWrappers();
   register("allure-node-test/loader", pathToFileURL(`${process.cwd()}/`));
-
-  return true;
 };
 
 if (!(globalThis as any)[SETUP_KEY]) {
   (globalThis as any)[SETUP_KEY] = true;
 
-  const testPlanFilterInstalled = installTestPlanFilter();
+  const testPlanAvailable = hasExecutableTestPlan();
 
-  if (!testPlanFilterInstalled) {
+  installNodeTestWrappers();
+
+  if (!testPlanAvailable) {
     assertSupportedNodeVersion();
   }
 

--- a/packages/allure-node-test/src/testplan.ts
+++ b/packages/allure-node-test/src/testplan.ts
@@ -4,7 +4,8 @@ import { LabelName } from "allure-js-commons";
 import { extractMetadataFromString, type TestPlanV1 } from "allure-js-commons/sdk";
 import { addSkipLabelAsMeta, includedInTestPlan, parseTestPlan } from "allure-js-commons/sdk/reporter";
 
-import { ALLURE_NODE_TEST_TESTPLAN_FILTER_ENV } from "./model.js";
+import { ALLURE_NODE_TEST_TESTPLAN_FILTER_ENV, type NodeTestContext } from "./model.js";
+import { runWithNodeTestHookContext } from "./runtime.js";
 import { getAllureFullNameFromParts, getFallbackNodeFullName, normalizeFilePath } from "./utils.js";
 
 type NodeTestFunction = ((...args: any[]) => unknown) & Record<string, any>;
@@ -45,14 +46,10 @@ const testPlan = parseTestPlan();
 
 export const hasExecutableTestPlan = () => !!testPlan;
 
-export const installCommonJsTestPlanFilter = () => {
-  if (!testPlan) {
-    return;
-  }
-
+export const installCommonJsNodeTestWrappers = () => {
   const require = createRequire(`${process.cwd()}/`);
   const nodeTest = require("node:test") as NodeTestModule;
-  const wrappers = applyNodeTestPlanFilter(nodeTest);
+  const wrappers = applyNodeTestWrappers(nodeTest);
 
   installCommonJsLoadFilter(require("node:module") as CommonJsModule, wrappers);
 };
@@ -80,33 +77,45 @@ const installCommonJsLoadFilter = (commonJsModule: CommonJsModule, wrappers: Nod
   };
 };
 
-export const applyNodeTestPlanFilter = (nodeTest: NodeTestModule): NodeTestWrappers => {
-  process.env[ALLURE_NODE_TEST_TESTPLAN_FILTER_ENV] = "1";
+export const applyNodeTestWrappers = (nodeTest: NodeTestModule): NodeTestWrappers => {
+  if (testPlan) {
+    process.env[ALLURE_NODE_TEST_TESTPLAN_FILTER_ENV] = "1";
+  }
 
   const originalTest = nodeTest.test ?? nodeTest.it;
   const originalDescribe = nodeTest.describe;
   const originalSuite = nodeTest.suite;
+  const before = wrapHook(nodeTest.before, "suite");
+  const beforeEach = wrapHook(nodeTest.beforeEach, "test");
+  const after = wrapHook(nodeTest.after, "suite");
+  const afterEach = wrapHook(nodeTest.afterEach, "test");
 
   if (!originalTest || !originalDescribe || !originalSuite) {
-    return nodeTest as NodeTestWrappers;
+    return {
+      ...(nodeTest as NodeTestWrappers),
+      after,
+      afterEach,
+      before,
+      beforeEach,
+    };
   }
 
-  const test = wrapTest(originalTest);
-  const describe = wrapSuite(originalDescribe);
-  const suite = wrapSuite(originalSuite);
+  const test = testPlan ? wrapTest(originalTest) : originalTest;
+  const describe = testPlan ? wrapSuite(originalDescribe) : originalDescribe;
+  const suite = testPlan ? wrapSuite(originalSuite) : originalSuite;
 
   test.it = test;
   test.test = test;
   test.describe = describe;
   test.suite = suite;
-  test.before = nodeTest.before;
-  test.beforeEach = nodeTest.beforeEach;
-  test.after = nodeTest.after;
-  test.afterEach = nodeTest.afterEach;
+  test.before = before;
+  test.beforeEach = beforeEach;
+  test.after = after;
+  test.afterEach = afterEach;
   test.run = nodeTest.run;
-  test.skip = wrapTestModifier(originalTest, "skip");
-  test.todo = wrapTestModifier(originalTest, "todo");
-  test.only = wrapTestModifier(originalTest, "only");
+  test.skip = testPlan ? wrapTestModifier(originalTest, "skip") : originalTest.skip;
+  test.todo = testPlan ? wrapTestModifier(originalTest, "todo") : originalTest.todo;
+  test.only = testPlan ? wrapTestModifier(originalTest, "only") : originalTest.only;
 
   describe.skip = originalDescribe.skip;
   describe.todo = originalDescribe.todo;
@@ -119,12 +128,16 @@ export const applyNodeTestPlanFilter = (nodeTest: NodeTestModule): NodeTestWrapp
   setIfWritable(nodeTest, "it", test);
   setIfWritable(nodeTest, "describe", describe);
   setIfWritable(nodeTest, "suite", suite);
+  setIfWritable(nodeTest, "before", before);
+  setIfWritable(nodeTest, "beforeEach", beforeEach);
+  setIfWritable(nodeTest, "after", after);
+  setIfWritable(nodeTest, "afterEach", afterEach);
 
   return {
-    after: nodeTest.after,
-    afterEach: nodeTest.afterEach,
-    before: nodeTest.before,
-    beforeEach: nodeTest.beforeEach,
+    after,
+    afterEach,
+    before,
+    beforeEach,
     describe,
     it: test,
     suite,
@@ -202,6 +215,51 @@ const wrapSuite = (originalSuite: NodeTestFunction): NodeTestFunction => {
   Object.assign(wrapped, originalSuite);
 
   return wrapped;
+};
+
+const wrapHook = (originalHook: NodeTestFunction | undefined, contextType: "suite" | "test"): NodeTestFunction => {
+  if (!originalHook) {
+    return originalHook as unknown as NodeTestFunction;
+  }
+
+  const wrapped = function allureNodeTestHookWithContext(this: unknown, ...args: any[]) {
+    const callbackIndex = args.findIndex((arg) => typeof arg === "function");
+
+    if (callbackIndex === -1) {
+      return originalHook.call(this, ...args);
+    }
+
+    const nextArgs = [...args];
+    const originalCallback = nextArgs[callbackIndex];
+
+    nextArgs[callbackIndex] = function allureNodeTestHookCallback(this: unknown, ...callbackArgs: any[]) {
+      const context = callbackArgs[0];
+
+      if (!isNodeTestContext(context)) {
+        return originalCallback.apply(this, callbackArgs);
+      }
+
+      return runWithNodeTestHookContext(context, contextType, () => originalCallback.apply(this, callbackArgs));
+    };
+
+    return originalHook.call(this, ...nextArgs);
+  } as NodeTestFunction;
+
+  Object.assign(wrapped, originalHook);
+
+  return wrapped;
+};
+
+const isNodeTestContext = (value: unknown): value is NodeTestContext => {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const context = value as NodeTestContext;
+
+  return (
+    typeof context.filePath === "string" || typeof context.fullName === "string" || typeof context.name === "string"
+  );
 };
 
 const shouldRunTest = (args: readonly unknown[]) => {

--- a/packages/allure-node-test/test/spec/node.test.ts
+++ b/packages/allure-node-test/test/spec/node.test.ts
@@ -400,4 +400,87 @@ describe("node --test integration", () => {
       expect(readAttachment(attachments, runtimeAttachment!.source)).toBe("hello node");
     },
   );
+
+  it.skipIf(!supportsNodeTestRuntimeApi)("writes runtime API data from native hooks", async () => {
+    const { attachments, exitCode, tests } = await runNodeInlineTest(
+      {
+        "hook-runtime.test.mjs": `
+          import { describe, it, before, beforeEach, afterEach, after } from "node:test";
+          import assert from "node:assert/strict";
+          import { attachment, label, step } from "allure-js-commons";
+
+          describe("hook runtime suite", () => {
+            before(async () => {
+              await label("owner", "before-hook");
+            });
+
+            beforeEach(async () => {
+              await label("feature", "before-each-hook");
+              await step("beforeEach runtime step", async () => {});
+            });
+
+            afterEach(async () => {
+              await attachment("afterEach runtime attachment", "after each body", "text/plain");
+            });
+
+            after(async () => {
+              await label("story", "after-hook");
+            });
+
+            it("uses hook runtime API", () => {
+              assert.equal(1 + 1, 2);
+            });
+
+            it("also uses hook runtime API", () => {
+              assert.equal(3 + 3, 6);
+            });
+          });
+        `,
+        "hook-runtime-cjs.test.cjs": `
+          const assert = require("node:assert/strict");
+          const { test, beforeEach } = require("node:test");
+          const { label } = require("allure-js-commons");
+
+          beforeEach(async () => {
+            await label("tag", "cjs-before-each-hook");
+          });
+
+          test("uses cjs hook runtime API", () => {
+            assert.equal(2 + 2, 4);
+          });
+        `,
+      },
+      { setup: true },
+    );
+
+    expect(exitCode).toBe(0);
+
+    for (const result of [
+      getTestByName(tests, "uses hook runtime API"),
+      getTestByName(tests, "also uses hook runtime API"),
+    ]) {
+      expect(result.labels).toEqual(
+        expect.arrayContaining([
+          { name: LabelName.OWNER, value: "before-hook" },
+          { name: LabelName.FEATURE, value: "before-each-hook" },
+          { name: LabelName.STORY, value: "after-hook" },
+        ]),
+      );
+      expect(result.steps).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: "beforeEach runtime step" })]),
+      );
+
+      const runtimeAttachment = result.steps
+        .flatMap((entry) => entry.attachments)
+        .concat(result.attachments)
+        .find((entry) => entry.name === "afterEach runtime attachment");
+
+      expect(runtimeAttachment).toBeDefined();
+      expect(readAttachment(attachments, runtimeAttachment!.source)).toBe("after each body");
+    }
+
+    expect(getTestByName(tests, "uses cjs hook runtime API").labels).toEqual(
+      expect.arrayContaining([{ name: LabelName.TAG, value: "cjs-before-each-hook" }]),
+    );
+  });
 });

--- a/packages/allure-node-test/test/spec/runtime.test.ts
+++ b/packages/allure-node-test/test/spec/runtime.test.ts
@@ -1,0 +1,45 @@
+import { join } from "node:path";
+
+import { LabelName } from "allure-js-commons";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createRuntimeMessageRecord, setNodeTestTracingStoreProvider } from "../../src/runtime.js";
+import { getAllureFullNameFromParts, normalizeFilePath } from "../../src/utils.js";
+
+describe("createRuntimeMessageRecord", () => {
+  afterEach(() => {
+    setNodeTestTracingStoreProvider(() => undefined);
+  });
+
+  it("uses node:test tracing data when TestContext is unavailable", () => {
+    const file = normalizeFilePath(join(process.cwd(), "test/fixtures/runtime-fallback.test.mjs"));
+    const message = {
+      type: "metadata",
+      data: {
+        labels: [{ name: LabelName.FEATURE, value: "fallback" }],
+      },
+    } as const;
+
+    setNodeTestTracingStoreProvider(() => ({
+      file,
+      fullName: "Runtime fallback > uses tracing data",
+      name: "uses tracing data",
+      testId: 17,
+      type: "test",
+    }));
+
+    expect(createRuntimeMessageRecord(message)).toEqual(
+      expect.objectContaining({
+        version: 1,
+        pid: process.pid,
+        testId: 17,
+        file,
+        name: "uses tracing data",
+        nodeFullName: "Runtime fallback > uses tracing data",
+        allureFullName: getAllureFullNameFromParts(file, ["Runtime fallback", "uses tracing data"]),
+        type: "test",
+        message,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
the adapter now captures the hook callback context that Node passes in and uses it when writing runtime messages

fixes https://github.com/allure-framework/allure-js/issues/1517 

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
