### PR TITLE
Fix Cucumber background steps reporting

### DIFF
--- a/packages/allure-cucumberjs/src/reporter.ts
+++ b/packages/allure-cucumberjs/src/reporter.ts
@@ -216,6 +216,8 @@ export default class AllureCucumberReporter extends Formatter {
         this.onRule(c.rule);
       } else if (c.scenario) {
         this.onScenario(c.scenario);
+      } else if (c.background) {
+        c.background.steps.forEach((step) => this.stepMap.set(step.id, step));
       }
     });
   }

--- a/packages/allure-cucumberjs/test/samples/features/background.feature
+++ b/packages/allure-cucumberjs/test/samples/features/background.feature
@@ -1,0 +1,11 @@
+Feature: background
+
+  Background:
+    Given a background step
+    And another background step
+
+  Scenario: passed with background
+    Given a passed step
+
+  Scenario: failed with background
+    Given a failed step

--- a/packages/allure-cucumberjs/test/samples/support/background.cjs
+++ b/packages/allure-cucumberjs/test/samples/support/background.cjs
@@ -1,0 +1,18 @@
+const { Given } = require("@cucumber/cucumber");
+const { equal } = require("node:assert");
+
+Given("a background step", async () => {
+  equal(1, 1);
+});
+
+Given("another background step", async () => {
+  equal(2, 2);
+});
+
+Given("a passed step", async () => {
+  equal(1, 1);
+});
+
+Given("a failed step", () => {
+  equal(1, 2);
+});

--- a/packages/allure-cucumberjs/test/spec/background.test.ts
+++ b/packages/allure-cucumberjs/test/spec/background.test.ts
@@ -1,0 +1,55 @@
+import { Stage, Status } from "allure-js-commons";
+import { expect, it } from "vitest";
+
+import { runCucumberInlineTest } from "../utils.js";
+
+it("includes background steps in each scenario", async () => {
+  const { tests } = await runCucumberInlineTest(["background"], ["background"]);
+
+  expect(tests).toHaveLength(2);
+
+  const backgroundSteps = [
+    expect.objectContaining({
+      name: "Given a background step",
+      status: Status.PASSED,
+      stage: Stage.FINISHED,
+    }),
+    expect.objectContaining({
+      name: "And another background step",
+      status: Status.PASSED,
+      stage: Stage.FINISHED,
+    }),
+  ];
+
+  expect(tests).toContainEqual(
+    expect.objectContaining({
+      name: "passed with background",
+      status: Status.PASSED,
+      stage: Stage.FINISHED,
+      steps: [
+        ...backgroundSteps,
+        expect.objectContaining({
+          name: "Given a passed step",
+          status: Status.PASSED,
+          stage: Stage.FINISHED,
+        }),
+      ],
+    }),
+  );
+
+  expect(tests).toContainEqual(
+    expect.objectContaining({
+      name: "failed with background",
+      status: Status.FAILED,
+      stage: Stage.FINISHED,
+      steps: [
+        ...backgroundSteps,
+        expect.objectContaining({
+          name: "Given a failed step",
+          status: Status.FAILED,
+          stage: Stage.FINISHED,
+        }),
+      ],
+    }),
+  );
+});


### PR DESCRIPTION
### Context

Cucumber background steps were missing their keywords in the Allure test body. `Given a precondition` and `And another precondition` would appear as `a precondition` and `another precondition`. 

Fixes https://github.com/allure-framework/allure-js/issues/1530

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
