### PR TITLE
fix(codeceptjs): preserve attachments for failed before hooks

### DIFF
--- a/packages/allure-codeceptjs/src/reporter.ts
+++ b/packages/allure-codeceptjs/src/reporter.ts
@@ -14,9 +14,12 @@ interface MetaStep {
 }
 
 interface CodeceptTestWithArtifacts {
-  artifacts?: {
-    screenshot?: string;
-  };
+  artifacts?: unknown;
+}
+
+interface PendingFailedBeforeEachHookTest {
+  test: Mocha.Test;
+  uuid: string;
 }
 
 const MAX_META_STEP_NESTING = 10;
@@ -53,7 +56,8 @@ const getCodeceptStatusFromError = (error: Partial<Error>, hookName?: string): S
   return isKnownCodeceptVerificationError(error) ? Status.FAILED : Status.BROKEN;
 };
 
-const isBeforeHook = (hookName?: string) => hookName === "Before" || hookName === "BeforeSuite";
+const isBeforeEachHook = (hookName?: string) => hookName === "Before";
+const isBeforeHook = (hookName?: string) => isBeforeEachHook(hookName) || hookName === "BeforeSuite";
 
 const isErrorInstance = (value: unknown): value is Error =>
   value instanceof Error ||
@@ -64,12 +68,22 @@ const isErrorInstance = (value: unknown): value is Error =>
 const isTryToSession = () => recorder.getCurrentSessionId?.() === TRY_TO_SESSION;
 const getRecorderPromise = (): Promise<unknown> | undefined =>
   (recorder.promise as (() => Promise<unknown> | undefined) | undefined)?.();
+const getScreenshotArtifactPath = (test?: CodeceptTestWithArtifacts) => {
+  const artifacts = test?.artifacts;
+
+  if (typeof artifacts !== "object" || artifacts === null || !("screenshot" in artifacts)) {
+    return undefined;
+  }
+
+  return typeof artifacts.screenshot === "string" ? artifacts.screenshot : undefined;
+};
 
 export class AllureCodeceptJsReporter extends AllureMochaReporter {
   protected currentBddStep?: string;
   protected metaStepStack: MetaStep[] = [];
   protected currentLeafStep?: string;
   protected currentTestHookName?: string;
+  protected pendingFailedBeforeEachHookTest?: PendingFailedBeforeEachHookTest;
 
   constructor(runner: Mocha.Runner, opts: Mocha.MochaOptions, isInWorker: boolean) {
     super(runner, opts, isInWorker);
@@ -80,8 +94,14 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
   registerEvents() {
     // Test
     event.dispatcher.on(event.test.before, this.testStarted.bind(this));
+    // A failed CodeceptJS Before hook emits test.failed before the scenario has
+    // started in Mocha. Start the Allure test before other failure listeners so
+    // their runtime attachments target the test, then defer writing the result
+    // until queued failure artifacts, such as screenshots, are available.
+    event.dispatcher.prependListener(event.test.failed, this.beforeHookTestFailed.bind(this));
     event.dispatcher.on(event.test.failed, this.testFailed.bind(this));
     event.dispatcher.on(event.test.finished, this.testFinished.bind(this));
+    event.dispatcher.on(event.hook.finished, this.hookFinished.bind(this));
     // Step
     event.dispatcher.on(event.step.started, this.stepStarted.bind(this));
     event.dispatcher.on(event.step.passed, this.stepPassed.bind(this));
@@ -112,7 +132,18 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
     });
   }
 
+  beforeHookTestFailed(test: Mocha.Test, error: Error, hookName?: string) {
+    if (isBeforeEachHook(hookName)) {
+      this.flushPendingFailedBeforeEachHookTest();
+      this.testFailed(test, error, hookName);
+    }
+  }
+
   testFailed(test: Mocha.Test, error: Error, hookName?: string) {
+    if (isBeforeEachHook(hookName) && this.pendingFailedBeforeEachHookTest?.test === test) {
+      return;
+    }
+
     this.currentTestHookName = hookName;
     const shouldFinishTest = isBeforeHook(hookName);
 
@@ -171,8 +202,17 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
         this.currentHook = undefined;
       }
 
-      this.onTestEnd(test);
-      this.currentTestHookName = undefined;
+      if (isBeforeEachHook(hookName)) {
+        if (this.currentTest) {
+          this.pendingFailedBeforeEachHookTest = {
+            test,
+            uuid: this.currentTest,
+          };
+        }
+      } else {
+        this.onTestEnd(test);
+        this.currentTestHookName = undefined;
+      }
     }
   }
 
