### PR TITLE
Add an option to turn off the steps generated from Cypress commands (fixes #1129)

### DIFF
--- a/packages/allure-cypress/src/browser/commandLog.ts
+++ b/packages/allure-cypress/src/browser/commandLog.ts
@@ -4,11 +4,16 @@ import type { CypressLogEntry, LogStepDescriptor } from "../types.js";
 import { isDefined } from "../utils.js";
 import { reportStepStart } from "./lifecycle.js";
 import serializePropValue from "./serialize.js";
-import { getCurrentStep, getStepStack, pushStep, setupStepFinalization } from "./state.js";
+import { getConfig, getCurrentStep, getStepStack, pushStep, setupStepFinalization } from "./state.js";
 import { ALLURE_STEP_CMD_SUBJECT, findAndStopStepWithSubsteps, isLogStep } from "./steps.js";
 import { resolveConsoleProps, resolveRenderProps } from "./utils.js";
 
 export const shouldCreateStepFromCommandLogEntry = (entry: CypressLogEntry) => {
+  if (!getConfig().stepsFromCommands.enabled) {
+    // The user has turned the automatic steps off. Only the steps created via the Allure API are reported.
+    return false;
+  }
+
   const { event, instrument } = entry.attributes;
   if (instrument !== "command") {
     // We are interested in the "TEST BODY" panel only for now.

--- a/packages/allure-cypress/src/reporter.ts
+++ b/packages/allure-cypress/src/reporter.ts
@@ -553,11 +553,13 @@ const createRuntimeState = (allureConfig?: AllureCypressConfig): AllureSpecState
 
 const getRuntimeConfigDefaults = ({
   stepsFromCommands: {
+    enabled = DEFAULT_RUNTIME_CONFIG.stepsFromCommands.enabled,
     maxArgumentLength = DEFAULT_RUNTIME_CONFIG.stepsFromCommands.maxArgumentLength,
     maxArgumentDepth = DEFAULT_RUNTIME_CONFIG.stepsFromCommands.maxArgumentDepth,
   } = DEFAULT_RUNTIME_CONFIG.stepsFromCommands,
 }: AllureCypressConfig = DEFAULT_RUNTIME_CONFIG): AllureSpecState["config"] => ({
   stepsFromCommands: {
+    enabled,
     maxArgumentDepth,
     maxArgumentLength,
   },

--- a/packages/allure-cypress/src/types.ts
+++ b/packages/allure-cypress/src/types.ts
@@ -235,6 +235,11 @@ export type StepFinalizer = (message: CypressStepFinalizeMessage["data"]) => voi
 export type AllureSpecState = {
   config: {
     stepsFromCommands: {
+      /**
+       * If `false`, Cypress commands are no longer converted into Allure steps. Only the steps created with the
+       * Allure API, e.g., `allure.step`, are reported. Defaults to `true`.
+       */
+      enabled: boolean;
       maxArgumentLength: number;
       maxArgumentDepth: number;
     };

--- a/packages/allure-cypress/src/utils.ts
+++ b/packages/allure-cypress/src/utils.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_RUNTIME_CONFIG = {
   stepsFromCommands: {
+    enabled: true,
     maxArgumentLength: 128,
     maxArgumentDepth: 3,
   },

--- a/packages/allure-cypress/test/spec/commands.test.ts
+++ b/packages/allure-cypress/test/spec/commands.test.ts
@@ -1108,3 +1108,120 @@ it("should not hang when using cy.origin with allure steps", async () => {
     }),
   ]);
 });
+
+describe("the enabled option", () => {
+  const specFile = ({ allureCommonsModulePath }: { allureCommonsModulePath: string }) => `
+    import { step } from "${allureCommonsModulePath}";
+
+    it("foo", () => {
+      step("bar", () => {
+        cy.wrap(1);
+      });
+      cy.log("baz");
+    });
+  `;
+
+  const configFile =
+    (stepsFromCommands: string) =>
+    ({
+      allureCypressReporterModulePath,
+      allureDirPath,
+    }: {
+      allureCypressReporterModulePath: string;
+      allureDirPath: string;
+    }) =>
+      `
+      const { allureCypress } = require("${allureCypressReporterModulePath}");
+
+      module.exports = {
+        e2e: {
+          baseUrl: "https://allurereport.org",
+          viewportWidth: 1240,
+          setupNodeEvents: (on, config) => {
+            allureCypress(on, config, {
+              resultsDir: "${allureDirPath}",
+              ${stepsFromCommands}
+            });
+
+            return config;
+          },
+        },
+      };
+    `;
+
+  const expectedStepsWhenOn = [
+    expect.objectContaining({
+      name: "bar",
+      status: Status.PASSED,
+      stage: Stage.FINISHED,
+      steps: [
+        expect.objectContaining({
+          name: "wrap 1",
+          status: Status.PASSED,
+        }),
+      ],
+    }),
+    expect.objectContaining({
+      name: "log baz",
+      status: Status.PASSED,
+      stage: Stage.FINISHED,
+      steps: [],
+    }),
+  ];
+
+  it("should create steps from commands if the option is missing", async () => {
+    issue("1129");
+    const { tests } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": specFile,
+      "cypress.config.js": configFile(`stepsFromCommands: { maxArgumentLength: 25 },`),
+    });
+
+    expect(tests).toEqual([
+      expect.objectContaining({
+        name: "foo",
+        status: Status.PASSED,
+        steps: expectedStepsWhenOn,
+      }),
+    ]);
+  });
+
+  it("should create steps from commands if the option is true", async () => {
+    issue("1129");
+    const { tests } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": specFile,
+      "cypress.config.js": configFile(`stepsFromCommands: { enabled: true },`),
+    });
+
+    expect(tests).toEqual([
+      expect.objectContaining({
+        name: "foo",
+        status: Status.PASSED,
+        steps: expectedStepsWhenOn,
+      }),
+    ]);
+  });
+
+  it("should keep the steps of the Allure API only if the option is false", async () => {
+    issue("1129");
+    const { tests } = await runCypressInlineTest({
+      "cypress/e2e/sample.cy.js": specFile,
+      "cypress.config.js": configFile(`stepsFromCommands: { enabled: false },`),
+    });
+
+    expect(tests).toEqual([
+      expect.objectContaining({
+        name: "foo",
+        status: Status.PASSED,
+        stage: Stage.FINISHED,
+        steps: [
+          expect.objectContaining({
+            name: "bar",
+            status: Status.PASSED,
+            stage: Stage.FINISHED,
+            steps: [],
+          }),
+        ],
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
### Context

Fixes #1129.

The switch is `enabled` inside the existing `stepsFromCommands` group, next to `maxArgumentLength` and `maxArgumentDepth`, so every setting for the command log steps stays in one place. A top level key was the alternative, and it would have split the group from the flag that turns the whole group into a no-op.

```js
allureCypress(on, config, {
  stepsFromCommands: { enabled: false },
});
```

The gate sits in `shouldCreateStepFromCommandLogEntry`, the single predicate the `log:added` handler consults before anything reaches the step stack. Nothing is pushed, so nothing needs unwinding when the option is off. Default is `true`, so a config that omits the key reports exactly what it reports today.

Limits worth knowing: the flag only covers steps built from the command log. Steps from the Allure API and attachments such as screenshots come from their own handlers and keep working. The value applies to the whole spec, there is no per test override.

Three cases in `packages/allure-cypress/test/spec/commands.test.ts`, each running a spec that puts one command inside `allure.step` and one outside it. Reverting the source change fails the `enabled: false` case and leaves the other two green; those two are there to pin the default.

#### Checklist

- [ ] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
