### PR TITLE
fix(playwright): avoid loading @playwright/test from reporter entrypoint

### DIFF
--- a/packages/allure-playwright/babel.cjs.json
+++ b/packages/allure-playwright/babel.cjs.json
@@ -6,7 +6,10 @@
         "rewriteImportExtensions": true
       }
     ],
-    ["@babel/preset-env"]
+    ["@babel/preset-env", { "modules": false }]
   ],
-  "plugins": ["babel-plugin-transform-import-meta"]
+  "plugins": [
+    "babel-plugin-transform-import-meta",
+    ["@babel/plugin-transform-modules-commonjs", { "lazy": ["@playwright/test"] }]
+  ]
 }

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import { access } from "node:fs/promises";
+import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 
@@ -1229,10 +1230,43 @@ export class AllureReporter implements ReporterV2 {
  */
 export const allure = allurePlaywrightLegacyApi;
 
+type PlaywrightTestModule = typeof import("@playwright/test");
+
+const localRequire = createRequire(import.meta.url);
+
+const getPlaywrightTestModule = () => localRequire("@playwright/test") as PlaywrightTestModule;
+
+const createLazyPlaywrightExport = <K extends keyof PlaywrightTestModule>(name: K): PlaywrightTestModule[K] => {
+  const lazyExport = function (this: unknown, ...args: unknown[]) {
+    const target = getPlaywrightTestModule()[name] as (...args: unknown[]) => unknown;
+
+    return target.apply(this, args);
+  };
+
+  return new Proxy(lazyExport, {
+    apply(_target, thisArg, args) {
+      const target = getPlaywrightTestModule()[name] as (...args: unknown[]) => unknown;
+
+      return Reflect.apply(target, thisArg, args);
+    },
+    get(_target, property, receiver) {
+      return Reflect.get(getPlaywrightTestModule()[name] as object, property, receiver);
+    },
+    set(_target, property, value, receiver) {
+      return Reflect.set(getPlaywrightTestModule()[name] as object, property, value, receiver);
+    },
+  }) as PlaywrightTestModule[K];
+};
+
 /**
  * @deprecated for removal, import functions directly from "@playwright/test".
  */
-export { test, expect } from "@playwright/test";
+export const test = createLazyPlaywrightExport("test");
+
+/**
+ * @deprecated for removal, import functions directly from "@playwright/test".
+ */
+export const expect = createLazyPlaywrightExport("expect");
 
 const toGlobalErrorMessage = (name: string, details: StatusDetails): RuntimeMessage => ({
   type: "global_error",

--- a/packages/allure-playwright/src/index.ts
+++ b/packages/allure-playwright/src/index.ts
@@ -1,6 +1,5 @@
 import { existsSync } from "node:fs";
 import { access } from "node:fs/promises";
-import { createRequire } from "node:module";
 import path from "node:path";
 import process from "node:process";
 
@@ -1230,43 +1229,10 @@ export class AllureReporter implements ReporterV2 {
  */
 export const allure = allurePlaywrightLegacyApi;
 
-type PlaywrightTestModule = typeof import("@playwright/test");
-
-const localRequire = createRequire(import.meta.url);
-
-const getPlaywrightTestModule = () => localRequire("@playwright/test") as PlaywrightTestModule;
-
-const createLazyPlaywrightExport = <K extends keyof PlaywrightTestModule>(name: K): PlaywrightTestModule[K] => {
-  const lazyExport = function (this: unknown, ...args: unknown[]) {
-    const target = getPlaywrightTestModule()[name] as (...args: unknown[]) => unknown;
-
-    return target.apply(this, args);
-  };
-
-  return new Proxy(lazyExport, {
-    apply(_target, thisArg, args) {
-      const target = getPlaywrightTestModule()[name] as (...args: unknown[]) => unknown;
-
-      return Reflect.apply(target, thisArg, args);
-    },
-    get(_target, property, receiver) {
-      return Reflect.get(getPlaywrightTestModule()[name] as object, property, receiver);
-    },
-    set(_target, property, value, receiver) {
-      return Reflect.set(getPlaywrightTestModule()[name] as object, property, value, receiver);
-    },
-  }) as PlaywrightTestModule[K];
-};
-
 /**
  * @deprecated for removal, import functions directly from "@playwright/test".
  */
-export const test = createLazyPlaywrightExport("test");
-
-/**
- * @deprecated for removal, import functions directly from "@playwright/test".
- */
-export const expect = createLazyPlaywrightExport("expect");
+export { test, expect } from "@playwright/test";
 
 const toGlobalErrorMessage = (name: string, details: StatusDetails): RuntimeMessage => ({
   type: "global_error",

--- a/packages/allure-playwright/test/spec/package.spec.ts
+++ b/packages/allure-playwright/test/spec/package.spec.ts
@@ -36,6 +36,30 @@ it("should not load @playwright/test when the reporter is loaded", () => {
   }
 });
 
+it("should re-export the original Playwright functions", () => {
+  const legacy = require("../../dist/cjs/index.js") as typeof import("../../src/index.js");
+  const playwright = require("@playwright/test") as typeof import("@playwright/test");
+
+  expect(legacy.test).toBe(playwright.test);
+  expect(legacy.expect).toBe(playwright.expect);
+});
+
+it("should select a legacy test by its declaration file and line", async () => {
+  const { tests } = await runPlaywrightInlineTest(
+    {
+      "sample.test.js": [
+        'import { test, expect } from "allure-playwright";',
+        'test("selected", async () => { expect(1).toBe(1); });',
+        'test("not selected", async () => {});',
+      ].join("\n"),
+    },
+    ["sample.test.js:2"],
+  );
+
+  expect(tests).toHaveLength(1);
+  expect(tests[0]).toMatchObject({ name: "selected", status: "passed" });
+});
+
 it("should set package label", async () => {
   const { tests } = await runPlaywrightInlineTest({
     "some/path/to/sample.test.js": `

--- a/packages/allure-playwright/test/spec/package.spec.ts
+++ b/packages/allure-playwright/test/spec/package.spec.ts
@@ -1,6 +1,40 @@
+import { createRequire } from "node:module";
+
 import { expect, it } from "vitest";
 
 import { runPlaywrightInlineTest } from "../utils.js";
+
+const require = createRequire(import.meta.url);
+
+it("should not load @playwright/test when the reporter is loaded", () => {
+  const moduleApi = require("node:module") as {
+    _load: (request: string, parent: NodeJS.Module | null | undefined, isMain: boolean) => unknown;
+  };
+  const distIndexPath = require.resolve("../../dist/cjs/index.js");
+  const originalLoad = moduleApi._load;
+
+  delete require.cache[distIndexPath];
+
+  moduleApi._load = (request, parent, isMain) => {
+    if (request === "@playwright/test") {
+      throw new Error("allure-playwright reporter must not load @playwright/test");
+    }
+
+    return originalLoad.call(moduleApi, request, parent, isMain);
+  };
+
+  try {
+    const reporter = require(distIndexPath) as {
+      AllureReporter: unknown;
+      default: unknown;
+    };
+
+    expect(reporter.default).toBe(reporter.AllureReporter);
+  } finally {
+    moduleApi._load = originalLoad;
+    delete require.cache[distIndexPath];
+  }
+});
 
 it("should set package label", async () => {
   const { tests } = await runPlaywrightInlineTest({


### PR DESCRIPTION
Fixes #1325 by removing the top-level `@playwright/test` load from the `allure-playwright` reporter entrypoint.

The deprecated `test` and `expect` exports are now resolved lazily, so loading `allure-playwright` as a Playwright reporter does not require `@playwright/test` and does not create a second Playwright Test instance in component-testing setups.


#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