@@ -198,24 +238,71 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
     this.metaStepStack = [];
     this.currentLeafStep = undefined;
 
-    const currentTest = this.currentTest;
-    if (currentTest) {
-      recorder.add(
-        "allure screenshot attachment",
-        () => {
-          if (!test?.artifacts?.screenshot) {
-            return;
-          }
-          const screenshotPath = test.artifacts.screenshot;
-
-          this.runtime.writeAttachment(currentTest, null, basename(screenshotPath), screenshotPath, {
-            contentType: ContentType.PNG,
-            wrapInStep: true,
-          });
-        },
-        true,
-      );
+    if (this.currentTest) {
+      this.attachScreenshot(this.currentTest, test);
     }
+  }
+
+  hookFinished() {
+    this.flushPendingFailedBeforeEachHookTest();
+  }
+
+  protected flushPendingFailedBeforeEachHookTest() {
+    const pendingTest = this.pendingFailedBeforeEachHookTest;
+
+    if (!pendingTest) {
+      return;
+    }
+
+    this.pendingFailedBeforeEachHookTest = undefined;
+    if (this.currentTest === pendingTest.uuid) {
+      this.currentTest = undefined;
+    }
+
+    recorder.add(
+      "allure failed before hook result",
+      () => {
+        this.writeFailedBeforeEachHookTest(pendingTest);
+      },
+      true,
+      false,
+    );
+  }
+
+  protected writeFailedBeforeEachHookTest({ test, uuid }: PendingFailedBeforeEachHookTest) {
+    const currentTest = this.currentTest;
+
+    this.currentTest = uuid;
+    this.writeScreenshotAttachment(uuid, test);
+    this.onTestEnd(test);
+
+    if (!this.currentTest && currentTest && currentTest !== uuid) {
+      this.currentTest = currentTest;
+    }
+    this.currentTestHookName = undefined;
+  }
+
+  protected attachScreenshot(currentTest: string, test?: CodeceptTestWithArtifacts) {
+    recorder.add(
+      "allure screenshot attachment",
+      () => {
+        this.writeScreenshotAttachment(currentTest, test);
+      },
+      true,
+    );
+  }
+
+  protected writeScreenshotAttachment(currentTest: string, test?: CodeceptTestWithArtifacts) {
+    const screenshotPath = getScreenshotArtifactPath(test);
+
+    if (!screenshotPath) {
+      return;
+    }
+
+    this.runtime.writeAttachment(currentTest, null, basename(screenshotPath), screenshotPath, {
+      contentType: ContentType.PNG,
+      wrapInStep: true,
+    });
   }
 
   stepStarted(step: CodeceptStep) {

--- a/packages/allure-codeceptjs/src/reporter.ts
+++ b/packages/allure-codeceptjs/src/reporter.ts
@@ -20,6 +20,7 @@ interface CodeceptTestWithArtifacts {
 interface PendingFailedBeforeEachHookTest {
   test: Mocha.Test;
   uuid: string;
+  hookName?: string;
 }
 
 const MAX_META_STEP_NESTING = 10;
@@ -134,7 +135,13 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
 
   beforeHookTestFailed(test: Mocha.Test, error: Error, hookName?: string) {
     if (isBeforeEachHook(hookName)) {
-      this.flushPendingFailedBeforeEachHookTest();
+      const pendingTest = this.flushPendingFailedBeforeEachHookTest();
+
+      if (pendingTest && pendingTest.test !== test && this.currentTest === pendingTest.uuid) {
+        this.currentTest = undefined;
+        this.currentTestHookName = undefined;
+      }
+
       this.testFailed(test, error, hookName);
     }
   }
@@ -207,7 +214,9 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
           this.pendingFailedBeforeEachHookTest = {
             test,
             uuid: this.currentTest,
+            hookName,
           };
+          this.queueFailedBeforeEachHookContext(this.pendingFailedBeforeEachHookTest);
         }
       } else {
         this.onTestEnd(test);
@@ -251,13 +260,10 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
     const pendingTest = this.pendingFailedBeforeEachHookTest;
 
     if (!pendingTest) {
-      return;
+      return undefined;
     }
 
     this.pendingFailedBeforeEachHookTest = undefined;
-    if (this.currentTest === pendingTest.uuid) {
-      this.currentTest = undefined;
-    }
 
     recorder.add(
       "allure failed before hook result",
@@ -267,18 +273,39 @@ export class AllureCodeceptJsReporter extends AllureMochaReporter {
       true,
       false,
     );
+
+    return pendingTest;
   }
 
-  protected writeFailedBeforeEachHookTest({ test, uuid }: PendingFailedBeforeEachHookTest) {
+  protected queueFailedBeforeEachHookContext({ uuid, hookName }: PendingFailedBeforeEachHookTest) {
+    // Helper _failed hooks can await I/O before calling the runtime API, so
+    // restore the failure context in the recorder before those hooks run.
+    recorder.add(
+      "allure failed before hook context",
+      () => {
+        this.currentTest = uuid;
+        this.currentTestHookName = hookName;
+      },
+      true,
+      false,
+    );
+  }
+
+  protected writeFailedBeforeEachHookTest({ test, uuid, hookName }: PendingFailedBeforeEachHookTest) {
     const currentTest = this.currentTest;
+    const currentTestHookName = this.currentTestHookName;
 
     this.currentTest = uuid;
+    this.currentTestHookName = hookName;
     this.writeScreenshotAttachment(uuid, test);
     this.onTestEnd(test);
 
     if (!this.currentTest && currentTest && currentTest !== uuid) {
       this.currentTest = currentTest;
+      this.currentTestHookName = currentTestHookName;
+      return;
     }
+
     this.currentTestHookName = undefined;
   }
 

--- a/packages/allure-codeceptjs/test/spec/screenshotOnFail.test.ts
+++ b/packages/allure-codeceptjs/test/spec/screenshotOnFail.test.ts
@@ -112,3 +112,131 @@ it("should support screenshot plugin", async () => {
     ]),
   );
 }, 10_000);
