### PR TITLE
fix: publish npm packages with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -24,4 +25,4 @@ jobs:
         run: |
           yarn install
           yarn build
-      - run: yarn workspaces foreach -Avv --no-private npm publish --tolerate-republish
+      - run: yarn workspaces foreach -Avv --no-private npm publish --provenance --tolerate-republish


### PR DESCRIPTION
Restore provenance generation for npm releases published through Yarn.

The release workflow already uses npm Trusted Publishing via OIDC, but Yarn does not enable provenance unless it is explicitly requested. Add the `--provenance` flag back to `yarn npm publish` and keep job permissions explicit with `contents: read` and `id-token: write`.

This preserves tokenless publishing while restoring npm attestations, so package managers with trust downgrade policies can install new Allure JS releases.

issue https://github.com/allure-framework/allure-js/issues/1559 

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
