### PR TITLE
Add an option to use legacy Playwright full names

### DIFF
--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -76,6 +76,19 @@ directory.
 
 You may select another location, or further customize the reporter's behavior with [the configuration options](https://allurereport.org/docs/playwright-configuration/).
 
+To use name-based test selectors instead of source locations, enable the legacy full name format:
+
+```js
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  reporter: [["allure-playwright", { useLegacyFullName: true }]],
+});
+```
+
+This produces full names in the `file#suite test` format instead of `file:line:column`. Test names must be unique
+within the same suite when this option is enabled.
+
 ### View the report
 
 Use Allure Report 2:

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -201,7 +201,7 @@ export class AllureReporter implements ReporterV2 {
       parameters: [],
       steps: [],
       testCaseId: md5(metadata.testCaseIdBase),
-      fullName: metadata.fullName,
+      fullName: this.options.useLegacyFullName ? metadata.legacyFullName : metadata.fullName,
       titlePath,
     };
 

--- a/packages/allure-playwright/src/model.ts
+++ b/packages/allure-playwright/src/model.ts
@@ -12,6 +12,7 @@ import type { ReporterConfig } from "allure-js-commons/sdk/reporter";
 export interface AllurePlaywrightReporterConfig extends ReporterConfig {
   detail?: boolean;
   suiteTitle?: boolean;
+  useLegacyFullName?: boolean;
 }
 
 export type HookScope = "before" | "after";

--- a/packages/allure-playwright/test/spec/fullName.spec.ts
+++ b/packages/allure-playwright/test/spec/fullName.spec.ts
@@ -25,3 +25,26 @@ it("should preserve fullName format and include fallback testCaseId", async () =
     ]),
   );
 });
+
+it("should use legacy fullName format when enabled", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "package.json": JSON.stringify({ name: "dummy" }),
+    "playwright.config.js": `
+      module.exports = {
+        reporter: [["allure-playwright", { useLegacyFullName: true }]],
+        projects: [{ name: "project" }],
+      };
+    `,
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+
+      test.describe('nested', () => {
+        test('test 1', async () => {});
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].fullName).toBe("sample.test.js#nested test 1");
+  expect(tests[0].testCaseId).toBe(md5("dummy:sample.test.js#nested test 1"));
+});


### PR DESCRIPTION
### Context

Playwright test results currently use `file:line:column` as `fullName`. This value is unstable when test locations change, which makes rerunning test cases from Allure TestOps unreliable for projects that do not use explicit Allure IDs.

This PR adds the optional `useLegacyFullName` reporter setting. When enabled, the reporter uses the legacy `file#suite test` format. The default behavior and `testCaseId` remain unchanged.

Using the option:

```js
import { defineConfig } from "@playwright/test";

export default defineConfig({
  reporter: [["allure-playwright", { useLegacyFullName: true }]],
});
```
Test names must be unique within the same suite when this option is enabled.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