+
+it("attaches failure-time artifacts when scenario fails in before hook", async () => {
+  const { tests, attachments } = await runCodeceptJsInlineTest({
+    "before-hook-failure.test.js": `
+        Feature("before-hook-failure-feature");
+
+        Before(async ({ I }) => {
+          await I.fail();
+        });
+
+        Scenario("before-hook-failure-scenario-a", async ({ I }) => {
+          await I.pass();
+        });
+
+        Scenario("before-hook-failure-scenario-b", async ({ I }) => {
+          await I.pass();
+        });
+      `,
+    "failedAttachmentPlugin.js": `
+        const { attachment } = require("allure-js-commons");
+        const { event } = require("codeceptjs");
+
+        module.exports = () => {
+          event.dispatcher.on(event.test.failed, (test) => {
+            attachment(test.title + ".txt", "artifact from " + test.title, { contentType: "text/plain" });
+          });
+        };
+      `,
+    "codecept.conf.js": `
+        const path = require("node:path");
+        const { setCommonPlugins } = require("./codeceptjs-configure.js");
+
+        setCommonPlugins();
+
+        exports.config = {
+          tests: "./**/*.test.js",
+          output: path.resolve(__dirname, "./output"),
+          plugins: {
+            allure: {
+              require: require.resolve("allure-codeceptjs"),
+              enabled: true,
+            },
+            screenshot: {
+              enabled: true,
+              on: "fail",
+            },
+            failedAttachmentPlugin: {
+              require: "./failedAttachmentPlugin.js",
+              enabled: true,
+            }
+          },
+          helpers: {
+            Playwright: {
+              require: "./helper.js",
+            },
+            ExpectHelper: {
+              require: require.resolve("codeceptjs-expect"),
+            },
+          },
+        };
+      `,
+    "helper.js": `
+        const Helper = require("@codeceptjs/helper");
+        const { writeFile } = require("fs/promises");
+        const path = require("path");
+
+        class MyHooksHelper extends Helper {
+          async pass() {
+            await Promise.resolve();
+          }
+
+          async fail() {
+            await Promise.reject(new Error("before hook failed"));
+          }
+
+          async saveScreenshot(fileName) {
+             const outputPath = path.join(global.output_dir, fileName);
+             await writeFile(outputPath, Buffer.from(JSON.stringify(fileName)), "utf-8");
+          }
+        }
+
+        module.exports = MyHooksHelper;
+      `,
+  });
+
+  expect(tests).toHaveLength(2);
+  for (const test of tests) {
+    const attachmentName = `${test.name}.txt`;
+    const screenshotNamePattern = new RegExp(`^${test.name}.*\\.failed\\.png$`);
+
+    expect(test).toMatchObject({
+      status: Status.BROKEN,
+      steps: expect.arrayContaining([
+        expect.objectContaining({
+          name: attachmentName,
+          attachments: [
+            expect.objectContaining({
+              name: attachmentName,
+              type: "text/plain",
+              source: expect.any(String),
+            }),
+          ],
+        }),
+        expect.objectContaining({
+          name: expect.stringMatching(screenshotNamePattern),
+          attachments: [
+            expect.objectContaining({
+              name: expect.stringMatching(screenshotNamePattern),
+              type: "image/png",
+              source: expect.any(String),
+            }),
+          ],
+        }),
+      ]),
+    });
+
+    const attachmentStep = test.steps.find((step) => step.name === attachmentName);
+    const attachmentSource = attachmentStep?.attachments[0]?.source;
+
+    expect(attachmentSource).toEqual(expect.any(String));
+    if (!attachmentSource) {
+      throw new Error(`${attachmentName} source is missing`);
+    }
+    expect(Buffer.from(attachments[attachmentSource] as string, "base64").toString("utf8")).toBe(
+      `artifact from ${test.name}`,
+    );
+  }
+}, 10_000);

