### PR TITLE
fix(playwright): resolve legacy Suite internals for test plan filtering

### DIFF
--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -69,6 +69,14 @@ type PlaywrightSuitePrototype = {
   _addTest?: (test: TestCase) => void;
 };
 
+type PlaywrightCommonModule = {
+  test?: { Suite?: { prototype?: PlaywrightSuitePrototype } };
+};
+
+type PlaywrightCommonTestModule = {
+  Suite?: { prototype?: PlaywrightSuitePrototype };
+};
+
 type PatchedPlaywrightSuitePrototype = PlaywrightSuitePrototype & Record<symbol, unknown>;
 type TestPlanExecutionFilter = (test: TestCase, parentSuite?: Suite) => boolean;
 
@@ -1148,14 +1156,28 @@ export class AllureReporter implements ReporterV2 {
     patchedSuitePrototype[testPlanFilterPatchSymbol] = true;
   }
 
-  private getPlaywrightSuitePrototype(): PlaywrightSuitePrototype | undefined {
+  private getPlaywrightSuitePrototype(
+    playwrightTestRequire = createRequire(localRequire.resolve("@playwright/test")),
+  ): PlaywrightSuitePrototype | undefined {
     try {
-      const playwrightTestRequire = createRequire(localRequire.resolve("@playwright/test"));
-      const playwrightCommon = playwrightTestRequire("playwright/lib/common") as {
-        test?: { Suite?: { prototype?: PlaywrightSuitePrototype } };
-      };
+      const playwrightCommon = playwrightTestRequire("playwright/lib/common") as PlaywrightCommonModule;
 
-      return playwrightCommon.test?.Suite?.prototype;
+      const suitePrototype = playwrightCommon.test?.Suite?.prototype;
+
+      if (suitePrototype) {
+        return suitePrototype;
+      }
+    } catch {
+      // Playwright 1.53-1.59 didn't export playwright/lib/common, but the Suite lived in lib/common/test.js.
+    }
+
+    try {
+      const playwrightPackagePath = playwrightTestRequire.resolve("playwright/package.json");
+      const playwrightCommonTest = playwrightTestRequire(
+        path.join(path.dirname(playwrightPackagePath), "lib/common/test.js"),
+      ) as PlaywrightCommonTestModule;
+
+      return playwrightCommonTest.Suite?.prototype;
     } catch {
       return undefined;
     }

--- a/packages/allure-playwright/test/spec/testplan.spec.ts
+++ b/packages/allure-playwright/test/spec/testplan.spec.ts
@@ -1,7 +1,41 @@
-import type { TestPlanV1 } from "allure-js-commons/sdk";
-import { describe, expect, it } from "vitest";
+import { join } from "node:path";
 
+import type { TestPlanV1 } from "allure-js-commons/sdk";
+import { describe, expect, it, vi } from "vitest";
+
+import { AllureReporter } from "../../src/index.js";
 import { runPlaywrightInlineTest } from "../utils.js";
+
+describe("Playwright internals", () => {
+  it("resolves Suite from legacy Playwright common test module", () => {
+    const suitePrototype = { _addTest: vi.fn() };
+    const playwrightPackagePath = join("playwright-root", "package.json");
+    const playwrightCommonTestPath = join("playwright-root", "lib/common/test.js");
+    const fakeRequire = Object.assign(
+      vi.fn((id: string) => {
+        if (id === "playwright/lib/common") {
+          throw Object.assign(new Error("not exported"), { code: "ERR_PACKAGE_PATH_NOT_EXPORTED" });
+        }
+
+        if (id === playwrightCommonTestPath) {
+          return { Suite: { prototype: suitePrototype } };
+        }
+
+        throw new Error(`Unexpected require: ${id}`);
+      }),
+      {
+        resolve: vi.fn((id: string) => {
+          expect(id).toBe("playwright/package.json");
+          return playwrightPackagePath;
+        }),
+      },
+    ) as unknown as NodeRequire;
+
+    const reporter = new AllureReporter({});
+
+    expect(reporter["getPlaywrightSuitePrototype"](fakeRequire)).toBe(suitePrototype);
+  });
+});
 
 describe("testplan with v1 reporter full names", () => {
   it("respects testplan", async () => {


### PR DESCRIPTION
## Summary

Fixes Allure test plan execution filtering with Playwright 1.53-1.59.

Those versions do not export `playwright/lib/common`, but `Suite.prototype._addTest` is still available from `lib/common/test.js`. The reporter now falls back to that legacy internal path before warning that the execution filter cannot be installed.

fixes https://github.com/allure-framework/allure-js/issues/1576

#### Checklist

- [ ] [Sign Allure CLA][cla]
- [ ] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
