### PR TITLE
Fix Cucumber scenario reported as passed when an attachment is added outside its steps

### DIFF
--- a/packages/allure-cucumberjs/test/samples/features/attachmentStepStatus.feature
+++ b/packages/allure-cucumberjs/test/samples/features/attachmentStepStatus.feature
@@ -1,0 +1,9 @@
+Feature: Trace attachment on a failing scenario
+
+  @control
+  Scenario: control failing scenario
+    Given a failing step
+
+  @trace
+  Scenario: failing scenario with a trace attached in an after hook
+    Given a failing step

--- a/packages/allure-cucumberjs/test/samples/support/attachmentStepStatus.cjs
+++ b/packages/allure-cucumberjs/test/samples/support/attachmentStepStatus.cjs
@@ -1,0 +1,13 @@
+const assert = require("node:assert");
+const { Given, After } = require("@cucumber/cucumber");
+const { attachment, ContentType } = require("allure-js-commons");
+
+After("@trace", async () => {
+  await attachment("Playwright Trace", "trace-content", {
+    contentType: ContentType.PLAYWRIGHT_TRACE,
+  });
+});
+
+Given("a failing step", () => {
+  assert.strictEqual("actual", "expected");
+});

--- a/packages/allure-cucumberjs/test/spec/attachmentStepStatus.test.ts
+++ b/packages/allure-cucumberjs/test/spec/attachmentStepStatus.test.ts
@@ -1,0 +1,15 @@
+import { Status } from "allure-js-commons";
+import { expect, it } from "vitest";
+
+import { runCucumberInlineTest } from "../utils.js";
+
+it("keeps a failing scenario failed when an attachment is added after its steps", async () => {
+  const { tests } = await runCucumberInlineTest(["attachmentStepStatus"], ["attachmentStepStatus"]);
+
+  const control = tests.find((t) => t.name === "control failing scenario");
+  const withAttachment = tests.find((t) => t.name === "failing scenario with a trace attached in an after hook");
+
+  expect(control?.status).toBe(Status.FAILED);
+  expect(withAttachment?.status).toBe(Status.FAILED);
+  expect(withAttachment?.statusDetails?.message).not.toBe("The test doesn't have an implementation.");
+});

--- a/packages/allure-js-commons/src/sdk/reporter/utils.ts
+++ b/packages/allure-js-commons/src/sdk/reporter/utils.ts
@@ -63,7 +63,15 @@ export const getWorstTestStepResult = (steps: StepResult[]): StepResult | undefi
     return;
   }
 
-  return [...steps].sort((a, b) => statusToPriority(a.status) - statusToPriority(b.status))[0];
+  // A step with no status (e.g. an attachment wrapper) is not an executed step
+  // and must not outrank a real outcome.
+  const evaluableSteps = steps.filter((step) => step.status !== undefined);
+
+  if (evaluableSteps.length === 0) {
+    return steps[0];
+  }
+
+  return evaluableSteps.sort((a, b) => statusToPriority(a.status) - statusToPriority(b.status))[0];
 };
 
 export const readImageAsBase64 = async (filePath: string): Promise<string | undefined> => {


### PR DESCRIPTION
### Context

**A failing scenario is published as `passed`, with its assertion message
replaced, for anyone attaching a Playwright trace in an `After` hook. The Allure
report shows green for a run that `cucumber-js` itself failed.**

A Cucumber scenario that fails is written to the report as `passed` if an
attachment is added after its last step finished — for example a Playwright
trace attached from an `After` hook, which is what
`test/spec/hookAttachments.test.ts` already covers for a passing scenario.

The scenario's error message is lost too: `statusDetails` is replaced with
"The test doesn't have an implementation.", which is not what happened — the
assertion message and stack are gone. `cucumber-js` itself fails the run and
exits `1` on this scenario, so the report disagrees with the run it describes.

**Reproduce** — one failing step, plus a trace attached in an `After` hook:

```js
const assert = require("node:assert");
const { Given, After } = require("@cucumber/cucumber");
const { attachment, ContentType } = require("allure-js-commons");

After("@trace", async () => {
  await attachment("Playwright Trace", "trace-content", {
    contentType: ContentType.PLAYWRIGHT_TRACE,
  });
});

Given("a failing step", () => {
  assert.strictEqual("actual", "expected");
});
```

Written result before this change:

```json
{
  "name": "failing scenario with a trace attached in an after hook",
  "status": "passed",
  "statusDetails": { "message": "The test doesn't have an implementation." },
  "steps": [
    { "name": "Given a failing step", "status": "failed" },
    { "name": "Playwright Trace" }
  ]
}
```

The failed step is still in `steps`, so the scenario only looks green until you
open it — but any pass-rate rollup over `status` counts it as a pass.

**Cause.** `ReporterRuntime.writeAttachment` wraps an attachment in a step
object with no `status`. In an `After` hook the scenario's last Gherkin step is
already stopped, so that wrapper is pushed onto the test result itself. In
`getWorstTestStepResult`, `statusToPriority` returns `-1` for a missing status —
lower than `failed` — so the wrapper is selected as the scenario's worst step,
and `onTestCaseFinished` falls back to `Status.PASSED` for it.

That `-1` looks like a sentinel rather than a rank: `StatusByPriority` declares
`FAILED` as index 0, the most severe status in the table, and `-1` is just what
`StatusByPriority.indexOf()` already returns for anything not in it. A step with
no status then ends up both "worse than failed" for selection and `passed` when
written, which is why I read this as unintended rather than a deliberate
ordering — but tell me if that's wrong.

**Fix.** `getWorstTestStepResult` now ignores steps that carry no `status`: a
step with no status was never executed and cannot be a scenario's worst outcome.
When no step has a status the previous value is still returned, so scenarios
made only of unimplemented steps are unaffected.

**Tests.** Adds `test/spec/attachmentStepStatus.test.ts` with a control (failing
scenario, no attachment → `failed`) and the transformed case (same scenario plus
the attachment → still `failed`), in the existing
`runCucumberInlineTest` sample style.

Full suites pass with no existing test changed: `allure-cucumberjs` 47/47 and
`allure-js-commons` 205/205, plus `oxfmt --check` and `oxlint` clean.

**Scope.** `getWorstTestStepResult` has one call site in this repository
(`allure-cucumberjs/src/reporter.ts`), so the only behaviour that changes here is
Cucumber scenario status. It is re-exported through `sdk/reporter`, so external
callers exist that I can't see — for those the change is the same rule: a step
with no status stops being eligible as the worst step. When every step lacks a
status the previous return value is unchanged, so the only affected case is one
where a status-less step was previously outranking a real outcome. Happy to gate
it behind the Cucumber reporter instead if you'd rather not move a shared helper.

### Related issues

Not marked as fixing these, because it does not fix them:

- #1358 — *Successful scenario after the "The test doesn't have an
  implementation" error*
- #1083 — *Unimplemented steps/scenarios are reported as unknown*

Both describe the same underlying "a step with no status decides the verdict"
shape, but from the *unimplemented step* direction. This PR only stops a
**failed** scenario from being reported as passed; after it, #1358's repro still
reports `passed`, because the worst step with an actual status is the passing
one.

Resolving those two needs a semantics decision this PR intentionally avoids:
treating a missing status as the *most* severe (or mapping it to `broken`) would
change the expectation asserted in `test/spec/undefinedStepDefs.test.ts`, which
currently pins `status: passed` for a scenario containing an undefined step.
Happy to follow up with that change if you want it — just say which status
unimplemented steps and scenarios should get.

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js