### PR TITLE
Replace useLegacyFullName with native, stable Playwright test identifiers

### DIFF
--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -81,6 +81,12 @@ changes. For a stable identifier instead, use the `playwrightTestId` label carri
 own [`TestCase.id`](https://playwright.dev/docs/api/class-testcase#test-case-id), a hash of the project, file, and
 suite/test titles that doesn't depend on source location.
 
+Each result also carries a `playwrightTestListSelector` label (`file › suite › ... › title`) usable verbatim as a
+line in a Playwright [`--test-list`](https://playwright.dev/docs/test-cli#test-list) file. When every entry in an
+`ALLURE_TESTPLAN_PATH` test plan's `selector` field is one of these values, the reporter passes that file to
+Playwright's own `--test-list`, so reruns skip loading non-matching test files entirely instead of relying only on
+per-test filtering.
+
 ### View the report
 
 Use Allure Report 2:

--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -76,18 +76,35 @@ directory.
 
 You may select another location, or further customize the reporter's behavior with [the configuration options](https://allurereport.org/docs/playwright-configuration/).
 
-To use name-based test selectors instead of source locations, enable the legacy full name format:
+By default, `fullName` is built from the test's source location (`file:line:column`), which shifts whenever the
+surrounding code changes. Reruns of specific tests (e.g. from Allure TestOps) that rely on `fullName` as a stable
+selector can use the `fullName` option to change that:
 
 ```js
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
-  reporter: [["allure-playwright", { useLegacyFullName: true }]],
+  reporter: [["allure-playwright", { fullName: "legacy" }]],
 });
 ```
 
-This produces full names in the `file#suite test` format instead of `file:line:column`. Test names must be unique
-within the same suite when this option is enabled.
+`"legacy"` produces full names in the `file#suite test` format instead of `file:line:column`. Test names must be
+unique within the same suite when this preset is used.
+
+For any other naming convention, pass a function instead:
+
+```js
+export default defineConfig({
+  reporter: [
+    [
+      "allure-playwright",
+      {
+        fullName: (test, { relativeFile, suiteTitles, title }) => `${relativeFile}::${[...suiteTitles, title].join(" > ")}`,
+      },
+    ],
+  ],
+});
+```
 
 ### View the report
 

--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -76,36 +76,10 @@ directory.
 
 You may select another location, or further customize the reporter's behavior with [the configuration options](https://allurereport.org/docs/playwright-configuration/).
 
-By default, `fullName` is built from the test's source location (`file:line:column`), which shifts whenever the
-surrounding code changes. Reruns of specific tests (e.g. from Allure TestOps) that rely on `fullName` as a stable
-selector can use the `fullName` option to change that:
-
-```js
-import { defineConfig } from "@playwright/test";
-
-export default defineConfig({
-  reporter: [["allure-playwright", { fullName: "legacy" }]],
-});
-```
-
-`"legacy"` produces full names in the `file#suite test` format instead of `file:line:column`. Test names must be
-unique within the same suite when this preset is used.
-
-For any other naming convention, pass a function instead:
-
-```js
-export default defineConfig({
-  reporter: [
-    [
-      "allure-playwright",
-      {
-        fullName: (test, { relativeFile, suiteTitles, title }) =>
-          `${relativeFile}::${[...suiteTitles, title].join(" > ")}`,
-      },
-    ],
-  ],
-});
-```
+`fullName` is built from the test's source location (`file:line:column`), which shifts whenever the surrounding code
+changes. For a stable identifier instead, use the `playwrightTestId` label carried on each result — it's Playwright's
+own [`TestCase.id`](https://playwright.dev/docs/api/class-testcase#test-case-id), a hash of the project, file, and
+suite/test titles that doesn't depend on source location.
 
 ### View the report
 

--- a/packages/allure-playwright/README.md
+++ b/packages/allure-playwright/README.md
@@ -99,7 +99,8 @@ export default defineConfig({
     [
       "allure-playwright",
       {
-        fullName: (test, { relativeFile, suiteTitles, title }) => `${relativeFile}::${[...suiteTitles, title].join(" > ")}`,
+        fullName: (test, { relativeFile, suiteTitles, title }) =>
+          `${relativeFile}::${[...suiteTitles, title].join(" > ")}`,
       },
     ],
   ],

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -1,6 +1,7 @@
-import { existsSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { access } from "node:fs/promises";
 import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
@@ -18,7 +19,7 @@ import {
   type StepResult,
   type TestResult,
 } from "allure-js-commons";
-import type { RuntimeMessage, RuntimeStepMetadataMessage, TestPlanV1Test } from "allure-js-commons/sdk";
+import type { RuntimeMessage, RuntimeStepMetadataMessage } from "allure-js-commons/sdk";
 import {
   extractMetadataFromString,
   getMessageAndTraceFromError,
@@ -32,7 +33,6 @@ import {
   ShallowStepsStack,
   createDefaultWriter,
   createStepResult,
-  escapeRegExp,
   formatLink,
   getEnvironmentLabels,
   getFallbackTestCaseIdLabel,
@@ -74,6 +74,8 @@ type TestPlanExecutionFilter = (test: TestCase, parentSuite?: Suite) => boolean;
 const localRequire = typeof require === "function" ? require : createRequire(import.meta.url);
 const testPlanFilterSymbol = Symbol.for("allure-playwright.testPlanFilter");
 const testPlanFilterPatchSymbol = Symbol.for("allure-playwright.testPlanFilterPatch");
+// Playwright's own --test-list format: `file › suite › ... › title`, ignoring source location.
+const NATIVE_SELECTOR_SEPARATOR = " › ";
 
 export class AllureReporter implements ReporterV2 {
   config!: FullConfig;
@@ -121,56 +123,25 @@ export class AllureReporter implements ReporterV2 {
 
     configElement?.preOnlyTestFilters?.push((test: TestCase) => this.isInTestPlan(test));
 
-    if (testPlan.tests.some((test) => test.id !== undefined)) {
+    if (!configElement) {
       return;
     }
 
-    const testsWithSelectors = testPlan.tests.filter((test) => test.selector);
+    // Only safe when every test plan entry is one of our own playwrightTestListSelector values: --test-list
+    // is an allowlist, so a test plan mixing in an id-only or differently-formatted selector entry would
+    // have those tests silently excluded before isInTestPlan (the always-on, authoritative filter) sees them.
+    const nativeSelectors = testPlan.tests
+      .map((test) => test.selector)
+      .filter((selector): selector is string => !!selector?.includes(NATIVE_SELECTOR_SEPARATOR));
 
-    const v1ReporterTests: TestPlanV1Test[] = [];
-    const v2ReporterTests: TestPlanV1Test[] = [];
-    const cliArgs: string[] = [];
-
-    testsWithSelectors.forEach((test) => {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-      if (!/#/.test(test.selector!)) {
-        v2ReporterTests.push(test);
-        return;
-      }
-
-      v1ReporterTests.push(test);
-    });
-
-    // The path needs to be specific to the current OS. Otherwise, it may not match against the test file.
-    const selectorToGrepPattern = (selector: string) => escapeRegExp(path.normalize(`/${selector}`));
-
-    if (v2ReporterTests.length) {
-      // we need to cut off column because playwright works only with line number
-      const v2SelectorsArgs = v2ReporterTests
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        .map((test) => test.selector!.replace(/:\d+$/, ""))
-        .map(selectorToGrepPattern);
-
-      cliArgs.push(...v2SelectorsArgs);
-    }
-
-    if (v1ReporterTests.length) {
-      const v1SelectorsArgs = v1ReporterTests
-        // we can filter tests only by absolute path, so we need to cut off test name
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        .map((test) => test.selector!.split("#")[0])
-        .map(selectorToGrepPattern);
-
-      cliArgs.push(...v1SelectorsArgs);
-    }
-
-    if (!cliArgs.length) {
+    if (nativeSelectors.length !== testPlan.tests.length) {
       return;
     }
 
-    if (configElement) {
-      configElement.cliArgs = cliArgs;
-    }
+    const testListPath = path.join(tmpdir(), `allure-playwright-testlist-${process.pid}-${randomUuid()}.txt`);
+    writeFileSync(testListPath, nativeSelectors.join("\n"), "utf8");
+
+    configElement.cliArgs = ["--test-list", testListPath];
   }
 
   onError(): void {}
@@ -212,6 +183,8 @@ export class AllureReporter implements ReporterV2 {
     result.labels!.push({ name: "titlePath", value: test.parent.titlePath().join(" > ") });
     // Stable across source-location changes, unlike the default fullName; see Playwright's TestCase.id docs.
     result.labels!.push({ name: "playwrightTestId", value: test.id });
+    // Usable verbatim as a line in a Playwright --test-list file; see the "Test list" section of the Playwright CLI docs.
+    result.labels!.push({ name: "playwrightTestListSelector", value: metadata.nativeSelector });
 
     // support for earlier playwright versions
     if ("tags" in test) {
@@ -1069,6 +1042,7 @@ export class AllureReporter implements ReporterV2 {
       titleMetadata,
       fullName: `${relativeFile}:${test.location.line}:${test.location.column}`,
       legacyFullName,
+      nativeSelector: [relativeFile, ...suiteTitles, titleMetadata.cleanTitle].join(NATIVE_SELECTOR_SEPARATOR),
       staticAllureId,
     };
   }
@@ -1078,10 +1052,10 @@ export class AllureReporter implements ReporterV2 {
       return true;
     }
 
-    const { fullName, legacyFullName, staticAllureId } = this.getStaticTestMetadata(test, parentSuite);
+    const { fullName, legacyFullName, nativeSelector, staticAllureId } = this.getStaticTestMetadata(test, parentSuite);
 
     return (
-      includedInTestPlan(this.testPlan, { fullName, id: staticAllureId }) ||
+      includedInTestPlan(this.testPlan, { fullName, id: staticAllureId, nativeSelector }) ||
       includedInTestPlan(this.testPlan, { fullName: legacyFullName, id: staticAllureId })
     );
   }

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -201,7 +201,7 @@ export class AllureReporter implements ReporterV2 {
       parameters: [],
       steps: [],
       testCaseId: md5(metadata.testCaseIdBase),
-      fullName: this.options.useLegacyFullName ? metadata.legacyFullName : metadata.fullName,
+      fullName: this.resolveFullName(test, metadata),
       titlePath,
     };
 
@@ -1065,10 +1065,26 @@ export class AllureReporter implements ReporterV2 {
       testCaseIdBase: projectName ? `${projectName}:${testCaseIdBase}` : testCaseIdBase,
       legacyTestCaseIdBase: testCaseIdBase,
       titleMetadata,
+      relativeFile,
       fullName: `${relativeFile}:${test.location.line}:${test.location.column}`,
       legacyFullName,
       staticAllureId,
     };
+  }
+
+  private resolveFullName(test: TestCase, metadata: ReturnType<AllureReporter["getStaticTestMetadata"]>): string {
+    const { fullName } = this.options;
+
+    if (typeof fullName === "function") {
+      return fullName(test, {
+        relativeFile: metadata.relativeFile,
+        suiteTitles: metadata.suiteTitles,
+        title: test.title,
+        projectName: metadata.projectName,
+      });
+    }
+
+    return fullName === "legacy" ? metadata.legacyFullName : metadata.fullName;
   }
 
   private isInTestPlan(test: TestCase, parentSuite?: Suite) {

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -201,7 +201,7 @@ export class AllureReporter implements ReporterV2 {
       parameters: [],
       steps: [],
       testCaseId: md5(metadata.testCaseIdBase),
-      fullName: this.resolveFullName(test, metadata),
+      fullName: metadata.fullName,
       titlePath,
     };
 
@@ -210,6 +210,8 @@ export class AllureReporter implements ReporterV2 {
     result.labels!.push(getPackageLabel(metadata.testFilePath, metadata.projectRootSearchFrom));
     result.labels!.push(getFallbackTestCaseIdLabel(md5(metadata.legacyTestCaseIdBase)));
     result.labels!.push({ name: "titlePath", value: test.parent.titlePath().join(" > ") });
+    // Stable across source-location changes, unlike the default fullName; see Playwright's TestCase.id docs.
+    result.labels!.push({ name: "playwrightTestId", value: test.id });
 
     // support for earlier playwright versions
     if ("tags" in test) {
@@ -1065,26 +1067,10 @@ export class AllureReporter implements ReporterV2 {
       testCaseIdBase: projectName ? `${projectName}:${testCaseIdBase}` : testCaseIdBase,
       legacyTestCaseIdBase: testCaseIdBase,
       titleMetadata,
-      relativeFile,
       fullName: `${relativeFile}:${test.location.line}:${test.location.column}`,
       legacyFullName,
       staticAllureId,
     };
-  }
-
-  private resolveFullName(test: TestCase, metadata: ReturnType<AllureReporter["getStaticTestMetadata"]>): string {
-    const { fullName } = this.options;
-
-    if (typeof fullName === "function") {
-      return fullName(test, {
-        relativeFile: metadata.relativeFile,
-        suiteTitles: metadata.suiteTitles,
-        title: test.title,
-        projectName: metadata.projectName,
-      });
-    }
-
-    return fullName === "legacy" ? metadata.legacyFullName : metadata.fullName;
   }
 
   private isInTestPlan(test: TestCase, parentSuite?: Suite) {

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -74,7 +74,6 @@ type TestPlanExecutionFilter = (test: TestCase, parentSuite?: Suite) => boolean;
 const localRequire = typeof require === "function" ? require : createRequire(import.meta.url);
 const testPlanFilterSymbol = Symbol.for("allure-playwright.testPlanFilter");
 const testPlanFilterPatchSymbol = Symbol.for("allure-playwright.testPlanFilterPatch");
-// Playwright's own --test-list format: `file › suite › ... › title`, ignoring source location.
 const NATIVE_SELECTOR_SEPARATOR = " › ";
 
 export class AllureReporter implements ReporterV2 {
@@ -127,9 +126,6 @@ export class AllureReporter implements ReporterV2 {
       return;
     }
 
-    // Only safe when every test plan entry is one of our own playwrightTestListSelector values: --test-list
-    // is an allowlist, so a test plan mixing in an id-only or differently-formatted selector entry would
-    // have those tests silently excluded before isInTestPlan (the always-on, authoritative filter) sees them.
     const nativeSelectors = testPlan.tests
       .map((test) => test.selector)
       .filter((selector): selector is string => !!selector?.includes(NATIVE_SELECTOR_SEPARATOR));
@@ -181,9 +177,7 @@ export class AllureReporter implements ReporterV2 {
     result.labels!.push(getPackageLabel(metadata.testFilePath, metadata.projectRootSearchFrom));
     result.labels!.push(getFallbackTestCaseIdLabel(md5(metadata.legacyTestCaseIdBase)));
     result.labels!.push({ name: "titlePath", value: test.parent.titlePath().join(" > ") });
-    // Stable across source-location changes, unlike the default fullName; see Playwright's TestCase.id docs.
     result.labels!.push({ name: "playwrightTestId", value: test.id });
-    // Usable verbatim as a line in a Playwright --test-list file; see the "Test list" section of the Playwright CLI docs.
     result.labels!.push({ name: "playwrightTestListSelector", value: metadata.nativeSelector });
 
     // support for earlier playwright versions

--- a/packages/allure-playwright/src/model.ts
+++ b/packages/allure-playwright/src/model.ts
@@ -9,10 +9,19 @@ import type {
 } from "@playwright/test/reporter";
 import type { ReporterConfig } from "allure-js-commons/sdk/reporter";
 
+export interface FullNameMeta {
+  relativeFile: string;
+  suiteTitles: string[];
+  title: string;
+  projectName?: string;
+}
+
+export type FullNamePreset = "location" | "legacy";
+
 export interface AllurePlaywrightReporterConfig extends ReporterConfig {
   detail?: boolean;
   suiteTitle?: boolean;
-  useLegacyFullName?: boolean;
+  fullName?: FullNamePreset | ((test: TestCase, meta: FullNameMeta) => string);
 }
 
 export type HookScope = "before" | "after";

--- a/packages/allure-playwright/src/model.ts
+++ b/packages/allure-playwright/src/model.ts
@@ -9,19 +9,9 @@ import type {
 } from "@playwright/test/reporter";
 import type { ReporterConfig } from "allure-js-commons/sdk/reporter";
 
-export interface FullNameMeta {
-  relativeFile: string;
-  suiteTitles: string[];
-  title: string;
-  projectName?: string;
-}
-
-export type FullNamePreset = "location" | "legacy";
-
 export interface AllurePlaywrightReporterConfig extends ReporterConfig {
   detail?: boolean;
   suiteTitle?: boolean;
-  fullName?: FullNamePreset | ((test: TestCase, meta: FullNameMeta) => string);
 }
 
 export type HookScope = "before" | "after";

--- a/packages/allure-playwright/test/spec/fullName.spec.ts
+++ b/packages/allure-playwright/test/spec/fullName.spec.ts
@@ -26,12 +26,12 @@ it("should preserve fullName format and include fallback testCaseId", async () =
   );
 });
 
-it("should use legacy fullName format when enabled", async () => {
+it("should use legacy fullName format when the legacy preset is selected", async () => {
   const { tests } = await runPlaywrightInlineTest({
     "package.json": JSON.stringify({ name: "dummy" }),
     "playwright.config.js": `
       module.exports = {
-        reporter: [["allure-playwright", { useLegacyFullName: true }]],
+        reporter: [["allure-playwright", { fullName: "legacy" }]],
         projects: [{ name: "project" }],
       };
     `,
@@ -47,4 +47,26 @@ it("should use legacy fullName format when enabled", async () => {
   expect(tests).toHaveLength(1);
   expect(tests[0].fullName).toBe("sample.test.js#nested test 1");
   expect(tests[0].testCaseId).toBe(md5("dummy:sample.test.js#nested test 1"));
+});
+
+it("should use a custom fullName resolver function when provided", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "package.json": JSON.stringify({ name: "dummy" }),
+    "playwright.config.js": `
+      module.exports = {
+        reporter: [["allure-playwright", { fullName: (test, meta) => \`custom::\${meta.relativeFile}::\${meta.title}\` }]],
+        projects: [{ name: "project" }],
+      };
+    `,
+    "sample.test.js": `
+      import { test } from '@playwright/test';
+
+      test.describe('nested', () => {
+        test('test 1', async () => {});
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0].fullName).toBe("custom::sample.test.js::test 1");
 });

--- a/packages/allure-playwright/test/spec/fullName.spec.ts
+++ b/packages/allure-playwright/test/spec/fullName.spec.ts
@@ -26,47 +26,31 @@ it("should preserve fullName format and include fallback testCaseId", async () =
   );
 });
 
-it("should use legacy fullName format when the legacy preset is selected", async () => {
-  const { tests } = await runPlaywrightInlineTest({
-    "package.json": JSON.stringify({ name: "dummy" }),
-    "playwright.config.js": `
-      module.exports = {
-        reporter: [["allure-playwright", { fullName: "legacy" }]],
-        projects: [{ name: "project" }],
-      };
-    `,
-    "sample.test.js": `
+it("should report a playwrightTestId label stable across source-location changes", async () => {
+  const specSource = (leadingBlankLines: string) => `${leadingBlankLines}
       import { test } from '@playwright/test';
 
       test.describe('nested', () => {
         test('test 1', async () => {});
       });
-    `,
-  });
-
-  expect(tests).toHaveLength(1);
-  expect(tests[0].fullName).toBe("sample.test.js#nested test 1");
-  expect(tests[0].testCaseId).toBe(md5("dummy:sample.test.js#nested test 1"));
-});
-
-it("should use a custom fullName resolver function when provided", async () => {
-  const { tests } = await runPlaywrightInlineTest({
+    `;
+  const projectFiles = {
     "package.json": JSON.stringify({ name: "dummy" }),
     "playwright.config.js": `
       module.exports = {
-        reporter: [["allure-playwright", { fullName: (test, meta) => \`custom::\${meta.relativeFile}::\${meta.title}\` }]],
+        reporter: [["allure-playwright"]],
         projects: [{ name: "project" }],
       };
     `,
-    "sample.test.js": `
-      import { test } from '@playwright/test';
+  };
 
-      test.describe('nested', () => {
-        test('test 1', async () => {});
-      });
-    `,
-  });
+  const before = await runPlaywrightInlineTest({ ...projectFiles, "sample.test.js": specSource("") });
+  const after = await runPlaywrightInlineTest({ ...projectFiles, "sample.test.js": specSource("\n\n\n") });
 
-  expect(tests).toHaveLength(1);
-  expect(tests[0].fullName).toBe("custom::sample.test.js::test 1");
+  const playwrightTestIdOf = (tests: (typeof before)["tests"]) =>
+    tests[0].labels.find((label) => label.name === "playwrightTestId")?.value;
+
+  expect(before.tests[0].fullName).not.toBe(after.tests[0].fullName);
+  expect(playwrightTestIdOf(before.tests)).toBeTruthy();
+  expect(playwrightTestIdOf(before.tests)).toBe(playwrightTestIdOf(after.tests));
 });

--- a/packages/allure-playwright/test/spec/testplan.spec.ts
+++ b/packages/allure-playwright/test/spec/testplan.spec.ts
@@ -432,3 +432,77 @@ describe("testplan with id fallback", () => {
     expect(results.tests).toEqual([]);
   });
 });
+
+describe("testplan with the native --test-list selector", () => {
+  const spec = /* ts */ `
+    import { test } from '@playwright/test';
+    test.describe('nested', () => {
+      test('should not execute', async () => {
+        (await import('node:fs')).writeFileSync('native-not-selected-ran.txt', 'yes');
+      });
+      test('should execute', async () => {
+        (await import('node:fs')).writeFileSync('native-selected-ran.txt', 'yes');
+      });
+    });
+  `;
+
+  it("matches by playwrightTestListSelector and survives a source-location shift", async () => {
+    const discovery = await runPlaywrightInlineTest({ "a.test.ts": spec });
+    const target = discovery.tests.find((test) => test.name === "should execute")!;
+    const nativeSelector = target.labels.find((label) => label.name === "playwrightTestListSelector")!.value;
+
+    const exampleTestPlan: TestPlanV1 = {
+      version: "1.0",
+      tests: [{ id: 1, selector: nativeSelector }],
+    };
+    const testPlanFilename = "example-testplan.json";
+    const results = await runPlaywrightInlineTest(
+      {
+        // Extra leading lines shift every test's file:line:column, which a --test-list selector ignores.
+        "a.test.ts": `\n\n\n\n\n${spec}`,
+        [testPlanFilename]: JSON.stringify(exampleTestPlan),
+      },
+      [],
+      { ALLURE_TESTPLAN_PATH: testPlanFilename },
+    );
+
+    expect(results.tests).toHaveLength(1);
+    expect(results.tests[0].name).toBe("should execute");
+    expect(results.restFiles["native-selected-ran.txt"]).toBe("yes");
+    expect(results.restFiles["native-not-selected-ran.txt"]).toBeUndefined();
+  });
+
+  it("falls back to per-test matching when a test plan mixes a native selector with an id-only entry", async () => {
+    const exampleTestPlan: TestPlanV1 = {
+      version: "1.0",
+      tests: [{ id: 1, selector: "a.test.ts › nested › should execute" }, { id: 5 }],
+    };
+    const testPlanFilename = "example-testplan.json";
+    const results = await runPlaywrightInlineTest(
+      {
+        "a.test.ts": /* ts */ `
+        import { test } from '@playwright/test';
+        test.describe('nested', () => {
+          test('should execute', async () => {
+            (await import('node:fs')).writeFileSync('by-selector-ran.txt', 'yes');
+          });
+          test('should also execute @allure.id=5', async () => {
+            (await import('node:fs')).writeFileSync('by-id-ran.txt', 'yes');
+          });
+          test('should not execute', async () => {
+            (await import('node:fs')).writeFileSync('not-selected-ran.txt', 'yes');
+          });
+        });
+      `,
+        [testPlanFilename]: JSON.stringify(exampleTestPlan),
+      },
+      [],
+      { ALLURE_TESTPLAN_PATH: testPlanFilename },
+    );
+
+    expect(results.tests).toHaveLength(2);
+    expect(results.restFiles["by-selector-ran.txt"]).toBe("yes");
+    expect(results.restFiles["by-id-ran.txt"]).toBe("yes");
+    expect(results.restFiles["not-selected-ran.txt"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Context

#1566 added `useLegacyFullName: boolean` to let `allure-playwright` emit `fullName` in the stable `file#suite test` format instead of the default `file:line:column`, which shifts whenever a test's source location changes. That instability breaks name-based rerun selectors built from a previous report (e.g. Allure TestOps constructing a selector for a specific test to rerun) for projects that don't set explicit `ALLURE_ID` labels.

An earlier version of this PR replaced the boolean with a `fullName?: "location" | "legacy" | ((test, meta) => string)` option instead. That's gone now — see below.

## Change

`fullName` is back to being exactly what it always was (`file:line:column`, unconditional, no option). Instead of asking every project to configure a different `fullName` format, each result now also carries two labels computed from data Playwright already gives us:

- **`playwrightTestId`** — Playwright's own [`TestCase.id`](https://playwright.dev/docs/api/class-testcase#test-case-id), a hash of the project, file, and suite/test titles. Stable across source-location changes; can't collide on duplicate test titles either, since Playwright itself refuses to run a suite with two identically-titled tests in the same scope.
- **`playwrightTestListSelector`** — `file › suite › ... › title`, usable verbatim as a line in a Playwright [`--test-list`](https://playwright.dev/docs/test-cli#test-list) file, which matches by that same hierarchy and ignores `line:column` entirely.

`ALLURE_TESTPLAN_PATH` test-plan handling now uses `playwrightTestListSelector` two ways:

- `isInTestPlan` matches a test plan's `selector` against it directly (in addition to the existing `fullName`/legacy-`file#suite title` checks), so a test plan built from a report that used this format keeps matching after the test moves to a different line.
- The old CLI fast-path — which built its own regex-escaped `--grep` patterns from `file:line:column`/`file#suite title` selectors — is replaced with generating a real Playwright `--test-list` file and passing it via `--test-list`, when every entry in the test plan uses the new selector format. Mixed or legacy-format test plans still fall back to the unchanged per-test `isInTestPlan` matching, so nothing existing regresses.

`testCaseId` is unaffected by any of this — it already uses a location-independent identity, so cross-report identity/history does not change.

`useLegacyFullName` (#1566) was merged very recently and has not shipped in a release yet, so this replaces it outright instead of deprecating it alongside something new.

#### Checklist

- [x] Provide unit tests
