### PR TITLE
add regression coverage for Playwright failure screenshots

### DIFF
--- a/packages/allure-playwright/test/spec/screenshots.spec.ts
+++ b/packages/allure-playwright/test/spec/screenshots.spec.ts
@@ -1,9 +1,65 @@
 import { createServer } from "node:http";
 
-import { Status } from "allure-js-commons";
+import { ContentType, Status } from "allure-js-commons";
 import { expect, it } from "vitest";
 
 import { runPlaywrightInlineTest } from "../utils.js";
+
+it("should attach playwright automatic failure screenshots", async () => {
+  const { tests, attachments } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import test, { expect } from '@playwright/test';
+
+      test('should fail with a screenshot', async ({ page }) => {
+        await page.setContent('<main>actual content</main>');
+        await expect(page.locator('main')).toHaveText('expected content');
+      });
+    `,
+    "playwright.config.js": `
+       module.exports = {
+         reporter: [
+           [
+             "allure-playwright",
+             {
+               resultsDir: "./allure-results",
+             },
+           ],
+           ["dot"],
+         ],
+         projects: [
+           {
+             name: "project",
+             use: {
+               screenshot: "only-on-failure",
+             },
+           },
+         ],
+       };
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toMatchObject({
+    status: Status.FAILED,
+    steps: expect.arrayContaining([
+      expect.objectContaining({
+        name: "screenshot",
+        attachments: [
+          expect.objectContaining({
+            name: "screenshot",
+            type: ContentType.PNG,
+            source: expect.stringMatching(/.*\.png/),
+          }),
+        ],
+      }),
+    ]),
+  });
+
+  const screenshotStep = tests[0].steps.find((step) => step.name === "screenshot");
+  const screenshotAttachment = screenshotStep?.attachments[0];
+
+  expect(screenshotAttachment?.source && attachments[screenshotAttachment.source]).toBeDefined();
+});
 
 it("should handle playwright native screenshot testing", async () => {
   const server = createServer((req, res) => {


### PR DESCRIPTION
Verify https://github.com/allure-framework/allure-js/issues/1131 isn't a problem now. Regression test for automatic screenshots captured with use.screenshot: "only-on-failure". The test runs a failing Playwright case and verifies that Allure records the screenshot as an image/png attachment on the generated test result, with the attachment file actually present in the output.

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
