### PR TITLE
Report Playwright steps interrupted by a skip modifier as skipped (fixes #1369)

### DIFF
--- a/packages/allure-playwright/src/utils.ts
+++ b/packages/allure-playwright/src/utils.ts
@@ -1,5 +1,5 @@
 import type { TestStatus } from "@playwright/test";
-import type { TestStep } from "@playwright/test/reporter";
+import type { TestError, TestStep } from "@playwright/test/reporter";
 import { Stage, Status, type StatusDetails, type StepResult } from "allure-js-commons";
 import { getMessageAndTraceFromError } from "allure-js-commons/sdk";
 
@@ -61,6 +61,27 @@ export const getSkipAnnotation = (step: Pick<TestStep, "annotations">) => {
   return step.annotations.find((annotation) => annotation.type === "skip");
 };
 
+// Playwright implements the test.skip() and test.fixme() modifiers by throwing an internal error with
+// this message. When a modifier is called from a hook or from inside a step, the error is attached to
+// the surrounding step, so a skipped test reaches the reporter with errored steps although nothing failed.
+const SKIP_MODIFIER_ERROR_REGEXP = /^(?:\S*Error:\s)?Test is skipped:\s?([\s\S]*)$/;
+
+/**
+ * Detects an error produced by a Playwright skip modifier and extracts the reason passed to it.
+ * Returns `undefined` for any other error, including a genuine failure.
+ */
+export const getSkipModifierError = (error: Pick<TestError, "message">): { reason?: string } | undefined => {
+  const match = error.message ? SKIP_MODIFIER_ERROR_REGEXP.exec(error.message) : null;
+
+  if (!match) {
+    return undefined;
+  }
+
+  const reason = match[1].trim();
+
+  return reason ? { reason } : {};
+};
+
 export const getStepStatusData = (
   step: Pick<TestStep, "annotations" | "error">,
 ): {
@@ -79,6 +100,15 @@ export const getStepStatusData = (
   }
 
   if (step.error) {
+    const skipModifierError = getSkipModifierError(step.error);
+
+    if (skipModifierError) {
+      return {
+        status: Status.SKIPPED,
+        statusDetails: skipModifierError.reason ? { message: skipModifierError.reason } : undefined,
+      };
+    }
+
     return {
       status: Status.FAILED,
       statusDetails: { ...getMessageAndTraceFromError(step.error) },

--- a/packages/allure-playwright/test/spec/skip.test.ts
+++ b/packages/allure-playwright/test/spec/skip.test.ts
@@ -1,4 +1,4 @@
-import { Status } from "allure-js-commons";
+import { Stage, Status } from "allure-js-commons";
 import { md5 } from "allure-js-commons/sdk/reporter";
 import { expect, it } from "vitest";
 
@@ -63,5 +63,194 @@ it("reports programmatically skipped results", async () => {
   );
   expect(skipped2.labels).toEqual(
     expect.arrayContaining([{ name: "_fallbackTestCaseId", value: md5("sample.test.js#should be skipped 2") }]),
+  );
+});
+
+it("reports steps of a test skipped in a hook as skipped", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import test from '@playwright/test';
+
+      test.describe('suite', () => {
+        test.beforeEach(async () => {
+          test.skip(true, "skipped in the hook");
+        });
+
+        test('should be skipped', async () => {});
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toEqual(
+    expect.objectContaining({
+      name: "should be skipped",
+      status: Status.SKIPPED,
+      statusDetails: expect.objectContaining({
+        message: "skipped in the hook",
+      }),
+    }),
+  );
+
+  const beforeHooks = tests[0].steps.find((step) => step.name === "Before Hooks")!;
+
+  expect(beforeHooks).toEqual(
+    expect.objectContaining({
+      status: Status.SKIPPED,
+      stage: Stage.FINISHED,
+      statusDetails: expect.objectContaining({
+        message: "skipped in the hook",
+      }),
+      steps: [
+        expect.objectContaining({
+          name: "beforeEach hook",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "skipped in the hook",
+          }),
+        }),
+      ],
+    }),
+  );
+});
+
+it("reports steps of a conditionally skipped test as skipped", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import test from '@playwright/test';
+
+      test.describe('suite', () => {
+        test.skip(() => true, "skipped by condition");
+
+        test('should be skipped', async () => {});
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toEqual(
+    expect.objectContaining({
+      name: "should be skipped",
+      status: Status.SKIPPED,
+    }),
+  );
+
+  const beforeHooks = tests[0].steps.find((step) => step.name === "Before Hooks")!;
+
+  expect(beforeHooks).toEqual(
+    expect.objectContaining({
+      status: Status.SKIPPED,
+      stage: Stage.FINISHED,
+      statusDetails: expect.objectContaining({
+        message: "skipped by condition",
+      }),
+      steps: [
+        expect.objectContaining({
+          name: "skip modifier",
+          status: Status.SKIPPED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: "skipped by condition",
+          }),
+        }),
+      ],
+    }),
+  );
+});
+
+it("reports a step interrupted by a skip modifier as skipped", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import test from '@playwright/test';
+
+      test('should be skipped', async () => {
+        await test.step('a step', async () => {
+          test.skip(true, "skipped in the step");
+        });
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toEqual(
+    expect.objectContaining({
+      name: "should be skipped",
+      status: Status.SKIPPED,
+    }),
+  );
+  expect(tests[0].steps).toContainEqual(
+    expect.objectContaining({
+      name: "a step",
+      status: Status.SKIPPED,
+      stage: Stage.FINISHED,
+      statusDetails: expect.objectContaining({
+        message: "skipped in the step",
+      }),
+    }),
+  );
+});
+
+it("keeps steps of a failed test failed", async () => {
+  const { tests } = await runPlaywrightInlineTest({
+    "sample.test.js": `
+      import test from '@playwright/test';
+
+      test('should fail in a step', async () => {
+        await test.step('a step', async () => {
+          throw new Error("something went wrong");
+        });
+      });
+
+      test.describe('suite', () => {
+        test.beforeEach(async () => {
+          throw new Error("the hook went wrong");
+        });
+
+        test('should fail in a hook', async () => {});
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(2);
+
+  const failedInStep = tests.find((test) => test.name === "should fail in a step")!;
+  const failedInHook = tests.find((test) => test.name === "should fail in a hook")!;
+
+  expect(failedInStep.status).toBe(Status.FAILED);
+  expect(failedInStep.steps).toContainEqual(
+    expect.objectContaining({
+      name: "a step",
+      status: Status.FAILED,
+      stage: Stage.FINISHED,
+      statusDetails: expect.objectContaining({
+        message: expect.stringContaining("something went wrong"),
+        trace: expect.stringContaining("something went wrong"),
+      }),
+    }),
+  );
+
+  expect(failedInHook.status).toBe(Status.FAILED);
+
+  const beforeHooks = failedInHook.steps.find((step) => step.name === "Before Hooks")!;
+
+  expect(beforeHooks).toEqual(
+    expect.objectContaining({
+      status: Status.FAILED,
+      stage: Stage.FINISHED,
+      statusDetails: expect.objectContaining({
+        message: expect.stringContaining("the hook went wrong"),
+      }),
+      steps: [
+        expect.objectContaining({
+          name: "beforeEach hook",
+          status: Status.FAILED,
+          stage: Stage.FINISHED,
+          statusDetails: expect.objectContaining({
+            message: expect.stringContaining("the hook went wrong"),
+          }),
+        }),
+      ],
+    }),
   );
 });


### PR DESCRIPTION
### Context

Fixes #1369.

Playwright gives the reporter no structured signal for this. The modifiers are implemented by throwing, and when one runs in a hook or inside a step the error is attached to the surrounding step, so `getStepStatusData` sees something indistinguishable from a failure. The skip annotation the reporter reads today only covers the step API (`test.step.skip()`, `stepInfo.skip()`), where Playwright swallows the error, which is why those steps never reached that branch. Matching the message is the only handle the reporter has.

The alternative was to move the annotation branch ahead of the error branch. I left the order alone, because a step can carry a skip annotation and an inherited soft assertion error at once, and the error should win in that case.

Residual risk: the match is anchored to the start of the message and to the exact `Test is skipped:` wording, so it depends on a Playwright internal string and needs a follow up if that wording changes. An error of your own that opens with the same text would be read as a skip.

Four cases in `packages/allure-playwright/test/spec/skip.test.ts`. Reverting the source change turns three of them red. The fourth covers a real throw in a step and a real throw in a hook and stays green either way, since its job is to catch a match that got too loose.

#### Checklist

- [ ] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
