### PR TITLE
fix(jest): mark unexpectedly passing failing tests as failed

### DIFF
--- a/packages/allure-jest/src/environmentFactory.ts
+++ b/packages/allure-jest/src/environmentFactory.ts
@@ -348,14 +348,16 @@ const createJestEnvironment = <T extends JestEnvironmentConstructor>(Base: T): T
         return;
       }
 
-      const { status, details } = this.#statusAndDetails(test.errors);
+      const statusAndDetails = this.#statusAndDetails(test.errors);
+      const status =
+        test.failing && statusAndDetails.status === Status.BROKEN ? Status.FAILED : statusAndDetails.status;
 
       this.runtime.updateTest(testUuid, (result) => {
         result.stage = Stage.FINISHED;
         result.status = status;
         result.statusDetails = {
           ...result.statusDetails,
-          ...details,
+          ...statusAndDetails.details,
         };
       });
       this.runtime.stopTest(testUuid, { duration: test.duration ?? 0 });

--- a/packages/allure-jest/test/spec/simple.test.ts
+++ b/packages/allure-jest/test/spec/simple.test.ts
@@ -24,6 +24,30 @@ it("handles jest tests", async () => {
   );
 });
 
+it("marks unexpectedly passing jest failing tests as failed", async () => {
+  const { tests } = await runJestInlineTest({
+    "sample.spec.js": `
+      test.failing("unexpected pass", () => {
+        expect(1).toBe(1);
+      });
+    `,
+  });
+
+  expect(tests).toHaveLength(1);
+  expect(tests).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        name: "unexpected pass",
+        status: Status.FAILED,
+        stage: Stage.FINISHED,
+        statusDetails: expect.objectContaining({
+          message: expect.stringContaining("Failing test passed even though it was supposed to fail"),
+        }),
+      }),
+    ]),
+  );
+});
+
 it("should set full name", async () => {
   const { tests } = await runJestInlineTest({
     "a/path/to/test/sample.spec.js": `


### PR DESCRIPTION
## Summary

- Report unexpectedly passing Jest `test.failing()` tests as `FAILED`
- Preserve Jest's failure details in the Allure result

#### Checklist

- [x] [Sign Allure CLA][cla]
- [x] Provide unit tests

[cla]: https://cla-assistant.io/accept/allure-framework/allure-js