--- a/packages/allure-codeceptjs/test/spec/screenshotOnFail.test.ts
+++ b/packages/allure-codeceptjs/test/spec/screenshotOnFail.test.ts
@@ -240,3 +240,97 @@ it("attaches failure-time artifacts when scenario fails in before hook", async (
     );
   }
 }, 10_000);
+
+it.each([1, 2])(
+  "attaches async helper _failed artifacts after a before hook failure with %i scenario(s)",
+  async (scenarioCount) => {
+    const scenarioNames = Array.from(
+      { length: scenarioCount },
+      (_, index) => `before-hook-async-failed-scenario-${index + 1}`,
+    );
+    const scenarios = scenarioNames
+      .map(
+        (name) => `
+        Scenario("${name}", async ({ I }) => {
+          await I.pass();
+        });
+      `,
+      )
+      .join("\n");
+
+    const { tests, attachments } = await runCodeceptJsInlineTest({
+      "before-hook-async-failed.test.js": `
+        Feature("before-hook-async-failed-feature");
+
+        Before(async ({ I }) => {
+          await I.fail();
+        });
+
+        ${scenarios}
+      `,
+      "helper.js": `
+        const Helper = require("@codeceptjs/helper");
+        const { attachment } = require("allure-js-commons");
+        const { mkdir, readFile, writeFile } = require("fs/promises");
+        const path = require("path");
+
+        class MyHooksHelper extends Helper {
+          async _failed(test) {
+            const attachmentName = test.title + ".async-failed.txt";
+            const outputPath = path.join(global.output_dir, "async-failed-artifacts");
+            const artifactPath = path.join(outputPath, attachmentName);
+
+            await mkdir(outputPath, { recursive: true });
+            await writeFile(artifactPath, "async artifact from " + test.title, "utf8");
+            await attachment(attachmentName, await readFile(artifactPath, "utf8"), { contentType: "text/plain" });
+          }
+
+          async pass() {
+            await Promise.resolve();
+          }
+
+          async fail() {
+            await Promise.reject(new Error("before hook failed"));
+          }
+        }
+
+        module.exports = MyHooksHelper;
+      `,
+    });
+
+    expect(tests).toHaveLength(scenarioCount);
+    expect(tests.map((test) => test.name).sort()).toEqual(scenarioNames);
+
+    for (const test of tests) {
+      const attachmentName = `${test.name}.async-failed.txt`;
+
+      expect(test).toMatchObject({
+        status: Status.BROKEN,
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            name: attachmentName,
+            attachments: [
+              expect.objectContaining({
+                name: attachmentName,
+                type: "text/plain",
+                source: expect.any(String),
+              }),
+            ],
+          }),
+        ]),
+      });
+
+      const attachmentStep = test.steps.find((step) => step.name === attachmentName);
+      const attachmentSource = attachmentStep?.attachments[0]?.source;
+
+      expect(attachmentSource).toEqual(expect.any(String));
+      if (!attachmentSource) {
+        throw new Error(`${attachmentName} source is missing`);
+      }
+      expect(Buffer.from(attachments[attachmentSource] as string, "base64").toString("utf8")).toBe(
+        `async artifact from ${test.name}`,
+      );
+    }
+  },
+  10_000,
+);


### PR DESCRIPTION
Fixes https://github.com/allure-framework/allure-js/issues/1580

The reporter now starts the Allure test before other `test.failed` listeners run, keeps the failed test open until queued failure artifacts are available, and finalizes each pending scenario by its own uuid. This also handles multi-scenario features without mixing artifacts between results.


#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
