### PR TITLE
publish result files atomically

### DIFF
--- a/packages/allure-js-commons/src/sdk/reporter/writer/FileSystemWriter.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/writer/FileSystemWriter.ts
@@ -1,5 +1,16 @@
-import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import {
+  closeSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
+import { basename, dirname, join } from "node:path";
 
 import type { Globals, TestResult, TestResultContainer } from "../../../model.js";
 import type { Category, EnvironmentInfo } from "../../types.js";
@@ -7,7 +18,66 @@ import type { Writer } from "../types.js";
 import { stringifyEnvInfo } from "../utils/envInfo.js";
 
 const writeJson = (path: string, data: unknown): void => {
-  writeFileSync(path, JSON.stringify(data), "utf-8");
+  writeFile(path, JSON.stringify(data), "utf-8");
+};
+
+const buildTempPath = (path: string): string => {
+  return join(dirname(path), `${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+};
+
+const writeAndFlushFile = (path: string, write: (fd: number) => void): void => {
+  const fd = openSync(path, "w");
+
+  try {
+    write(fd);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+};
+
+const publishFile = (path: string, writeTempFile: (path: string) => void): void => {
+  const tempPath = buildTempPath(path);
+
+  try {
+    writeTempFile(tempPath);
+    renameSync(tempPath, path);
+  } finally {
+    rmSync(tempPath, {
+      force: true,
+    });
+  }
+};
+
+const writeFile = (path: string, data: string | Buffer, encoding?: BufferEncoding): void => {
+  publishFile(path, (tempPath) => {
+    writeAndFlushFile(tempPath, (fd) => {
+      writeFileSync(fd, data, encoding);
+    });
+  });
+};
+
+const copyFile = (from: string, to: string): void => {
+  publishFile(to, (tempPath) => {
+    const fromFd = openSync(from, "r");
+
+    try {
+      writeAndFlushFile(tempPath, (toFd) => {
+        const buffer = Buffer.allocUnsafe(64 * 1024);
+        let bytesRead = 0;
+
+        while ((bytesRead = readSync(fromFd, buffer, 0, buffer.length, null)) > 0) {
+          let bytesWritten = 0;
+
+          while (bytesWritten < bytesRead) {
+            bytesWritten += writeSync(toFd, buffer, bytesWritten, bytesRead - bytesWritten);
+          }
+        }
+      });
+    } finally {
+      closeSync(fromFd);
+    }
+  });
 };
 
 export class FileSystemWriter implements Writer {
@@ -16,20 +86,20 @@ export class FileSystemWriter implements Writer {
   writeAttachment(distFileName: string, content: Buffer): void {
     const path = this.buildPath(distFileName);
 
-    writeFileSync(path, content, "utf-8");
+    writeFile(path, content);
   }
 
   writeAttachmentFromPath(distFileName: string, from: string): void {
     const to = this.buildPath(distFileName);
 
-    copyFileSync(from, to);
+    copyFile(from, to);
   }
 
   writeEnvironmentInfo(info: EnvironmentInfo): void {
     const text = stringifyEnvInfo(info);
     const path = this.buildPath("environment.properties");
 
-    writeFileSync(path, text);
+    writeFile(path, text);
   }
 
   writeCategoriesDefinitions(categories: Category[]): void {

--- a/packages/allure-js-commons/src/sdk/reporter/writer/FileSystemWriter.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/writer/FileSystemWriter.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 
 import type { Globals, TestResult, TestResultContainer } from "../../../model.js";
 import type { Category, EnvironmentInfo } from "../../types.js";
@@ -22,7 +22,21 @@ const writeJson = (path: string, data: unknown): void => {
 };
 
 const buildTempPath = (path: string): string => {
-  return join(dirname(path), `${basename(path)}.${process.pid}.${randomUUID()}.tmp`);
+  return join(dirname(path), `.allure-write-${randomUUID()}.tmp`);
+};
+
+const removeTempFile = (path: string): void => {
+  rmSync(path, {
+    force: true,
+  });
+};
+
+const tryRemoveTempFile = (path: string): void => {
+  try {
+    removeTempFile(path);
+  } catch (ignored) {
+    void ignored;
+  }
 };
 
 const writeAndFlushFile = (path: string, write: (fd: number) => void): void => {
@@ -42,11 +56,12 @@ const publishFile = (path: string, writeTempFile: (path: string) => void): void 
   try {
     writeTempFile(tempPath);
     renameSync(tempPath, path);
-  } finally {
-    rmSync(tempPath, {
-      force: true,
-    });
+  } catch (error) {
+    tryRemoveTempFile(tempPath);
+    throw error;
   }
+
+  removeTempFile(tempPath);
 };
 
 const writeFile = (path: string, data: string | Buffer, encoding?: BufferEncoding): void => {

--- a/packages/allure-js-commons/test/sdk/reporter/writer/FileSystemWriter.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/writer/FileSystemWriter.spec.ts
@@ -27,6 +27,7 @@ vi.mock("node:fs", async (importOriginal) => {
     ...actual,
     fsyncSync: vi.fn(actual.fsyncSync),
     renameSync: vi.fn(actual.renameSync),
+    rmSync: vi.fn(actual.rmSync),
   };
 });
 
@@ -62,6 +63,7 @@ describe("FileSystemWriter", () => {
   beforeEach(() => {
     vi.mocked(fsyncSync).mockClear();
     vi.mocked(renameSync).mockClear();
+    vi.mocked(rmSync).mockClear();
   });
 
   it("should save attachment from path", () => {
@@ -160,6 +162,26 @@ describe("FileSystemWriter", () => {
     expect(fsyncSync).toHaveBeenCalledTimes(5);
   });
 
+  it("replaces fixed-name metadata files without leaving temporary files", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+
+    writer.writeCategoriesDefinitions([{ name: "first category" }]);
+    writer.writeCategoriesDefinitions([{ name: "second category" }]);
+    writer.writeEnvironmentInfo({ browser: "chrome" });
+    writer.writeEnvironmentInfo({ browser: "firefox" });
+
+    expect(JSON.parse(readFileSync(path.join(allureResults, "categories.json"), "utf-8"))).toEqual([
+      { name: "second category" },
+    ]);
+    expect(readFileSync(path.join(allureResults, "environment.properties"), "utf-8")).toBe("browser=firefox");
+    expectNoTmpFiles(allureResults);
+    expect(fsyncSync).toHaveBeenCalledTimes(4);
+  });
+
   it("flushes the temporary file before publishing the final name", () => {
     const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
     const allureResults = path.join(tmp, "allure-results");
@@ -176,7 +198,8 @@ describe("FileSystemWriter", () => {
     writer.writeResult(createTestResult("result-uuid"));
 
     expect(tmpFilesDuringFlush).toHaveLength(1);
-    expect(tmpFilesDuringFlush[0]).toMatch(/^result-uuid-result\.json\.\d+\..+\.tmp$/);
+    expect(tmpFilesDuringFlush[0]).toMatch(/^\.allure-write-.+\.tmp$/);
+    expect(tmpFilesDuringFlush[0]).not.toContain("result");
     expect(existsSync(path.join(allureResults, "result-uuid-result.json"))).toBe(true);
     expectNoTmpFiles(allureResults);
   });
@@ -197,6 +220,26 @@ describe("FileSystemWriter", () => {
     );
     expect(existsSync(path.join(allureResults, "failed-attachment.txt"))).toBe(false);
     expectNoTmpFiles(allureResults);
+  });
+
+  it("keeps the original publishing error when temporary cleanup fails", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+
+    vi.mocked(fsyncSync).mockImplementationOnce(() => {
+      throw new Error("fsync failed");
+    });
+    vi.mocked(rmSync).mockImplementationOnce(() => {
+      throw new Error("cleanup failed");
+    });
+
+    expect(() => writer.writeAttachment("failed-cleanup-attachment.txt", Buffer.from("partial", "utf8"))).toThrow(
+      "fsync failed",
+    );
+    expect(existsSync(path.join(allureResults, "failed-cleanup-attachment.txt"))).toBe(false);
   });
 
   it("removes temporary files when publishing fails during rename", () => {

--- a/packages/allure-js-commons/test/sdk/reporter/writer/FileSystemWriter.spec.ts
+++ b/packages/allure-js-commons/test/sdk/reporter/writer/FileSystemWriter.spec.ts
@@ -1,16 +1,69 @@
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  fsyncSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { ContentType } from "../../../../src/model.js";
+import { ContentType, Stage, Status, type TestResult, type TestResultContainer } from "../../../../src/model.js";
 import { ReporterRuntime } from "../../../../src/sdk/reporter/ReporterRuntime.js";
 import type { ReporterRuntimeConfig } from "../../../../src/sdk/reporter/types.js";
 import { FileSystemWriter } from "../../../../src/sdk/reporter/writer/FileSystemWriter.js";
 
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+
+  return {
+    ...actual,
+    fsyncSync: vi.fn(actual.fsyncSync),
+    renameSync: vi.fn(actual.renameSync),
+  };
+});
+
+const listTmpFiles = (dir: string) => {
+  return existsSync(dir) ? readdirSync(dir).filter((file) => file.endsWith(".tmp")) : [];
+};
+
+const expectNoTmpFiles = (dir: string) => {
+  expect(listTmpFiles(dir)).toEqual([]);
+};
+
+const createTestResult = (uuid = "test-uuid"): TestResult => ({
+  uuid,
+  name: "test",
+  status: Status.PASSED,
+  statusDetails: {},
+  stage: Stage.FINISHED,
+  steps: [],
+  attachments: [],
+  parameters: [],
+  labels: [],
+  links: [],
+});
+
+const createTestContainer = (uuid = "container-uuid"): TestResultContainer => ({
+  uuid,
+  children: [],
+  befores: [],
+  afters: [],
+});
+
 describe("FileSystemWriter", () => {
+  beforeEach(() => {
+    vi.mocked(fsyncSync).mockClear();
+    vi.mocked(renameSync).mockClear();
+  });
+
   it("should save attachment from path", () => {
     const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
     const allureResults = path.join(tmp, "allure-results");
@@ -34,11 +87,134 @@ describe("FileSystemWriter", () => {
     const resultFiles = readdirSync(allureResults);
 
     expect(resultFiles).toHaveLength(2);
+    expectNoTmpFiles(allureResults);
 
     const attachmentResultPath = resultFiles.find((file) => file.includes("attachment"))!;
     const actualContent = readFileSync(path.join(allureResults, attachmentResultPath));
 
     expect(actualContent.toString("utf8")).toBe(data);
+    expect(fsyncSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("publishes buffer attachments via a temporary file", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+
+    writer.writeAttachment("source-attachment.txt", Buffer.from("attachment body", "utf8"));
+
+    expect(readFileSync(path.join(allureResults, "source-attachment.txt"), "utf-8")).toBe("attachment body");
+    expectNoTmpFiles(allureResults);
+    expect(fsyncSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("publishes read-only path attachments", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+    const from = path.join(tmp, "read-only-attachment.txt");
+
+    writeFileSync(from, "read-only content", "utf8");
+    chmodSync(from, 0o444);
+
+    writer.writeAttachmentFromPath("read-only-attachment.txt", from);
+
+    expect(readFileSync(path.join(allureResults, "read-only-attachment.txt"), "utf-8")).toBe("read-only content");
+    expectNoTmpFiles(allureResults);
+    expect(fsyncSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("writes json and metadata files via the same atomic publish path", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+    const result = createTestResult("result-uuid");
+    const container = createTestContainer("container-uuid");
+    const globals = {
+      attachments: [],
+      errors: [],
+    };
+
+    writer.writeResult(result);
+    writer.writeGroup(container);
+    writer.writeGlobals("global-uuid-globals.json", globals);
+    writer.writeCategoriesDefinitions([{ name: "Product defects", matchedStatuses: [Status.FAILED] }]);
+    writer.writeEnvironmentInfo({ browser: "chrome", empty: undefined });
+
+    expect(JSON.parse(readFileSync(path.join(allureResults, "result-uuid-result.json"), "utf-8"))).toEqual(result);
+    expect(JSON.parse(readFileSync(path.join(allureResults, "container-uuid-container.json"), "utf-8"))).toEqual(
+      container,
+    );
+    expect(JSON.parse(readFileSync(path.join(allureResults, "global-uuid-globals.json"), "utf-8"))).toEqual(globals);
+    expect(JSON.parse(readFileSync(path.join(allureResults, "categories.json"), "utf-8"))).toEqual([
+      { name: "Product defects", matchedStatuses: [Status.FAILED] },
+    ]);
+    expect(readFileSync(path.join(allureResults, "environment.properties"), "utf-8")).toBe("browser=chrome");
+    expectNoTmpFiles(allureResults);
+    expect(fsyncSync).toHaveBeenCalledTimes(5);
+  });
+
+  it("flushes the temporary file before publishing the final name", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+    let tmpFilesDuringFlush: string[] = [];
+
+    vi.mocked(fsyncSync).mockImplementationOnce(() => {
+      tmpFilesDuringFlush = listTmpFiles(allureResults);
+      expect(existsSync(path.join(allureResults, "result-uuid-result.json"))).toBe(false);
+    });
+
+    writer.writeResult(createTestResult("result-uuid"));
+
+    expect(tmpFilesDuringFlush).toHaveLength(1);
+    expect(tmpFilesDuringFlush[0]).toMatch(/^result-uuid-result\.json\.\d+\..+\.tmp$/);
+    expect(existsSync(path.join(allureResults, "result-uuid-result.json"))).toBe(true);
+    expectNoTmpFiles(allureResults);
+  });
+
+  it("removes temporary files when publishing fails before rename", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+
+    vi.mocked(fsyncSync).mockImplementationOnce(() => {
+      throw new Error("fsync failed");
+    });
+
+    expect(() => writer.writeAttachment("failed-attachment.txt", Buffer.from("partial", "utf8"))).toThrow(
+      "fsync failed",
+    );
+    expect(existsSync(path.join(allureResults, "failed-attachment.txt"))).toBe(false);
+    expectNoTmpFiles(allureResults);
+  });
+
+  it("removes temporary files when publishing fails during rename", () => {
+    const tmp = mkdtempSync(path.join(os.tmpdir(), "foo-"));
+    const allureResults = path.join(tmp, "allure-results");
+    const writer = new FileSystemWriter({
+      resultsDir: allureResults,
+    });
+
+    vi.mocked(renameSync).mockImplementationOnce(() => {
+      throw new Error("rename failed");
+    });
+
+    expect(() => writer.writeAttachment("failed-rename-attachment.txt", Buffer.from("content", "utf8"))).toThrow(
+      "rename failed",
+    );
+    expect(existsSync(path.join(allureResults, "failed-rename-attachment.txt"))).toBe(false);
+    expectNoTmpFiles(allureResults);
   });
 
   it("creates allure-report nested path every time writer write something", () => {


### PR DESCRIPTION
Write Allure result files and attachments to same-directory .tmp files, fsync them, and rename them to the final names after writing completes.

This prevents live report generation and TestOps readers from observing partially written outputs, especially large attachments such as videos. Failed publications clean up their temporary files.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
